### PR TITLE
Fixes issue 773: crash if no boundary species

### DIFF
--- a/rrplugins/plugins/auto2000/libAutoTelluriumInterface/telAutoTelluriumInterface.cpp
+++ b/rrplugins/plugins/auto2000/libAutoTelluriumInterface/telAutoTelluriumInterface.cpp
@@ -149,10 +149,11 @@ bool AutoTellurimInterface::setupUsingCurrentModel()
 	mModelParameters = list1;
 
 	lists= gHostInterface->getBoundarySpeciesIds(mRR);
-	StringList list2(lists->String, lists->Count);
-    //Boundary species can be used as PCP as well
-    mModelBoundarySpecies   = list2;
-
+	if (lists) {
+		StringList list2(lists->String, lists->Count);
+		//Boundary species can be used as PCP as well
+		mModelBoundarySpecies = list2;
+	}
     //Set initial value of Primary continuation parameter
     setInitialPCPValue();
     setCallbackStpnt(ModelInitializationCallback);	

--- a/test/models/PLUGINS/auto2000_2rxn.xml
+++ b/test/models/PLUGINS/auto2000_2rxn.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.3. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="X" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="Y" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="k" value="2" constant="true"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction id="J1" reversible="true">
+        <listOfProducts>
+          <speciesReference species="X" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <minus/>
+              <ci> k </ci>
+              <ci> X </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="J2" reversible="true">
+        <listOfProducts>
+          <speciesReference species="Y" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference species="X"/>
+        </listOfModifiers>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <minus/>
+              <ci> X </ci>
+              <ci> Y </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/plugin_auto2000/auto2000.cpp
+++ b/test/plugin_auto2000/auto2000.cpp
@@ -25,6 +25,23 @@ public:
 };
 
 
+TEST_F(PluginAuto2000Tests, Issue_773_no_boundary_species)
+{
+    //This just tests to make sure we don't crash if there's no boundary species.
+    PluginManager* PM = new PluginManager(rrPluginsBuildDir_.string());
+
+    Plugin* a2kplugin = PM->getPlugin("tel_auto2000");
+    ASSERT_TRUE(a2kplugin != NULL);
+    a2kplugin->setPropertyByString("SBML", (pluginsModelsDir / "auto2000_2rxn.xml").string().c_str());
+    a2kplugin->setPropertyByString("PrincipalContinuationParameter", "k");
+    a2kplugin->setPropertyByString("ScanDirection", "Positive");
+    a2kplugin->setPropertyByString("RL0", "0");
+    a2kplugin->setPropertyByString("RL1", "5");
+
+    a2kplugin->execute();
+
+}
+
 TEST_F(PluginAuto2000Tests, RUN_BIOMOD_203)
 {
     PluginManager* PM = new PluginManager(rrPluginsBuildDir_.string());


### PR DESCRIPTION
https://github.com/sys-bio/roadrunner/issues/773

This turned out to be a simple fix:  at one point we ask for the list of boundary species, and if there are zero, NULL is returned.  If we check for that, everything else works fine.