### PR TITLE
Attempt to make mac azure debug build on first try.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -254,9 +254,9 @@ stages:
               BuildType: Debug
               SelfHost: false
               CMakeArgs: "-DCMAKE_INSTALL_PREFIX=$(Build.BinariesDirectory)/install-azure-debug"
-              llvm_link: https://github.com/sys-bio/llvm-6.x/releases/download/release%2F6.x/llvm-6.x-clang11.0.3-x64-debug.zip
-              llvm_zip: llvm-6.x-clang11.0.3-x64-debug.zip
-              llvm_install: llvm-6.x-clang11.0.3-x64-debug
+              llvm_link: https://github.com/sys-bio/llvm-6.x/releases/download/release%2F6.x/llvm-6.x-clang11.0.3-x64-release.zip
+              llvm_zip: llvm-6.x-clang11.0.3-x64-release.zip
+              llvm_install: llvm-6.x-clang11.0.3-x64-release
               rr_deps_link: https://github.com/CiaranWelsh/roadrunner-deps/releases/download/v2.0.1/libroadrunner-deps-mac-x64-debug.zip
               rr_deps_zip: libroadrunner-deps-mac-x64-debug.zip
               rr_deps_install: libroadrunner-deps-mac-x64-debug


### PR DESCRIPTION
For some reason, every time the mac debug build runs, it fails on importing llvm, but if you click 're-run failed tests' it succeeds.  Maybe it'll work if we import the release llvm instead?