### PR TITLE
Fix for https://github.com/sys-bio/roadrunner/issues/781

### DIFF
--- a/rrplugins/plugins/levenberg_marquardt/CMakeLists.txt
+++ b/rrplugins/plugins/levenberg_marquardt/CMakeLists.txt
@@ -43,7 +43,7 @@ if(BUILD_PYTHON)
     DESTINATION ${RR_PLUGINS_PYLIB_INSTALL_PREFIX}
     COMPONENT plugins
     )
-    file(GLOB EXAMPLES docs/*)
+    file(GLOB EXAMPLES docs/Examples/*)
     install(FILES ${EXAMPLES} DESTINATION "${RR_PLUGINS_PYTHON_INSTALL_PREFIX}" COMPONENT plugins)
     unset(EXAMPLES)
 endif()

--- a/rrplugins/plugins/monte_carlo_bs/CMakeLists.txt
+++ b/rrplugins/plugins/monte_carlo_bs/CMakeLists.txt
@@ -35,7 +35,7 @@ if(BUILD_PYTHON)
     DESTINATION ${RR_PLUGINS_PYLIB_INSTALL_PREFIX}
     COMPONENT plugins
     )
-    file(GLOB EXAMPLES docs/*)
+    file(GLOB EXAMPLES docs/Examples/*)
     install(FILES ${EXAMPLES} DESTINATION "${RR_PLUGINS_PYTHON_INSTALL_PREFIX}" COMPONENT plugins)
     unset(EXAMPLES)
 endif()

--- a/rrplugins/plugins/nelder_mead/CMakeLists.txt
+++ b/rrplugins/plugins/nelder_mead/CMakeLists.txt
@@ -49,7 +49,7 @@ if(BUILD_PYTHON)
     DESTINATION ${RR_PLUGINS_PYLIB_INSTALL_PREFIX}
     COMPONENT plugins
     )
-    file(GLOB EXAMPLES docs/*)
+    file(GLOB EXAMPLES docs/Examples/*)
     install(FILES ${EXAMPLES} DESTINATION "${RR_PLUGINS_PYTHON_INSTALL_PREFIX}" COMPONENT plugins)
     unset(EXAMPLES)
 endif()

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1997,6 +1997,16 @@ std::vector<ls::Complex> RoadRunner::getReducedEigenValues()
     return getEigenValues(JACOBIAN_REDUCED);
 }
 
+DoubleMatrix RoadRunner::getFullEigenValuesNamedArray()
+{
+    return getEigenValuesNamedArray(JACOBIAN_FULL);
+}
+
+DoubleMatrix RoadRunner::getReducedEigenValuesNamedArray()
+{
+    return getEigenValuesNamedArray(JACOBIAN_REDUCED);
+}
+
 std::vector< std::complex<double> > RoadRunner::getEigenValues(RoadRunner::JacobianMode mode)
 {
     check_model();
@@ -2011,6 +2021,35 @@ std::vector< std::complex<double> > RoadRunner::getEigenValues(RoadRunner::Jacob
         mat = getReducedJacobian();
     }
     return ls::getEigenValues(mat);
+}
+
+DoubleMatrix RoadRunner::getEigenValuesNamedArray(RoadRunner::JacobianMode mode)
+{
+    check_model();
+    DoubleMatrix mat;
+
+    if (mode == JACOBIAN_FULL)
+    {
+        mat = getFullJacobian();
+    }
+    else
+    {
+        mat = getReducedJacobian();
+    }
+    std::vector< std::complex<double> > eigens = ls::getEigenValues(mat);
+    //std::vector< std::complex<double> > eigens = getEigenValues(mode);
+    DoubleMatrix v(eigens.size(), 2);
+    for (unsigned int i = 0; i < eigens.size(); i++)
+    {
+        v(i, 0) = std::real(eigens[i]);
+        v(i, 1) = std::imag(eigens[i]);
+    }
+    v.setRowNames(mat.getRowNames());
+    std::vector<std::string> colnames;
+    colnames.push_back("real");
+    colnames.push_back("imaginary");
+    v.setColNames(colnames);
+    return v;
 }
 
 DoubleMatrix RoadRunner::getFloatingSpeciesAmountsNamedArray()
@@ -5665,6 +5704,20 @@ void RoadRunner::setHasOnlySubstanceUnits(const std::string& sid, bool hasOnlySu
 	species->setHasOnlySubstanceUnits(hasOnlySubstanceUnits);
 
 	regenerateModel(forceRegenerate);
+}
+
+bool RoadRunner::getHasOnlySubstanceUnits(const std::string& sid)
+{
+    using namespace libsbml;
+    Model* sbmlModel = impl->document->getModel();
+    Species* species = sbmlModel->getSpecies(sid);
+
+    if (species == NULL)
+    {
+        throw std::invalid_argument("Roadrunner::getHasOnlySubstanceUnits failed, no species with ID " + sid + " existed in the model");
+    }
+
+    return species->getHasOnlySubstanceUnits();
 }
 
 void RoadRunner::setInitAmount(const std::string& sid, double initAmount, bool forceRegenerate)

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -553,20 +553,41 @@ namespace rr
         /**
          * Returns the eigenvalues of the full jacobian.
          *
-         * If the eigenvalues are all real, this returns a N x 1 matrix,
-         * if complex, returns an N x 2 matrix where the first column is the
-         * real values and the second is the imaginary part.
+         * This returns a vector of Complex numbers.  In the python bindings,
+         * the values are complex only if there are non-zero imaginary
+         * parts of the values.
          */
         std::vector<ls::Complex> getFullEigenValues();
 
         /**
          * Returns the eigenvalues of the reduced jacobian.
          *
-         * If the eigenvalues are all real, this returns a N x 1 matrix,
-         * if complex, returns an N x 2 matrix where the first column is the
-         * real values and the second is the imaginary part.
+         * This returns a vector of Complex numbers.  In the python bindings,
+         * the values are complex only if there are non-zero imaginary
+         * parts of the values.
          */
         std::vector<ls::Complex> getReducedEigenValues();
+
+
+        /**
+         * Returns the eigenvalues of the full jacobian as a named array.
+         *
+         * This returns an N x 2 matrix where the first column is the
+         * real values and the second is the imaginary part.  The rows
+         * are labeled with the corresponding species ids, and the columns
+         * are labeled 'real' and 'imaginary'.
+         */
+        ls::DoubleMatrix getFullEigenValuesNamedArray();
+
+        /**
+         * Returns the eigenvalues of the reduced jacobian as a named array.
+         *
+         * This returns an N x 2 matrix where the first column is the
+         * real values and the second is the imaginary part.  The rows
+         * are labeled with the corresponding species ids, and the columns
+         * are labeled 'real' and 'imaginary'.
+         */
+        ls::DoubleMatrix getReducedEigenValuesNamedArray();
 
 
         ls::DoubleMatrix getLinkMatrix();
@@ -814,6 +835,12 @@ namespace rr
          *					       set this flag to true only in the last call of editing
          */
         void setHasOnlySubstanceUnits(const std::string& sid, bool hasOnlySubstanceUnits, bool forceRegenerate = true);
+
+        /**
+         * Get the hasOnlySubstanceUnits attribute for an existing species.
+         * @param sid: the ID of a species
+         */
+        bool getHasOnlySubstanceUnits(const std::string& sid);
 
 
         /**
@@ -1636,6 +1663,8 @@ namespace rr
         };
 
         std::vector< std::complex<double> > getEigenValues(JacobianMode mode);
+
+        ls::DoubleMatrix getEigenValuesNamedArray(JacobianMode mode);
 
         /**
          * private implementation class, can only access if inside

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -39,6 +39,22 @@ TEST_F(ModelAnalysisTests, AnalysisFunctionsWithEvent) {
 }
 
 
+TEST_F(ModelAnalysisTests, EigenvalueNamedArrays) {
+    RoadRunner* rr = new RoadRunner((modelAnalysisModelsDir / "BIOMD0000000035_url.xml").string());
+
+    ls::DoubleMatrix eigens = rr->getFullEigenValuesNamedArray();
+    EXPECT_EQ(eigens.size(), 18);
+    EXPECT_EQ(eigens.RSize(), 9);
+    EXPECT_EQ(eigens.CSize(), 2);
+    for (unsigned int r = 0; r < 9; r++) {
+        EXPECT_GT(eigens(r, 0), -105);
+        EXPECT_GT(eigens(r, 1), -15);
+    }
+
+    delete rr;
+}
+
+
 TEST_F(ModelAnalysisTests, GetEventIDs) {
     RoadRunner *rr = new RoadRunner((modelAnalysisModelsDir / "event.xml").string());
 

--- a/wrappers/Python/roadrunner/roadrunner.i
+++ b/wrappers/Python/roadrunner/roadrunner.i
@@ -235,51 +235,22 @@
 
     bool iscpx = false;
 
-    // small number
-    double epsilon = 2 * std::numeric_limits<double>::epsilon();
-    for (std::vector<cpx>::const_iterator i = vec.begin(); i != vec.end(); ++i)
-    {
-        iscpx = iscpx || (std::imag(*i) >= epsilon);
-        if (iscpx) break;
+    size_t len = $1.size();
+    npy_intp dims[1] = {static_cast<npy_intp>(len)};
+
+    PyObject *array = PyArray_SimpleNew(1, dims, NPY_COMPLEX128);
+    VERIFY_PYARRAY(array);
+
+    if (!array) {
+        // TODO error handling.
+        return 0;
     }
 
-    if (iscpx) {
-        size_t len = $1.size();
-        npy_intp dims[1] = {static_cast<npy_intp>(len)};
+    cpx *data = (cpx*)PyArray_DATA((PyArrayObject*)array);
 
-        PyObject *array = PyArray_SimpleNew(1, dims, NPY_COMPLEX128);
-        VERIFY_PYARRAY(array);
+    memcpy(data, &vec[0], sizeof(std::complex<double>)*len);
 
-        if (!array) {
-            // TODO error handling.
-            return 0;
-        }
-
-        cpx *data = (cpx*)PyArray_DATA((PyArrayObject*)array);
-
-        memcpy(data, &vec[0], sizeof(std::complex<double>)*len);
-
-        $result  = array;
-    } else {
-        size_t len = $1.size();
-        npy_intp dims[1] = {static_cast<npy_intp>(len)};
-
-        PyObject *array = PyArray_SimpleNew(1, dims, NPY_DOUBLE);
-        VERIFY_PYARRAY(array);
-
-        if (!array) {
-            // TODO error handling.
-            return 0;
-        }
-
-        double *data = (double*)PyArray_DATA((PyArrayObject*)array);
-
-        for (int i = 0; i < vec.size(); ++i) {
-            data[i] = std::real(vec[i]);
-        }
-
-        $result  = array;
-    }
+    $result  = array;
 }
 
 


### PR DESCRIPTION
(Also, add 'getHasOnlySubstanceUnits', which I needed for a different problem but am sticking here because lazy.)

This change adds new functions for eigenvalues that return named arrays, and also changes the existing functions to always return complex values instead of changing the return type based on content.