### PR TITLE
issue-833 why doesn't set_integrator work from rrtest suite? 

### DIFF
--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -184,11 +184,14 @@ namespace rr {
          */
         SensitivitySolver *makeSensitivitySolver(const std::string &name);
 
-
-        /* Return a list of the names of all existing integrators. */
+        /**
+         * Return a list of the names of all existing integrators.
+         */
         std::vector<std::string> getExistingIntegratorNames();
 
-        /* Return a list of the names of all existing integrators. */
+        /**
+         * Return a list of the names of all existing integrators.
+         */
         std::vector<std::string> getExistingSteadyStateSolverNames();
 
         /**
@@ -349,7 +352,7 @@ namespace rr {
          * @brief simulate the model using currently set integrator
          * @param times a vector of all the time outputs desired.
          */
-        const ls::DoubleMatrix* simulate(const std::vector<double>& times);
+        const ls::DoubleMatrix *simulate(const std::vector<double> &times);
 
         /**
          * @brief simulate a timeseries with sensitivities from start to step with num
@@ -369,17 +372,18 @@ namespace rr {
          * at the end.
          * @param k (default 0) return the kth other derivative of the sensitivity data.
          */
-        Matrix3D<double, double> timeSeriesSensitivities(double start, double stop, int num,
+        Matrix3D<double, double> timeSeriesSensitivities(
+                double start, double stop, int num,
                 std::vector<std::string> params = std::vector<std::string>(),
                 std::vector<std::string> species = std::vector<std::string>(),
                 int k = 0);
 
         /*
-        *  Saves this roadrunner instance to a file so it can be reloaded later
-        * If opt == 'b' (the default value), this function will output a platform-specific
-        * binary file which can be reloaded later
-        * If opt == 'r', this function will output a human readable file which cannot be reloaded later
-        */
+         *  Saves this roadrunner instance to a file so it can be reloaded later
+         * If opt == 'b' (the default value), this function will output a platform-specific
+         * binary file which can be reloaded later
+         * If opt == 'r', this function will output a human readable file which cannot be reloaded later
+         */
         void saveState(std::string filename, char opt = 'b');
 
         /*
@@ -472,7 +476,6 @@ namespace rr {
          * @deprecated
          */
         void changeInitialConditions(const std::vector<double> &ic);
-
 
         /**
          * get a pointer to the ExecutableModel owned by the RoadRunner object.
@@ -1542,7 +1545,7 @@ namespace rr {
          * @internal
          * @deprecated
          */
-        RR_DEPRECATED(void setBoundarySpeciesAmounts(const std::vector<double>& values));
+        RR_DEPRECATED(void setBoundarySpeciesAmounts(const std::vector<double> &values));
 
         /**
          * @internal

--- a/test/cxx_api_tests/RoadRunnerAPITests.cpp
+++ b/test/cxx_api_tests/RoadRunnerAPITests.cpp
@@ -1336,6 +1336,18 @@ TEST_F(RoadRunnerAPITests, setIntegrator){
     ASSERT_STREQ("gillespie", rr.getIntegrator()->getName().c_str());
 }
 
+TEST_F(RoadRunnerAPITests, setIntegratorToRk4){
+    RoadRunner rr(SimpleFlux().str());
+    rr.setIntegrator("rk4");
+    ASSERT_STREQ("rk4", rr.getIntegrator()->getName().c_str());
+}
+
+TEST_F(RoadRunnerAPITests, setIntegratorToRk45){
+    RoadRunner rr(SimpleFlux().str());
+    rr.setIntegrator("rk45");
+    ASSERT_STREQ("rk45", rr.getIntegrator()->getName().c_str());
+}
+
 TEST_F(RoadRunnerAPITests, setSteadyStateSolver){
     RoadRunner rr(SimpleFlux().str());
     rr.setSteadyStateSolver("nleq1");


### PR DESCRIPTION
Attempt to resolve #833 but haven't yet got to the bottom of the problem. 

Add a new test in CAPICoreTest called CheckRK4WorksFromC to try and figure out why we can't seem to set RK4 or RK45 integrators from the CAPI rrtest suite. The problem is that registrars vector of the IntegratorFactory is empty, where it should be full of strings like cvode, or rk45. This is not reproducible outside this test suite since CheckRK45WorksFromC passes meaning its probably a bug in the test suite resulting from use of shared state between tests