### PR TITLE
Fix the non-static rrplugins libraries so they compile.

### DIFF
--- a/rrplugins/plugins/add_noise/add_noise.h
+++ b/rrplugins/plugins/add_noise/add_noise.h
@@ -9,13 +9,13 @@
 //---------------------------------------------------------------------------
 namespace addNoise
 {
-using namespace tlp;
+    using namespace tlp;
 
-class AddNoise : public CPPPlugin
-{
+    class AddNoise : public CPPPlugin
+    {
     public:
         friend class AddNoiseWorker;
-        enum NoiseType {ntGaussian = 0, ntPsychological, ntUndefined};
+        enum NoiseType { ntGaussian = 0, ntPsychological, ntUndefined };
 
     private:
         Property<int>               mNoiseType;
@@ -26,24 +26,24 @@ class AddNoise : public CPPPlugin
         void                        assignPropertyDescriptions();
 
     public:
-                                    AddNoise(rrc::THostInterface* aRR = NULL, PluginEvent fn1 = NULL, PluginEvent fn2 = NULL, PluginEvent fn3 = NULL);
-                                   ~AddNoise();
+        AddNoise(rrc::THostInterface* aRR = NULL, PluginEvent fn1 = NULL, PluginEvent fn2 = NULL, PluginEvent fn3 = NULL);
+        ~AddNoise();
 
-                                
+
         bool                        execute(bool inThread = false);
         bool                        isWorking() const; //Returns true as long the thread is active..
-        unsigned char*              getManualAsPDF() const;
+        unsigned char* getManualAsPDF() const;
         size_t                      getPDFManualByteSize();
-};
+    };
 
 #ifdef EXPORT_ADD_NOISE
 
-extern "C"
-{
-TLP_DS Plugin*      plugins_cc createPlugin();
-TLP_DS const char*  plugins_cc getImplementationLanguage();
-TLP_DS void         plugins_cc setHostInterface(rrc::THostInterface* _hostInterface);
-}
+    extern "C"
+    {
+        TLP_DS Plugin* plugins_cc createPlugin();
+        TLP_DS const char* plugins_cc getImplementationLanguage();
+        TLP_DS void         plugins_cc setHostInterface(rrc::THostInterface* _hostInterface);
+    }
 
 #endif
 
@@ -52,44 +52,44 @@ TLP_DS void         plugins_cc setHostInterface(rrc::THostInterface* _hostInterf
 namespace tlp
 {
 
-template<>
-inline string getPropertyType(const addNoise::AddNoise::NoiseType& value)
-{
-    return "NoiseType";
-}
-
-template<>
-inline string Property<addNoise::AddNoise::NoiseType>::getValueAsString() const
-{
-    switch(mValue)
+    template<>
+    inline string getPropertyType(const addNoise::AddNoise::NoiseType& value)
     {
+        return "NoiseType";
+    }
+
+    template<>
+    inline string Property<addNoise::AddNoise::NoiseType>::getValueAsString() const
+    {
+        switch (mValue)
+        {
         case addNoise::AddNoise::ntGaussian:
             return "Gaussian";
         case addNoise::AddNoise::ntPsychological:
             return "SomethingElse";
         case addNoise::AddNoise::ntUndefined:
             return "Undefined";
+        }
+        return "";
     }
-    return "";
-}
 
-template<>
-inline void Property< addNoise::AddNoise::NoiseType >::setValueFromString(const string& val)
-{
-    //Only gaussian noise is available at this time
-    if(val == "0")
+    template<>
+    inline void Property< addNoise::AddNoise::NoiseType >::setValueFromString(const string& val)
     {
-        mValue = addNoise::AddNoise::ntGaussian;
+        //Only gaussian noise is available at this time
+        if (val == "0")
+        {
+            mValue = addNoise::AddNoise::ntGaussian;
+        }
+        else if (val == "1")
+        {
+            mValue = addNoise::AddNoise::ntPsychological;
+        }
+        else
+        {
+            mValue = addNoise::AddNoise::ntUndefined;
+        }
     }
-    else if(val == "1")
-    {
-        mValue = addNoise::AddNoise::ntPsychological;
-    }
-    else
-    {
-        mValue = addNoise::AddNoise::ntUndefined;
-    }
-}
 
 }
 

--- a/rrplugins/plugins/auto2000/libAutoTelluriumInterface/CMakeLists.txt
+++ b/rrplugins/plugins/auto2000/libAutoTelluriumInterface/CMakeLists.txt
@@ -23,7 +23,7 @@ endif ()
 
 target_link_libraries(${target} PUBLIC
         rr-libstruct::rr-libstruct-static
-        telplugins_core
+        telplugins_core-static
         libAuto-static
         )
 add_dependencies(${target} telplugins_core)

--- a/rrplugins/plugins/chisquare/CMakeLists.txt
+++ b/rrplugins/plugins/chisquare/CMakeLists.txt
@@ -15,8 +15,8 @@ set(RRP_CHISQUARED_SOURCES
 add_library(${target} MODULE ${RRP_CHISQUARED_SOURCES})
 
 target_link_libraries (${target} PRIVATE
-  telpluginsBaseClass
-  telplugins_math
+  telpluginsBaseClass-static
+  telplugins_math-static
   #telplugins_common
   ${RRPLUGINS_COMMON_SHARED_LIBS}
 )

--- a/rrplugins/plugins/hello_roadrunner/CMakeLists.txt
+++ b/rrplugins/plugins/hello_roadrunner/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Debashish Roy
 
+project(hello)
 set(target tel_hello)
 
 set(RRP_HELLO_SOURCES
@@ -10,11 +11,16 @@ set(RRP_HELLO_SOURCES
 add_library(${target} MODULE ${RRP_HELLO_SOURCES})
 
 target_link_libraries ( ${target} PUBLIC
-  telpluginsBaseClass
+  telpluginsBaseClass-static
+  telplugins_math-static
+  telplugins_common-static
   ${RRPLUGINS_COMMON_SHARED_LIBS}
 )
 
-target_compile_definitions(${target} PRIVATE EXPORT_HELLO)
+target_compile_definitions(${target} PRIVATE
+     -DEXPORT_TEL_PLUGIN
+     -DEXPORT_HELLO
+     )
 
 if (UNIX)
   set_target_properties( ${target} PROPERTIES INSTALL_RPATH "$ORIGIN/./" )

--- a/rrplugins/plugins/hello_roadrunner/hello.h
+++ b/rrplugins/plugins/hello_roadrunner/hello.h
@@ -1,7 +1,9 @@
-#pragma once
-#include "rrplugins/pluginBaseClass/telCPPPlugin.h"
-#include "rrplugins/core/tel_api.h"
+#ifndef helloH
+#define helloH
 #include "telProperty.h"
+#include "rrplugins/pluginBaseClass/telCPPPlugin.h"
+#include "telTelluriumData.h"
+#include "rrplugins/core/tel_api.h"
 
 namespace hello
 {
@@ -9,22 +11,24 @@ namespace hello
 
     class Hello : public CPPPlugin
     {
-        private:    
-            char*               mVersion;
+    private:
+        char* mVersion;
 
-        public:
-            Hello();
-            bool                execute(bool inThread = false);
-            string              message;
+    public:
+        Hello();
+        bool                execute(bool inThread = false);
+        string              message;
     };
 
-    #ifdef EXPORT_HELLO
+#ifdef EXPORT_HELLO
     extern "C"
     {
-        TLP_DS Plugin*      plugins_cc createPlugin();
-        TLP_DS const char*  plugins_cc getImplementationLanguage();
+        TLP_DS Plugin* plugins_cc createPlugin();
+        TLP_DS const char* plugins_cc getImplementationLanguage();
         TLP_DS void         plugins_cc setHostInterface(rrc::THostInterface* _hostInterface);
     }
-    #endif
+#endif
 }
+
+#endif //helloH
 

--- a/rrplugins/plugins/test_model/CMakeLists.txt
+++ b/rrplugins/plugins/test_model/CMakeLists.txt
@@ -20,8 +20,8 @@ add_library(${target} MODULE ${RRP_TEST_MODEL_SOURCES})
 target_compile_definitions(${target} PRIVATE -DEXPORT_TEL_PLUGIN -DEXPORT_TEST_MODEL)
 
 target_link_libraries(${target} PRIVATE
-        telpluginsBaseClass
-        telplugins_math
+        telpluginsBaseClass-static
+        telplugins_math-static
         ${RRPLUGINS_COMMON_SHARED_LIBS})
 
 if (UNIX)

--- a/rrplugins/rrplugins/common/CMakeLists.txt
+++ b/rrplugins/rrplugins/common/CMakeLists.txt
@@ -47,7 +47,8 @@ if (RR_PLUGINS_BUILD_SHARED_LIB)
 
     target_link_libraries(${target} PUBLIC
             ${RRPLUGINS_COMMON_SHARED_LIBS}
-            roadrunner roadrunner_c_api
+            roadrunner-static
+            roadrunner_c_api
             )
     target_include_directories(${target}
             PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
@@ -59,7 +60,7 @@ if (RR_PLUGINS_BUILD_SHARED_LIB)
     endif ()
 
     # Install shared library
-    install(TARGETS ${target} DESTINATION "${PYTHON_PACKAGE_INSTALL_PREFIX}/rrplugins")
+    install(TARGETS ${target} DESTINATION "${RR_PLUGINS_INSTALL_PREFIX}")
 
     # disable the auto addition of "lib" onto target name
     set_target_properties(${target} PROPERTIES PREFIX "")

--- a/rrplugins/rrplugins/core/CMakeLists.txt
+++ b/rrplugins/rrplugins/core/CMakeLists.txt
@@ -9,6 +9,7 @@ set(
         ${RR_PLUGINS_ROOT}/rrplugins/pluginBaseClass/telCPlugin
         ${RR_PLUGINS_ROOT}/rrplugins/pluginBaseClass/telCPPPlugin
         ${RR_PLUGINS_ROOT}/rrplugins/pluginBaseClass/telPlugin
+        ${RR_PLUGINS_ROOT}/rrplugins/common/telException
         tel_api   #struct of roadrunner function pointer
         telPluginManager
         telVersionInfo
@@ -18,31 +19,23 @@ set(
 
 if (RR_PLUGINS_BUILD_SHARED_LIB)
     add_library(${target} SHARED ${sources})
-
-    target_compile_definitions(${target} PRIVATE EXPORT_CORE_API)
+    target_compile_definitions(${target} PUBLIC SHARED_PLUGIN_API)
 
     target_link_libraries(${target} PUBLIC
-            telplugins_common
-            telpluginsBaseClass
-            ${RRPLUGINS_COMMON_SHARED_LIBS}
+            telplugins_common-static
+            telpluginsBaseClass-static
+            ${RRPLUGINS_COMMON_STATIC_LIBS}
             roadrunner_c_api
-            roadrunner
+            roadrunner-static
             )
-
     target_include_directories(${target} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${RR_PLUGINS_ROOT})
 
-    if (UNIX)
-        set_target_properties(${target} PROPERTIES INSTALL_RPATH "$ORIGIN/./")
-    endif ()
-
-    # Install shared library
+    # Install static library
     install(TARGETS ${target}
-            RUNTIME DESTINATION bin COMPONENT rrplugins
-            LIBRARY DESTINATION lib COMPONENT rrplugins
-            ARCHIVE DESTINATION lib COMPONENT rrplugins
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT rrplugins
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT rrplugins
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT rrplugins
             )
-
-    install(TARGETS ${target} DESTINATION "${PYTHON_PACKAGE_INSTALL_PREFIX}/rrplugins")
 
     # disable the auto addition of "lib" onto target name
     set_target_properties(${target} PROPERTIES PREFIX "")

--- a/rrplugins/rrplugins/math/CMakeLists.txt
+++ b/rrplugins/rrplugins/math/CMakeLists.txt
@@ -18,7 +18,8 @@ if (RR_PLUGINS_BUILD_SHARED_LIB)
     target_compile_definitions(${target} PRIVATE EXPORT_MATH_API)
 
     target_link_libraries(${target} PUBLIC
-            telplugins_common ${RRPLUGINS_COMMON_SHARED_LIBS})
+            telplugins_common-static
+            ${RRPLUGINS_COMMON_SHARED_LIBS})
     target_include_directories(${target} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
     if (UNIX)
@@ -32,7 +33,7 @@ if (RR_PLUGINS_BUILD_SHARED_LIB)
             ARCHIVE DESTINATION lib COMPONENT rrplugins
             )
 
-    install(TARGETS ${target} DESTINATION "${PYTHON_PACKAGE_INSTALL_PREFIX}/rrplugins")
+    install(TARGETS ${target} DESTINATION "${RR_PLUGINS_INSTALL_PREFIX}")
 
     # disable the auto addition of "lib" onto target name
     set_target_properties(${target} PROPERTIES PREFIX "")
@@ -45,7 +46,8 @@ if (RR_PLUGINS_BUILD_STATIC_LIB)
     target_compile_definitions(${target}-static PRIVATE STATIC_PLUGIN_API)
 
     target_link_libraries(${target}-static PUBLIC
-            telplugins_common-static ${RRPLUGINS_COMMON_STATIC_LIBS})
+            telplugins_common-static 
+            ${RRPLUGINS_COMMON_STATIC_LIBS})
 
     target_include_directories(${target}-static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/rrplugins/rrplugins/pluginBaseClass/CMakeLists.txt
+++ b/rrplugins/rrplugins/pluginBaseClass/CMakeLists.txt
@@ -15,20 +15,23 @@ set(sources
 
 if (RR_PLUGINS_BUILD_SHARED_LIB)
     add_library(${target} SHARED ${sources})
-    target_compile_definitions(${target} PRIVATE EXPORT_CORE_API)
+    target_compile_definitions(${target} PUBLIC SHARED_PLUGIN_API)
 
-    target_link_libraries(${target} PUBLIC telplugins_common ${RRPLUGINS_COMMON_SHARED_LIBS})
-    if (UNIX)
-        set_target_properties(telpluginsBaseClass PROPERTIES INSTALL_RPATH "$ORIGIN/./")
-    endif ()
+    target_link_libraries(${target} PUBLIC
+            telplugins_common-static 
+            ${RRPLUGINS_COMMON_SHARED_LIBS})
 
     target_include_directories(${target} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${RR_PLUGINS_ROOT})
 
-    install(TARGETS ${target} DESTINATION "${PYTHON_PACKAGE_INSTALL_PREFIX}/rrplugins")
-
+    # Install static library
+    install(TARGETS ${target}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT rrplugins
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT rrplugins
+            )
     # disable the auto addition of "lib" onto target name
     set_target_properties(${target} PROPERTIES PREFIX "")
 endif ()
+
 
 # ** Static lib ******
 
@@ -37,7 +40,8 @@ if (RR_PLUGINS_BUILD_STATIC_LIB)
     target_compile_definitions(${target}-static PUBLIC STATIC_PLUGIN_API)
 
     target_link_libraries(${target}-static PUBLIC
-            telplugins_common-static ${RRPLUGINS_COMMON_STATIC_LIBS})
+            telplugins_common-static 
+            ${RRPLUGINS_COMMON_STATIC_LIBS})
 
     target_include_directories(${target}-static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${RR_PLUGINS_ROOT})
 

--- a/rrplugins/rrplugins/pluginBaseClass/telCPPPlugin.h
+++ b/rrplugins/rrplugins/pluginBaseClass/telCPPPlugin.h
@@ -48,7 +48,8 @@ namespace tlp
 /**
  * Plugins written in C++ should inherit from this class.
  */
-class CORE_DECLSPEC CPPPlugin : public Plugin
+//class CORE_DECLSPEC CPPPlugin : public Plugin
+class CPPPlugin : public Plugin
 {
     protected:
 

--- a/rrplugins/rrplugins/pluginBaseClass/telCPlugin.h
+++ b/rrplugins/rrplugins/pluginBaseClass/telCPlugin.h
@@ -62,7 +62,8 @@ typedef void* (*getAPropertyF)(const char*);
  * The CPlugin class is containing the framework to load plugins that are written in pure C.
  * The shared library need to export an execute and destroy function.
  */
-class CORE_DECLSPEC CPlugin : public Plugin
+//class CORE_DECLSPEC CPlugin : public Plugin
+class CPlugin : public Plugin
 {
     friend class PluginManager;
     public:

--- a/rrplugins/rrplugins/pluginBaseClass/telPlugin.cpp
+++ b/rrplugins/rrplugins/pluginBaseClass/telPlugin.cpp
@@ -25,7 +25,7 @@ mCategory(category),
 mDescription("<none>"),
 mHint("<none>"),
 mVersion("0.0"),
-mCopyright("Totte Karlsson, J Kyle Medley, Wilbert Copeland and Herbert Sauro, Systems Biology, UW 2012-2015"),
+mCopyright("Totte Karlsson, J Kyle Medley, Wilbert Copeland and Herbert Sauro, Systems Biology, UW 2012-2020"),
 mWorkStartedEvent(NULL),
 mWorkProgressEvent(NULL),
 mWorkFinishedEvent(NULL),
@@ -355,7 +355,7 @@ string Plugin::getPropertyValueAsString(const string& propName)
     {
         stringstream str;
         str<<"No property with name: "<<propName;
-        throw(Exception(str.str()));
+        throw(tlp::Exception(str.str()));
     }
 }
 

--- a/rrplugins/rrplugins/pluginBaseClass/telPlugin.h
+++ b/rrplugins/rrplugins/pluginBaseClass/telPlugin.h
@@ -84,7 +84,8 @@ typedef void    (event_cc *PluginEvent)(void* data1, void* data2);
   -# A plugin may embed documentation in various forms, e.g. PDF (getPDFManual(), or simple text getExtendedInfo().
  */
 //      CORE_DECLSPEC
-class CORE_DECLSPEC Plugin
+//class CORE_DECLSPEC Plugin
+class Plugin
 {
     friend class PluginManager;
     public:

--- a/rrplugins/wrappers/C/CMakeLists.txt
+++ b/rrplugins/wrappers/C/CMakeLists.txt
@@ -16,10 +16,10 @@ add_library(${target} SHARED
         )
 
 target_link_libraries(${target} PUBLIC
-        telplugins_common
-        telplugins_core
-        telplugins_math
-        telpluginsBaseClass
+        telplugins_common-static
+        telplugins_core-static
+        telplugins_math-static
+        telpluginsBaseClass-static
         ${RRPLUGINS_COMMON_SHARED_LIBS}
         )
 
@@ -51,4 +51,4 @@ install(
         LIBRARY DESTINATION lib COMPONENT rrplugins
 )
 
-install(TARGETS ${target} DESTINATION "${PYTHON_PACKAGE_INSTALL_PREFIX}/rrplugins")
+install(TARGETS ${target} DESTINATION "${RR_PLUGINS_INSTALL_PREFIX}")

--- a/wrappers/C/rrc_api.h
+++ b/wrappers/C/rrc_api.h
@@ -2997,7 +2997,7 @@ C_DECL_SPEC int rrcCallConv getConfigInt(const char* key);
 C_DECL_SPEC int rrcCallConv setConfigDouble(const char* key, double value);
 
 
-//RRPLugins
+//RRPlugins
 /*!
     \return the number of floating species pointed by the model by handle
 */


### PR DESCRIPTION
For now, the only way I could find to make this work was to make literally everything always link the static libraries.  I have a feeling that there's some other option somewhere I could find to let it work a different way, but since this works, I'm going with it for now.

Also, some of the classes needed to not be set export the way they were.