### PR TITLE
remove uninitialized value warning in favor of exception

### DIFF
--- a/source/llvm/LLVMModelSymbols.cpp
+++ b/source/llvm/LLVMModelSymbols.cpp
@@ -67,11 +67,6 @@ LLVMModelSymbols::LLVMModelSymbols(const libsbml::Model *m, LLVMModelDataSymbols
             if (model->getInitialAssignment(id) == NULL &&
                     model->getAssignmentRule(id) == NULL)
             {
-                Log(Logger::LOG_WARNING) << "Global parameter, \'"
-                        << param->getId() << "\' missing value and missing init "
-                        "assignment and assignment rule!, defaulting value to 0.0.";
-                Log(Logger::LOG_WARNING) << "This probably is NOT what you want "
-                        "with global parameter \'" << param->getId() << "\'.";
                 value->setValue(0.0);
                 std::stringstream ss;
                 ss << "Global parameter '" << param->getId() << "' missing value and missing init assignment and assignment rule!";

--- a/source/llvm/LLVMModelSymbols.cpp
+++ b/source/llvm/LLVMModelSymbols.cpp
@@ -67,7 +67,6 @@ LLVMModelSymbols::LLVMModelSymbols(const libsbml::Model *m, LLVMModelDataSymbols
             if (model->getInitialAssignment(id) == NULL &&
                     model->getAssignmentRule(id) == NULL)
             {
-                value->setValue(0.0);
                 std::stringstream ss;
                 ss << "Global parameter '" << param->getId() << "' missing value and missing init assignment and assignment rule!";
                 rr::UninitializedValue(ss.str());

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1097,6 +1097,8 @@ void RoadRunner::load(const string& uriOrSbml, const Dictionary *dict)
         impl->document = std::unique_ptr<libsbml::SBMLDocument>(reader.readSBMLFromString(mCurrentSBML));
         impl->model = std::unique_ptr<ExecutableModel>(ExecutableModelFactory::createModel(mCurrentSBML, &impl->loadOpt));
     } catch (const rr::UninitializedValueException& e) {
+        // catch specifically for UninitializedValueException, otherwise for some
+        // reason the message is erased, and an 'unknown error' is displayed to the user.
         throw e;
     } catch (const std::exception& e) {
         string errors = validateSBML(mCurrentSBML);

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1089,14 +1089,16 @@ void RoadRunner::load(const string& uriOrSbml, const Dictionary *dict)
 		}
 	}
     try {
-		
-    // the following lines load and compile the model. If anything fails here,
-    // we validate the model to provide explicit details about where it
-    // failed. Its *VERY* expensive to pre-validate the model.
-		libsbml::SBMLReader reader;
-		impl->document = std::unique_ptr<libsbml::SBMLDocument>(reader.readSBMLFromString(mCurrentSBML));
-		impl->model = std::unique_ptr<ExecutableModel>(ExecutableModelFactory::createModel(mCurrentSBML, &impl->loadOpt));
-    } catch (std::exception& e) {
+
+        // the following lines load and compile the model. If anything fails here,
+        // we validate the model to provide explicit details about where it
+        // failed. Its *VERY* expensive to pre-validate the model.
+        libsbml::SBMLReader reader;
+        impl->document = std::unique_ptr<libsbml::SBMLDocument>(reader.readSBMLFromString(mCurrentSBML));
+        impl->model = std::unique_ptr<ExecutableModel>(ExecutableModelFactory::createModel(mCurrentSBML, &impl->loadOpt));
+    } catch (const rr::UninitializedValueException& e) {
+        throw e;
+    } catch (const std::exception& e) {
         string errors = validateSBML(mCurrentSBML);
 
         if(!errors.empty()) {


### PR DESCRIPTION
This addresses the observation that both a warning and an exception are issued when an uninitialized parameter is present. Per [this reply](https://github.com/sys-bio/roadrunner/issues/566#issuecomment-530097861), the warning is removed and the exception message is now passed on to Python.