### PR TITLE
Fix references to the beginnings of empty arrays.

### DIFF
--- a/source/CVODEIntegrator.cpp
+++ b/source/CVODEIntegrator.cpp
@@ -783,11 +783,11 @@ namespace rr {
                 if (varstep
                     && (timeEnd - timeStart > 2. * epsilon)) {
                     // event status before time step
-                    mModel->getEventTriggers(eventStatus.size(), 0, &eventStatus[0]);
+
+                    mModel->getEventTriggers(eventStatus.size(), 0, eventStatus.empty() ? nullptr : &eventStatus[0]);
                     // apply events and write state to variableStepPostEventState
                     // model state is updated by events.
-                    int handled = mModel->applyEvents(timeEnd, &eventStatus[0],
-                                                      NULL, &variableStepPostEventState[0]);
+                    int handled = mModel->applyEvents(timeEnd, eventStatus.empty() ? nullptr : &eventStatus[0], NULL, variableStepPostEventState.empty() ? nullptr : &variableStepPostEventState[0]);
                     if (handled > 0) {
                         // write original state back to model
                         mModel->setTime(timeEnd - epsilon);
@@ -1241,7 +1241,7 @@ namespace rr {
     double CVODEIntegrator::applyVariableStepPendingEvents() {
         if (variableStepTimeEndEvent) {
             // post event state allready calcuated.
-            mModel->setStateVector(&variableStepPostEventState[0]);
+            mModel->setStateVector(variableStepPostEventState.size() == 0 ? NULL : &variableStepPostEventState[0]);
             // copy state std::vector into cvode memory
             if (mStateVector) {
                 mModel->getStateVector(NV_DATA_S(mStateVector));

--- a/test/c_api_core/CAPICoreTest.cpp
+++ b/test/c_api_core/CAPICoreTest.cpp
@@ -105,7 +105,7 @@ TEST_F(CAPICoreTest, ReloadingModelModelRecompilation) {
     freeRRInstance(aRR);
 }
 
-TEST_F(CAPICoreTest, RoloadingModelNoModelRecompilation) {
+TEST_F(CAPICoreTest, ReloadingModelNoModelRecompilation) {
     RRHandle aRR = createRRInstance();
     EXPECT_TRUE(std::filesystem::exists(testModelFilePath));
 

--- a/test/cxx_api_tests/RoadRunnerAPITests.cpp
+++ b/test/cxx_api_tests/RoadRunnerAPITests.cpp
@@ -311,8 +311,8 @@ TEST_F(RoadRunnerAPITests, oneStep) {
  */
 TEST_F(RoadRunnerAPITests, internalOneStep) {
     RoadRunner rr(TestModelFactory("SimpleFlux")->str());
-    rr.oneStep(0, 10, true);
-    ASSERT_EQ(rr.getModel()->getTime(), 10);
+    rr.internalOneStep(0, 10, true);
+    ASSERT_LT(rr.getModel()->getTime(), 0.003);
 }
 
 /**


### PR DESCRIPTION
Noticed that a test didn't test what it said it did ('internalOneStep'); when I changed so it did, found a separate bug that apparently only triggers if the new test is run.  This turned out to be having a pointer to an empty array, i.e. &array[0].  Fixed this the same way we did elsewhere in the code, and found one other place the same fix needed to be applied.

Also fixed a typo in another test name.