### PR TITLE
Throw when encountering a delay differential equation.

### DIFF
--- a/source/llvm/ASTNodeCodeGen.cpp
+++ b/source/llvm/ASTNodeCodeGen.cpp
@@ -611,14 +611,16 @@ llvm::Value* ASTNodeCodeGen::delayExprCodeGen(const libsbml::ASTNode* ast)
     }
 
     char* formula = SBML_formulaToL3String(ast);
-    std::string str = formula;
+    std::stringstream err;
+    err << "Unable to support delay differential equations.  The function '" << formula << "' is not supported.";
     free(formula);
+    throw_llvm_exception(err.str())
 
-    rrLog(Logger::LOG_WARNING)
-      << "Unable to handle SBML csymbol 'delay'. Delay ignored in expression '"
-      << str << "'.";
+    //rrLog(Logger::LOG_WARNING)
+    //  << "Unable to handle SBML csymbol 'delay'. Delay ignored in expression '"
+    //  << str << "'.";
 
-    return codeGen(ast->getChild(0));
+    //return codeGen(ast->getChild(0));
 }
 
 llvm::Value* ASTNodeCodeGen::nameExprCodeGen(const libsbml::ASTNode* ast)

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1345,7 +1345,12 @@ namespace rr {
             // catch specifically for UninitializedValueException, otherwise for some
             // reason the message is erased, and an 'unknown error' is displayed to the user.
             throw e;
-        } catch (const std::exception &e) {
+        } catch (const rrllvm::LLVMException& e) {
+            // catch specifically for LLVMException, otherwise the exception type is removed, 
+            // and an 'unknown error' is displayed to the user.
+            throw e;
+        }
+        catch (const std::exception &e) {
             std::string errors = validateSBML(mCurrentSBML);
 
             if (!errors.empty()) {

--- a/test/semantic_STS/sbml_test_suite.cpp
+++ b/test/semantic_STS/sbml_test_suite.cpp
@@ -4,6 +4,7 @@
 #include "rrException.h"
 #include "rrUtils.h"
 #include "rrTestSuiteModelSimulation.h"
+#include "llvm/LLVMException.h"
 #include <filesystem>
 #include "RoadRunnerTest.h"
 
@@ -144,6 +145,11 @@ public:
 
             //If we've gotten this far, rejoice!  roadrunner didn't crash, which is good enough.
             //cerr << "\tPASS" << endl;
+            return true;
+        }
+        catch (rrllvm::LLVMException& ex)
+        {
+            //Sometimes, rr itself knows when it can't load a model.  This is also fine.
             return true;
         }
         catch (Exception& ex)


### PR DESCRIPTION
We never have actually supported this, and would instead just simulate anyway and return wrong results.  As requested by Matthias, this changes so we throw instead.