### PR TITLE
Throw specific exception when trying to get the rate of a floating species

### DIFF
--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1145,7 +1145,7 @@ namespace rr {
                 }
                 catch (std::out_of_range) {
                     std::stringstream err;
-                    err << "No rate available for floating speces " << record.p1 << ": if conserved moieties are enabled, this species may be defined by an implied assignment rule instead, and its rate cannot be determined.";
+                    err << "No rate available for floating species " << record.p1 << ": if conserved moieties are enabled, this species may be defined by an implied assignment rule instead, and its rate cannot be determined.";
                     throw std::invalid_argument(err.str());
                 }
 

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1140,7 +1140,15 @@ namespace rr {
 
             case SelectionRecord::FLOATING_AMOUNT_RATE:
                 dResult = 0;
-                impl->model->getFloatingSpeciesAmountRates(1, &record.index, &dResult);
+                try {
+                    impl->model->getFloatingSpeciesAmountRates(1, &record.index, &dResult);
+                }
+                catch (std::out_of_range) {
+                    std::stringstream err;
+                    err << "No rate available for floating speces " << record.p1 << ": if conserved moieties are enabled, this species may be defined by an implied assignment rule instead, and its rate cannot be determined.";
+                    throw std::invalid_argument(err.str());
+                }
+
                 break;
 
             case SelectionRecord::COMPARTMENT:

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -26,18 +26,36 @@ TEST_F(ModelAnalysisTests, GetRateOfConservedSpecies) {
     rr.setConservedMoietyAnalysis(true);
 
     EXPECT_THROW(
-    {
-        try
         {
-            double S1 = rr.getValue("S2'");
-        }
-        catch (const std::invalid_argument& e)
+            try
+            {
+                rr.getValue("S2'");
+            }
+            catch (const std::invalid_argument& e)
+            {
+                // Test that it has the correct message.
+                EXPECT_STREQ(e.what(), "No rate available for floating species S2: if conserved moieties are enabled, this species may be defined by an implied assignment rule instead, and its rate cannot be determined.");
+                throw e;
+            }
+        }, std::invalid_argument);
+
+    std::vector<std::string> selections;
+    selections.push_back("time");
+    selections.push_back("S2'");
+    rr.setSelections(selections);
+    EXPECT_THROW(
         {
-            // Test that it has the correct message.
-            EXPECT_STREQ(e.what(),"hello");
-            throw e;
-        }
-    }, std::invalid_argument);
+            try
+            {
+                rr.simulate();
+            }
+            catch (const std::invalid_argument& e)
+            {
+                // Test that it has the correct message.
+                EXPECT_STREQ(e.what(), "No rate available for floating species S2: if conserved moieties are enabled, this species may be defined by an implied assignment rule instead, and its rate cannot be determined.");
+                throw e;
+            }
+        }, std::invalid_argument);
 }
 
 

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -21,6 +21,26 @@ public:
 };
 
 
+TEST_F(ModelAnalysisTests, GetRateOfConservedSpecies) {
+    RoadRunner rr((modelAnalysisModelsDir / "conserved_cycle.xml").string());
+    rr.setConservedMoietyAnalysis(true);
+
+    EXPECT_THROW(
+    {
+        try
+        {
+            double S1 = rr.getValue("S2'");
+        }
+        catch (const std::invalid_argument& e)
+        {
+            // Test that it has the correct message.
+            EXPECT_STREQ(e.what(),"hello");
+            throw e;
+        }
+    }, std::invalid_argument);
+}
+
+
 TEST_F(ModelAnalysisTests, ResetBoundarySpeciesRate) {
     RoadRunner rr((modelAnalysisModelsDir / "boundary_change_rate.xml").string());
     double S1 = rr.getValue("init(S1)");


### PR DESCRIPTION
The most likely problem (if not the only problem) is that conserved moieties are on, and the species in question is no longer determined by a rate, but by an implied assignment rule, based on the conserved totals.

Addresses issue https://github.com/sys-bio/roadrunner/issues/325