### PR TITLE
Clean up model editing functions.

### DIFF
--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -6154,7 +6154,7 @@ void checkAddRule(const std::string& vid, libsbml::Model* sbmlModel)
 {
     libsbml::SBase* sbase = sbmlModel->getElementBySId(vid);
     if (sbase == NULL) {
-        throw std::invalid_argument("Roadrunner::addAssignmentRule failed, no variable with ID " + vid + " existed in the model");
+        throw std::invalid_argument("Unable to add rule because no variable with ID " + vid + " was found in the model.");
     }
     switch (sbase->getTypeCode()) {
     case libsbml::SBML_COMPARTMENT:
@@ -6167,6 +6167,9 @@ void checkAddRule(const std::string& vid, libsbml::Model* sbmlModel)
     {
         libsbml::Species* species = static_cast<libsbml::Species*>(sbase);
         species->setConstant(false);
+        if (species->isSetBoundaryCondition() && species->getBoundaryCondition()==false) {
+            throw std::invalid_argument("Unable to add rule because the species with ID " + vid + " is not a boundary species, and therefore may only change due to reactions.  To change this, the boundary species flag can be set with the function 'setBoundary(id, value)' or when added with 'addSpecies'.");
+        }
         species->setBoundaryCondition(true);
     }
     break;
@@ -6185,13 +6188,13 @@ void checkAddRule(const std::string& vid, libsbml::Model* sbmlModel)
     default:
     {
         const char* code = libsbml::SBMLTypeCode_toString(sbase->getTypeCode(), "core");
-        throw std::invalid_argument("Roadrunner::addAssignmentRule failed, the variable with ID " + vid + " is a " + code + ", which does not have mathematical meaning.");
+        throw std::invalid_argument("Unable to add rule because the variable with ID " + vid + " is a " + code + ", which does not have mathematical meaning.");
     }
     }
 
     if (sbmlModel->getRule(vid) != NULL)
     {
-        throw std::invalid_argument("Roadrunner::addAssignmentRule failed, variable " + vid + " already has a rule existing in the model");
+        throw std::invalid_argument("Unable to add rule because the variable " + vid + " already has a rule existing in the model.");
     }
 }
 

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 #include <list>
+#include <set>
 
 namespace ls
 {
@@ -1248,6 +1249,11 @@ public:
      */
     ls::DoubleMatrix getSteadyStateValuesNamedArray();
 
+    /**
+     * Regenerate this RoadRunner instance's ExecutableModel based on the model in its SBMLDocument
+     */
+    void regenerate(bool forceRegenerate, bool reset = false);
+
     /******************************* End Steady State Section *********************/
     #endif /***********************************************************************/
     /******************************************************************************/
@@ -1526,7 +1532,7 @@ public:
      */
     std::string getTempDir();
 
-    #endif // #ifndef SWIG
+#endif // #ifndef SWIG
 
 
     /******** !!! DEPRECATED INTERNAL METHODS * THESE WILL BE REMOVED!!! **********/
@@ -1560,7 +1566,7 @@ private:
 
 	bool isParameterUsed(const std::string& sid);
 
-	void getAllVariables(const libsbml::ASTNode* node, std::vector<std::string>& ids);
+    void getAllVariables(const libsbml::ASTNode* node, std::set<std::string>& ids);
 
     /// Get the row index of the time variable in the output array (returns -1 if time is not selected)
     int getTimeRowIndex();
@@ -1618,11 +1624,6 @@ private:
     * Check if the id already existed in the model
     */
     void checkID(const std::string& functionName, const std::string& sid);
-    
-    /*
-    * Regenerate this RoadRunner instance's ExecutableModel based on the model in its SBMLDocument
-    */
-    void regenerate(bool forceRegenerate, bool reset = false);
     
     /*
     * Parse a string with format stoichiometry + sID and return its stoichiometry value and sID

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -1252,7 +1252,7 @@ public:
     /**
      * Regenerate this RoadRunner instance's ExecutableModel based on the model in its SBMLDocument
      */
-    void regenerate(bool forceRegenerate, bool reset = false);
+    void regenerate(bool forceRegenerate = true, bool reset = false);
 
     /******************************* End Steady State Section *********************/
     #endif /***********************************************************************/

--- a/source/testing/tests/model_editing.cpp
+++ b/source/testing/tests/model_editing.cpp
@@ -930,6 +930,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 	{
 		CHECK(RunModelEditingTest([](RoadRunner *rri)
 		{
+			rri->setBoundary("S1", true);
 			rri->addAssignmentRule("S1", "7");
 		}));
 	}
@@ -938,6 +939,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 	{
 		CHECK(RunModelEditingTest([](RoadRunner *rri)
 		{
+			rri->setBoundary("S1", true);
 			rri->addAssignmentRule("S1", "7");
 		}));
 	}
@@ -946,6 +948,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 	{
 		CHECK(RunModelEditingTest([](RoadRunner *rri)
 		{
+			rri->setBoundary("S3", true);
 			rri->addAssignmentRule("S3", "k1 * S2");
 		}));
 	}
@@ -954,6 +957,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 	{
 		CHECK(RunModelEditingTest([](RoadRunner *rri)
 		{
+			rri->setBoundary("S1", true);
 			rri->addRateRule("S1", "7");
 		}));
 	}
@@ -963,6 +967,8 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 	{
 		CHECK(RunModelEditingTest([](RoadRunner *rri)
 		{
+			rri->setBoundary("S1", true);
+			rri->setBoundary("S2", true);
 			rri->addRateRule("S1", "-1 * k1 * S1", false);
 			rri->addRateRule("S2", "k1 * S1", true);
 		}));
@@ -972,6 +978,8 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 	{
 		CHECK(RunModelEditingTest([](RoadRunner *rri)
 		{
+			rri->setBoundary("S1", true);
+			rri->setBoundary("S2", true);
 			rri->addRateRule("S1", "-1 * k1 * S1");
 			rri->addRateRule("S2", "k1 * S1");
 		}));
@@ -1300,7 +1308,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 		CHECK(RunTestModelFromScratch([](RoadRunner *rri)
 		{
 			rri->addCompartment("compartment", 1);
-			rri->addSpecies("S1", "compartment", 0, true);
+			rri->addSpecies("S1", "compartment", 0, true, true);
 			rri->addRateRule("S1", "7");
 		}));
 	}
@@ -1310,7 +1318,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 		CHECK(RunTestModelFromScratch([](RoadRunner *rri)
 		{
 			rri->addCompartment("compartment", 1);
-			rri->addSpecies("S1", "compartment", 7, true);
+			rri->addSpecies("S1", "compartment", 7, true, true);
 			rri->addAssignmentRule("S1", "7");
 		}));
 	}
@@ -1322,7 +1330,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 			rri->addCompartment("compartment", 1);
 			rri->addSpecies("S1", "compartment", 1, true);
 			rri->addSpecies("S2", "compartment", 1.5e-15, true);
-			rri->addSpecies("S3", "compartment", 1, true);
+			rri->addSpecies("S3", "compartment", 1, true, true);
 			rri->addParameter("k1", 0.75);
 			rri->addParameter("k2", 50);
 			rri->addAssignmentRule("S3", "k1*S2");
@@ -1445,7 +1453,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 		CHECK(RunTestModelFromScratch([](RoadRunner *rri)
 		{
 			rri->addCompartment("compartment", 1);
-			rri->addSpecies("S1", "compartment", 0);
+			rri->addSpecies("S1", "compartment", 0, false, true);
 			rri->addRateRule("S1", "7");
 		}, "l3v1"));
 	}
@@ -1455,7 +1463,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 		CHECK(RunTestModelFromScratch([](RoadRunner *rri)
 		{
 			rri->addCompartment("compartment", 1);
-			rri->addSpecies("S1", "compartment", 7);
+			rri->addSpecies("S1", "compartment", 7, false, true);
 			rri->addAssignmentRule("S1", "7");
 		}, "l3v1"));
 	}
@@ -1467,7 +1475,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 			rri->addCompartment("compartment", 1);
 			rri->addSpecies("S1", "compartment", 1);
 			rri->addSpecies("S2", "compartment", 1.5e-15);
-			rri->addSpecies("S3", "compartment", 1);
+			rri->addSpecies("S3", "compartment", 1, false, true);
 			rri->addParameter("k1", 0.75);
 			rri->addParameter("k2", 50);
 			rri->addAssignmentRule("S3", "k1*S2");
@@ -1539,6 +1547,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 		CHECK(RunModelEditingTest([](RoadRunner* rri)
 		{
 			rri->setConstant("S1", false, false);
+			rri->setBoundary("S1", true);
 			rri->addRateRule("S1", "7");
 		}));
 	}

--- a/source/testing/tests/state_saving.cpp
+++ b/source/testing/tests/state_saving.cpp
@@ -764,7 +764,7 @@ SUITE(STATE_SAVING_TEST_SUITE)
 		CHECK(StateRunTestModelFromScratch([](RoadRunner *rri)
 		{
 			rri->addCompartment("compartment", 1);
-			rri->addSpecies("S1", "compartment", 0, true);
+			rri->addSpecies("S1", "compartment", 0, true, true);
 			rri->addRateRule("S1", "7");
 			
 			rri->saveState("test-save-state.rr");
@@ -784,7 +784,7 @@ SUITE(STATE_SAVING_TEST_SUITE)
 
 			rri->loadState("test-save-state.rr");
 
-			rri->addSpecies("S1", "compartment", 7, true);
+			rri->addSpecies("S1", "compartment", 7, true, true);
 			rri->addAssignmentRule("S1", "7");
 		}));
 	}
@@ -798,7 +798,7 @@ SUITE(STATE_SAVING_TEST_SUITE)
 			rri->loadState("test-save-state.rr");
 			rri->addSpecies("S1", "compartment", 1, true);
 			rri->addSpecies("S2", "compartment", 1.5e-15, true);
-			rri->addSpecies("S3", "compartment", 1, true);
+			rri->addSpecies("S3", "compartment", 1, true, true);
 			rri->addParameter("k1", 0.75);
 			rri->addParameter("k2", 50);
 			rri->addAssignmentRule("S3", "k1*S2");
@@ -881,7 +881,7 @@ SUITE(STATE_SAVING_TEST_SUITE)
 		CHECK(StateRunTestModelFromScratch([](RoadRunner *rri)
 		{
 			rri->addCompartment("compartment", 1);
-			rri->addSpecies("S1", "compartment", 0, true);
+			rri->addSpecies("S1", "compartment", 0, true, true);
 			rri->addRateRule("S1", "7");
 			
 			rri->saveState("test-save-state.rr");
@@ -894,6 +894,6 @@ SUITE(STATE_SAVING_TEST_SUITE)
 	{
 		RoadRunner rri;
 		rri.loadState("test-save-state.rr");
-		CHECK(rri.getFloatingSpeciesByIndex(0) == 0);
+		CHECK(rri.getBoundarySpeciesByIndex(0) == 0);
 	}
 }

--- a/wrappers/C/Testing/Suite_Test_Model_Editing.cpp
+++ b/wrappers/C/Testing/Suite_Test_Model_Editing.cpp
@@ -465,6 +465,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 	{
 		CHECK(RunTestWithModification([](RRHandle rri)
 		{
+			setBoundary(rri, "S1", true);
 			addAssignmentRule(rri, "S1", "7");
 		}));
 	}
@@ -473,6 +474,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 	{
 		CHECK(RunTestWithModification([](RRHandle rri)
 		{
+			setBoundary(rri, "S1", true);
 			addRateRule(rri, "S1", "7");
 		}));
 	}
@@ -565,6 +567,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 		CHECK(RunTestWithModification([](RRHandle rri)
 		{
 			setConstantNoRegen(rri, "S1", false);
+			setBoundary(rri, "S1", true);
 			addRateRule(rri, "S1", "7");
 		}));
 	}
@@ -753,7 +756,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 		CHECK(RunTestModelFromScratch([](RRHandle rri)
 		{
 			addCompartment(rri, "compartment", 1);
-			addSpecies(rri, "S1", "compartment", 0, false, false);
+			addSpecies(rri, "S1", "compartment", 0, false, true);
 			addRateRule(rri, "S1", "7");
 		}));
 	}
@@ -763,7 +766,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 		CHECK(RunTestModelFromScratch([](RRHandle rri)
 		{
 			addCompartment(rri, "compartment", 1);
-			addSpecies(rri, "S1", "compartment", 7, false, false);
+			addSpecies(rri, "S1", "compartment", 7, false, true);
 			addAssignmentRule(rri, "S1", "7");
 		}));
 	}
@@ -775,7 +778,7 @@ SUITE(MODEL_EDITING_TEST_SUITE)
 			addCompartment(rri, "compartment", 1);
 			addSpecies(rri, "S1", "compartment", 1, false, false);
 			addSpecies(rri, "S2", "compartment", 1.5e-15, false, false);
-			addSpecies(rri, "S3", "compartment", 1, false, false);
+			addSpecies(rri, "S3", "compartment", 1, false, true);
 			addParameter(rri, "k1", 0.75);
 			addParameter(rri, "k2", 50);
 			addAssignmentRule(rri, "S3", "k1*S2");


### PR DESCRIPTION
This allows the user to call 'regenerate' directly, instead of having to call it by proxy when adding/removing SBML elements.  It also cleans up a lot of the model editing functions:
  * Only does some validation when 'forceRegenerate' is on, on the assumption that until the user wants to regenerate the model, it might be in an inconsistent state.
  * Calls 'getReactant'/'getProduct' directly instead of 'getReactantList', etc.
  * Consolidates checks when adding assignment and rate rules.
  * Changes the constant/boundarySpecies attributes as appropriate (might want to throw instead?)
  * Collects a set of variables to check, instead of a vector (to eliminate duplicate checking).
  * Properly cleans up after species references with rules when deleting reactions.

Finally, fixes tests that had added a rate rules/assignment rules for non-boundary species:  they're now properly boundary species when constructed.