### PR TITLE
Conserved Moieties Update on Debug

### DIFF
--- a/source/CVODEIntegrator.cpp
+++ b/source/CVODEIntegrator.cpp
@@ -233,7 +233,7 @@ double CVODEIntegrator::integrate(double timeStart, double hstep)
         }
 
         // event status before time step
-        mModel->getEventTriggers(eventStatus.size(), 0, &eventStatus[0]);
+        mModel->getEventTriggers(eventStatus.size(), 0, eventStatus.size() == 0 ? NULL : &eventStatus[0]);
 
         // time step
         int nResult = CVode(mCVODE_Memory, nextTargetEndTime,  mStateVector, &timeEnd, itask);
@@ -459,7 +459,7 @@ void CVODEIntegrator::createCVode()
 void CVODEIntegrator::testRootsAtInitialTime()
 {
     vector<unsigned char> initialEventStatus(mModel->getEventTriggers(0, 0, 0), false);
-    mModel->getEventTriggers(initialEventStatus.size(), 0, &initialEventStatus[0]);
+    mModel->getEventTriggers(initialEventStatus.size(), 0, initialEventStatus.size() == 0 ? NULL : &initialEventStatus[0]);
     applyEvents(0, initialEventStatus);
 }
 
@@ -467,7 +467,7 @@ void CVODEIntegrator::testRootsAtInitialTime()
 void CVODEIntegrator::applyEvents(double timeEnd, vector<unsigned char> &previousEventStatus)
 {
     double *stateVector = mStateVector ? NV_DATA_S(mStateVector) : 0;
-    mModel->applyEvents(timeEnd, &previousEventStatus[0], stateVector, stateVector);
+    mModel->applyEvents(timeEnd, previousEventStatus.size() == 0 ? NULL : &previousEventStatus[0], stateVector, stateVector);
 
     if(timeEnd > 0.0) {
         mModel->setTime(timeEnd);
@@ -488,8 +488,8 @@ void CVODEIntegrator::applyPendingEvents(double timeEnd)
 {
     if(mModel) {
          // get current event triggered state
-        mModel->getEventTriggers(eventStatus.size(), 0, &eventStatus[0]);
-        int handled = mModel->applyEvents(timeEnd, &eventStatus[0], NULL, NULL);
+        mModel->getEventTriggers(eventStatus.size(), 0, eventStatus.size() == 0 ? NULL : &eventStatus[0]);
+        int handled = mModel->applyEvents(timeEnd, eventStatus.size() == 0 ? NULL : &eventStatus[0], NULL, NULL);
         if (handled > 0)
         {
             Log(Logger::LOG_DEBUG) << __FUNC__;

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -561,10 +561,12 @@ int RoadRunner::createDefaultTimeCourseSelectionList()
 {
 	vector<string> theList;
 	vector<string> oFloating  = getFloatingSpeciesIds();
-	int numIndSpecies = getNumberOfIndependentSpecies();
+	int numFloatingSpecies = oFloating.size();
+	//int numIndSpecies = getNumberOfIndependentSpecies();
 
 	theList.push_back("time");
-	for(int i = 0; i < numIndSpecies; i++)
+	//for(int i = 0; i < numIndSpecies; i++)
+	for (int i = 0; i < numFloatingSpecies; i++)
 	{
 		theList.push_back("[" + oFloating[i] + "]");
 	}
@@ -1781,9 +1783,12 @@ int RoadRunner::createDefaultSteadyStateSelectionList()
 	impl->mSteadyStateSelection.clear();
 	// default should be independent floating species only ...
 	vector<string> floatingSpecies = getFloatingSpeciesIds();
-	int numIndSpecies = getNumberOfIndependentSpecies();
-	impl->mSteadyStateSelection.resize(numIndSpecies);
-	for (int i = 0; i < numIndSpecies; i++)
+	int numFloatingSpecies = floatingSpecies.size();
+	//int numIndSpecies = getNumberOfIndependentSpecies();
+	//impl->mSteadyStateSelection.resize(numIndSpecies);
+	impl->mSteadyStateSelection.resize(numFloatingSpecies);
+	//for (int i = 0; i < numIndSpecies; i++)
+	for (int i = 0; i < numFloatingSpecies; i++)
 	{
 		SelectionRecord aRec;
 		aRec.selectionType = SelectionRecord::FLOATING_CONCENTRATION;


### PR DESCRIPTION
@wcopeland I think this is your conserved moiety fix which reverts the default selection list back to the original behavior. I couldn't remember if it was ready for merging or not so please confirm if yes and I will go ahead and merge it.

- Reverted default selection list behavior.
- Added ternary operators to event status arrays that return pointers to
a missing 0th element.