### PR TITLE
Initialize member variables.

### DIFF
--- a/source/rrNLEQ1Interface.cpp
+++ b/source/rrNLEQ1Interface.cpp
@@ -46,16 +46,29 @@ static bool isWarning(int e)
 }
 
 NLEQ1Interface::NLEQ1Interface(ExecutableModel *_model) :
-    IWK(0),
+    nOpts(50),
+    IWK(NULL),
     LIWK(0),
     LRWK(0),
-    RWK(0),
-    XScal(0),
+    RWK(NULL),
+    XScal(NULL),
     ierr(0),
-    iopt(0),
-    model(0),
-    nOpts(50)
-
+    iopt(NULL),
+    model(NULL),
+    n(0),
+    allowPreSim(false),
+    preSimTolerance(0.0),
+    preSimMaximumSteps(0),
+    preSimTime(0.0),
+    allowApprox(false),
+    approxTolerance(0.0),
+    approxMaximumSteps(0),
+    approxTime(0.0),
+    relativeTolerance(0.0),
+    maxIterations(0),
+    minDamping(0.0),
+    broyden(0),
+    linearity(0)
 {
     model = _model;
 

--- a/source/rrNLEQ2Interface.cpp
+++ b/source/rrNLEQ2Interface.cpp
@@ -46,16 +46,29 @@ static bool isWarning(int e)
 }
 
 NLEQ2Interface::NLEQ2Interface(ExecutableModel *_model) :
-    IWK(0),
+    nOpts(50),
+    IWK(NULL),
     LIWK(0),
     LRWK(0),
-    RWK(0),
-    XScal(0),
+    RWK(NULL),
+    XScal(NULL),
     ierr(0),
     iopt(0),
-    model(0),
-    nOpts(50)
-
+    model(NULL),
+    n(0),
+    allowPreSim(false),
+    preSimTolerance(0.0),
+    preSimMaximumSteps(0),
+    preSimTime(0.0),
+    allowApprox(false),
+    approxTolerance(0.0),
+    approxMaximumSteps(0),
+    approxTime(0.0),
+    relativeTolerance(0.0),
+    maxIterations(0),
+    minDamping(0.0),
+    broyden(0),
+    linearity(0)
 {
     model = _model;
 


### PR DESCRIPTION
'broyden' in particular was being used uninitialized in the 'setup' functions of the NLEQ solvers.

The other uninitialized values that valgrind was complaining about were mostly from a particular file in clapack, which I have fixed our local copy of.