### PR TITLE
Prevent conserved moieties from going negative

### DIFF
--- a/source/conservation/ConservationExtension.cpp
+++ b/source/conservation/ConservationExtension.cpp
@@ -297,6 +297,14 @@ bool ConservationExtension::getConservedMoiety(const libsbml::Parameter& s)
     return plugin ? plugin->getConservedMoiety() : false;
 }
 
+std::string ConservationExtension::getConservedQuantity(const libsbml::Species& s)
+{
+    const ConservedMoietyPlugin* plugin =
+            dynamic_cast<const ConservedMoietyPlugin*>(
+                    s.getPlugin("conservation"));
+    return plugin ? plugin->getConservedQuantity() : "";
+}
+
 
 bool ConservationExtension::isConservedMoietyDocument(
         const libsbml::SBMLDocument* doc)

--- a/source/conservation/ConservationExtension.h
+++ b/source/conservation/ConservationExtension.h
@@ -90,6 +90,12 @@ public:
 
 
   /**
+   * get the conserved moiety global parameter associated with this species
+   */
+  static std::string getConservedQuantity(const libsbml::Species& s);
+
+
+  /**
    * check if the document is already a conserved moeity document
    */
   static bool isConservedMoietyDocument(const libsbml::SBMLDocument*);

--- a/source/conservation/ConservedMoietyConverter.cpp
+++ b/source/conservation/ConservedMoietyConverter.cpp
@@ -66,7 +66,6 @@ public:
         plugin->setConservedMoiety(conservedMoiety);
 
         if (quantity.size()) {
-            std::cerr << "set conserved quantity for " << getId() << " to " << quantity << "\n";
             plugin->setConservedQuantity(quantity);
         }
     }
@@ -76,7 +75,6 @@ public:
 
         assert(plugin && "could not get conservation plugin from species");
 
-        std::cerr << "set conserved quantity for " << getId() << " to " << quantity << "\n";
         plugin->setConservedQuantity(quantity);
     }
 };
@@ -330,7 +328,6 @@ int ConservedMoietyConverter::setDocument(const libsbml::SBMLDocument* doc)
         ConversionProperties versionProps = versionConverter.getDefaultProperties();
 
         versionProps.addOption("strict", false);
-        std::cerr << "ConservedMoietyConverter::setDocument\n";
 
         versionConverter.setProperties(&versionProps);
 
@@ -619,8 +616,6 @@ static void createDependentSpeciesRules(Model* newModel,
             conc.addChild(volume);
             rule->setMath(&conc);
         }
-
-        std::cerr << "Set assignment rule for " << id << " to " << rule->getFormula() << "\n";
     }
 }
 

--- a/source/conservation/ConservedMoietyPlugin.cpp
+++ b/source/conservation/ConservedMoietyPlugin.cpp
@@ -53,6 +53,16 @@ void ConservedMoietyPlugin::setConservedMoiety(bool value)
     conservedMoiety = value;
 }
 
+const std::string& ConservedMoietyPlugin::getConservedQuantity() const
+{
+    return conservedQuantity;
+}
+
+void ConservedMoietyPlugin::setConservedQuantity(const std::string& id)
+{
+    conservedQuantity = id;
+}
+
 }
 } // namespace rr } namespace conservation }
 
@@ -78,13 +88,24 @@ void rr::conservation::ConservedMoietyPlugin::readAttributes(
     {
         conservedMoiety = false;
     }
+    if(attributes.hasAttribute("conservedQuantity", mURI))
+    {
+        if (!attributes.readInto("conservedQuantity", conservedMoiety))
+        {
+            std::string value = attributes.getValue("conservedQuantity");
+            throw std::invalid_argument("conservedQuantity attribute with value " + value
+                                        + " can not be converted to a string");
+        }
+    }
 }
 
 void rr::conservation::ConservedMoietyPlugin::writeAttributes(
         libsbml::XMLOutputStream& stream) const
 {
 
-    libsbml::XMLTriple triple("conservedMoiety", mURI, mPrefix);
+    libsbml::XMLTriple triple1("conservedMoiety",   mURI, mPrefix);
+    libsbml::XMLTriple triple2("conservedQuantity", mURI, mPrefix);
 
-    stream.writeAttribute(triple, conservedMoiety);
+    stream.writeAttribute(triple1, conservedMoiety);
+    stream.writeAttribute(triple2, conservedQuantity);
 }

--- a/source/conservation/ConservedMoietyPlugin.h
+++ b/source/conservation/ConservedMoietyPlugin.h
@@ -53,6 +53,12 @@ public:
 
     void setConservedMoiety(bool value);
 
+    // gets the global parameter associated with this
+    // species if it forms part of a conserved cycle
+    const std::string& getConservedQuantity() const;
+
+    void setConservedQuantity(const std::string& id);
+
     /**
      * Subclasses must override this method to read values from the given
      * XMLAttributes if they have their specific attributes.
@@ -74,6 +80,7 @@ public:
 
 private:
     bool conservedMoiety;
+    std::string conservedQuantity;
 
 };
 

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -1263,7 +1263,48 @@ void LLVMExecutableModel::setValue(const std::string& id, double value)
         setCompartmentVolumes(1, &index, &value);
         break;
     case SelectionRecord::GLOBAL_PARAMETER:
+        std::cerr << "Set global parameter " << id << " = " << value << "\n";
         setGlobalParameterValues(1, &index, &value);
+//         dirty |= DIRTY_CONSERVED_MOIETIES;
+        for(uint cm = 0; cm < symbols->getConservedMoietySize(); ++cm) {
+            // is this the index of the cm we are setting?
+            if (symbols->getConservedMoietyId(cm) == id) {
+                std::cerr << "  Is conserved moiety conserved total, cm = " << cm << "\n";
+                // eliminate loop?
+                for (int d = 0; d < getNumDepFloatingSpecies(); ++d) {
+                    int i_dep = modelData->numIndFloatingSpecies+d;
+                    double amt;
+                    getFloatingSpeciesAmounts(1,&i_dep,&amt);
+                    std::cerr << "dep amt " << amt << "\n";
+                    // if the dependent species went negative, we need to correct for it
+                    if (amt < 0) {
+                        const ls::DoubleMatrix& L0 = *symbols->getL0Matrix();
+                        for (int i = 0; i < modelData->numIndFloatingSpecies; ++i) {
+                            double stoich = L0(d, i);
+                            std::cerr << "stoich(" << d << ", " << i << ") = " << stoich << "\n";
+                        }
+                    }
+                }
+
+//                 if (deps_went_negative) {
+//                     for (int i = 0; i < modelData->numIndFloatingSpecies; ++i) {
+//                         for (int d = 0; d < getNumDepFloatingSpecies(); ++d) {
+//                             double stoich = L0(i, j);
+//
+// //                         uint cm_pair;
+// //                         std::cerr << "i = " << i << " out of " << modelData->numIndFloatingSpecies << "\n";
+// //                         if (symbols->isConservedMoietySpecies(i, cm_pair)) {
+// //                             std::cerr << "cm_pair = " << cm_pair << "\n";
+// //                             if (cm_pair == cm) {
+// //                                 std::cerr << "    " << symbols->getFloatingSpeciesId(i) << " is an associated indep species\n";
+// //                             }
+// //                         }
+// //                         std::cerr << "  completed\n";
+//                         }
+//                     }
+//                 }
+            }
+        }
         break;
     case SelectionRecord::BOUNDARY_AMOUNT:
         setBoundarySpeciesAmounts(1, &index, &value);

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -1263,19 +1263,15 @@ void LLVMExecutableModel::setValue(const std::string& id, double value)
         setCompartmentVolumes(1, &index, &value);
         break;
     case SelectionRecord::GLOBAL_PARAMETER:
-        std::cerr << "Set global parameter " << id << " = " << value << "\n";
         setGlobalParameterValues(1, &index, &value);
-//         dirty |= DIRTY_CONSERVED_MOIETIES;
         for(uint cm = 0; cm < symbols->getConservedMoietySize(); ++cm) {
             // is this the index of the cm we are setting?
             if (symbols->getConservedMoietyId(cm) == id) {
-                std::cerr << "  Is conserved moiety conserved total, cm = " << cm << "\n";
                 // eliminate loop?
                 uint d = symbols->getDepSpeciesIndexForConservedMoietyId(id);
                 int i_dep = modelData->numIndFloatingSpecies+d;
                 double amt;
                 getFloatingSpeciesAmounts(1,&i_dep,&amt);
-                std::cerr << "dep amt " << amt << "\n";
                 // if the dependent species went negative, we need to correct for it
                 if (amt < 0) {
                     const std::vector<uint>& ind = symbols->getIndSpeciesIndexForConservedMoietyId(id);
@@ -1286,24 +1282,6 @@ void LLVMExecutableModel::setValue(const std::string& id, double value)
                         setFloatingSpeciesAmounts(1,&i,&zero);
                     }
                 }
-
-//                 if (deps_went_negative) {
-//                     for (int i = 0; i < modelData->numIndFloatingSpecies; ++i) {
-//                         for (int d = 0; d < getNumDepFloatingSpecies(); ++d) {
-//                             double stoich = L0(i, j);
-//
-// //                         uint cm_pair;
-// //                         std::cerr << "i = " << i << " out of " << modelData->numIndFloatingSpecies << "\n";
-// //                         if (symbols->isConservedMoietySpecies(i, cm_pair)) {
-// //                             std::cerr << "cm_pair = " << cm_pair << "\n";
-// //                             if (cm_pair == cm) {
-// //                                 std::cerr << "    " << symbols->getFloatingSpeciesId(i) << " is an associated indep species\n";
-// //                             }
-// //                         }
-// //                         std::cerr << "  completed\n";
-//                         }
-//                     }
-//                 }
             }
         }
         break;

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -1271,18 +1271,19 @@ void LLVMExecutableModel::setValue(const std::string& id, double value)
             if (symbols->getConservedMoietyId(cm) == id) {
                 std::cerr << "  Is conserved moiety conserved total, cm = " << cm << "\n";
                 // eliminate loop?
-                for (int d = 0; d < getNumDepFloatingSpecies(); ++d) {
-                    int i_dep = modelData->numIndFloatingSpecies+d;
-                    double amt;
-                    getFloatingSpeciesAmounts(1,&i_dep,&amt);
-                    std::cerr << "dep amt " << amt << "\n";
-                    // if the dependent species went negative, we need to correct for it
-                    if (amt < 0) {
-                        const ls::DoubleMatrix& L0 = *symbols->getL0Matrix();
-                        for (int i = 0; i < modelData->numIndFloatingSpecies; ++i) {
-                            double stoich = L0(d, i);
-                            std::cerr << "stoich(" << d << ", " << i << ") = " << stoich << "\n";
-                        }
+                uint d = symbols->getDepSpeciesIndexForConservedMoietyId(id);
+                int i_dep = modelData->numIndFloatingSpecies+d;
+                double amt;
+                getFloatingSpeciesAmounts(1,&i_dep,&amt);
+                std::cerr << "dep amt " << amt << "\n";
+                // if the dependent species went negative, we need to correct for it
+                if (amt < 0) {
+                    const std::vector<uint>& ind = symbols->getIndSpeciesIndexForConservedMoietyId(id);
+                    double zero=0;
+
+                    for(std::vector<uint>::const_iterator it = ind.begin(); it != ind.end(); ++it) {
+                        int i = *it;
+                        setFloatingSpeciesAmounts(1,&i,&zero);
                     }
                 }
 

--- a/source/llvm/LLVMModelDataSymbols.cpp
+++ b/source/llvm/LLVMModelDataSymbols.cpp
@@ -800,7 +800,6 @@ void LLVMModelDataSymbols::initFloatingSpecies(const libsbml::Model* model,
     {
         const Species *s = species->get(i);
         std::string quantity = ConservationExtension::getConservedQuantity(*s);
-        std::cerr << s->getId() << " conserved quantity " << quantity << "\n";
 
         if (s->getBoundaryCondition())
         {
@@ -813,7 +812,6 @@ void LLVMModelDataSymbols::initFloatingSpecies(const libsbml::Model* model,
         {
             indFltSpecies.push_back(sid);
             if (quantity.size()) {
-                std::cerr << "ind spec " << sid << " belongs to cm " << quantity << "\n";
                 conservedMoietyIndSpecies[quantity].push_back(indFltSpecies.size()-1);
             }
         }
@@ -821,7 +819,6 @@ void LLVMModelDataSymbols::initFloatingSpecies(const libsbml::Model* model,
         {
             depFltSpecies.push_back(sid);
             if (quantity.size()) {
-                std::cerr << "dep spec " << sid << " belongs to cm " << quantity << "\n";
                 conservedMoietyDepSpecies[quantity] = depFltSpecies.size()-1;
             }
         }
@@ -845,11 +842,6 @@ void LLVMModelDataSymbols::initFloatingSpecies(const libsbml::Model* model,
         if (conservedMoiety) {
             conservedMoietySpeciesSet.insert(sid);
         }
-
-        if (conservedMoiety)
-          std::cerr << s->getId() << " is conserved\n";
-        else
-          std::cerr << s->getId() << " is not conserved\n";
     }
 
     // stuff the species in the map

--- a/source/llvm/LLVMModelDataSymbols.cpp
+++ b/source/llvm/LLVMModelDataSymbols.cpp
@@ -200,6 +200,7 @@ LLVMModelDataSymbols::LLVMModelDataSymbols(const libsbml::Model *model,
 
 LLVMModelDataSymbols::~LLVMModelDataSymbols()
 {
+    delete m_structural;
 }
 
 const std::string& LLVMModelDataSymbols::getModelName() const
@@ -795,10 +796,15 @@ void LLVMModelDataSymbols::initFloatingSpecies(const libsbml::Model* model,
     list<string> indInitFltSpecies;
     list<string> depInitFltSpecies;
 
+    m_structural = new ls::LibStructural(model);
+    L0 = m_structural->getL0Matrix();
+
     // figure out 'fully' indendent flt species -- those without rules.
     for (uint i = 0; i < species->size(); ++i)
     {
         const Species *s = species->get(i);
+        std::string quantity = ConservationExtension::getConservedQuantity(*s);
+        std::cerr << s->getId() << " conserved quantity " << quantity << "\n";
 
         if (s->getBoundaryCondition())
         {
@@ -835,6 +841,11 @@ void LLVMModelDataSymbols::initFloatingSpecies(const libsbml::Model* model,
         if (conservedMoiety) {
             conservedMoietySpeciesSet.insert(sid);
         }
+
+        if (conservedMoiety)
+          std::cerr << s->getId() << " is conserved\n";
+        else
+          std::cerr << s->getId() << " is not conserved\n";
     }
 
     // stuff the species in the map

--- a/source/llvm/LLVMModelDataSymbols.h
+++ b/source/llvm/LLVMModelDataSymbols.h
@@ -17,8 +17,6 @@
 #include "tr1proxy/rr_memory.h"
 #include "tr1proxy/rr_unordered_map.h"
 
-#include "rr-libstruct/lsLibStructural.h"
-
 
 #include <map>
 #include <set>
@@ -130,6 +128,7 @@ class LLVMModelDataSymbols
 public:
 
     typedef std::map<std::string, uint> StringUIntMap;
+    typedef std::map<std::string, std::vector<uint> > StringUIntVectorMap;
     typedef std::pair<std::string, uint> StringUIntPair;
     typedef cxx11_ns::unordered_map<uint, uint> UIntUIntMap;
 
@@ -378,6 +377,16 @@ public:
     uint getConservedMoietySize() const;
 
     /**
+     * get the dependent species for a given conserved moiety id
+     */
+    uint getDepSpeciesIndexForConservedMoietyId(std::string id) const;
+
+    /**
+     * get all the independent species for a given conserved moiety id
+     */
+    const std::vector<uint>& getIndSpeciesIndexForConservedMoietyId(std::string id) const;
+
+    /**
      * get the index of a global parameter given a conserved moiety index.
      */
     uint getConservedMoietyGlobalParameterIndex(uint cmIndex) const;
@@ -391,8 +400,6 @@ public:
      * get the id of a conserved moiety given its name.
      */
     uint getConservedMoietyIndex(const std::string& name) const;
-
-    ls::DoubleMatrix* getL0Matrix() const { return m_structural->getL0Matrix(); }
 
 private:
 
@@ -422,6 +429,12 @@ private:
      * in the same order as the conserved moieties.
      */
     UIntUIntMap floatingSpeciesToConservedMoietyIdMap;
+
+    // holds the conserved moiety id for each dependent species
+    StringUIntMap conservedMoietyDepSpecies;
+
+    // holds the conserved moiety id for each independent species
+    StringUIntVectorMap conservedMoietyIndSpecies;
 
 
 /*****************************************************************************/
@@ -598,11 +611,6 @@ private:
     StringUIntMap boundarySpeciesMap;
     StringUIntMap compartmentsMap;
     StringUIntMap globalParametersMap;
-
-    // so that conserved moieties can be calculated
-    ls::LibStructural* m_structural;
-    ls::DoubleMatrix *L0;
-
 
 
     /**

--- a/source/llvm/LLVMModelDataSymbols.h
+++ b/source/llvm/LLVMModelDataSymbols.h
@@ -17,6 +17,8 @@
 #include "tr1proxy/rr_memory.h"
 #include "tr1proxy/rr_unordered_map.h"
 
+#include "rr-libstruct/lsLibStructural.h"
+
 
 #include <map>
 #include <set>
@@ -390,6 +392,8 @@ public:
      */
     uint getConservedMoietyIndex(const std::string& name) const;
 
+    ls::DoubleMatrix* getL0Matrix() const { return m_structural->getL0Matrix(); }
+
 private:
 
     /**
@@ -594,6 +598,10 @@ private:
     StringUIntMap boundarySpeciesMap;
     StringUIntMap compartmentsMap;
     StringUIntMap globalParametersMap;
+
+    // so that conserved moieties can be calculated
+    ls::LibStructural* m_structural;
+    ls::DoubleMatrix *L0;
 
 
 


### PR DESCRIPTION
Fix #374. Zero out independent species when changing the conserved total causes any dependents to go negative.