### PR TITLE
Undeprecate everything.

### DIFF
--- a/source/rrFileName.h
+++ b/source/rrFileName.h
@@ -11,7 +11,7 @@ namespace rr
 
 /**
  * @internal
- * @deprecated
+ * Used in FileName.
  */
 class RR_DECLSPEC FileName
 {

--- a/source/rrOSSpecifics.h
+++ b/source/rrOSSpecifics.h
@@ -41,16 +41,6 @@
 #endif // _MSC_VER
 
 
-#if defined (__GNUC__) || defined(__clang__)
-    #define RR_DEPRECATED(func) func __attribute__ ((deprecated))
-#elif defined(_MSC_VER)
-    #define RR_DEPRECATED(func) __declspec(deprecated) func
-#else
-#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
-    #define RR_DEPRECATED(func) func
-#endif
-
-
 #if defined(_MSC_VER)
     #define rrCallConv __cdecl
 #elif defined(__BORLANDC__)

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -4,10 +4,6 @@
 
 #include "rrOSSpecifics.h"
 
-// TODO will clean these up in the future
-#undef RR_DEPRECATED
-#define RR_DEPRECATED(func) func
-
 #include <iostream>
 #include "rrRoadRunner.h"
 #include "rrException.h"
@@ -168,8 +164,6 @@ namespace rr {
 /**
  * The type of sbml element that the RoadRunner::setParameterValue
  * and RoadRunner::getParameterValue method operate on.
- *
- * @deprecated use the ExecutableModel methods directly.
  */
     enum ParameterType {
         ptGlobalParameter = 0,

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -478,8 +478,6 @@ namespace rr {
          * set the floating species initial concentrations.
          *
          * equivalent to ExecutableModel::reset, then ExecutableModel::setFloatingSpeciesConcentrations
-         *
-         * @deprecated
          */
         void changeInitialConditions(const std::vector<double> &ic);
 
@@ -1407,45 +1405,40 @@ namespace rr {
         /*********              Used by rrplugins             *************************/
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
         void setBoundarySpeciesByIndex(const int &index, const double &value);
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
         int getNumberOfIndependentSpecies();
 
         /**
-         * @internal
-         * @deprecated use ExecutableModel::getGlobalParameterIds
+         * Alias for this function on the child model object.
+         * use ExecutableModel::getGlobalParameterIds
          */
         std::vector<std::string> getGlobalParameterIds();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
         std::vector<std::string> getBoundarySpeciesIds();
 
 
         /**
-        * @author KC
         * @brief Gets the ids for all boundary species concentrations
         */
         std::vector<std::string> getBoundarySpeciesConcentrationIds();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
         double getBoundarySpeciesByIndex(const int &index);
 
         /**
-         * @internal
-         * @deprecated use ExecutableModel::getGlobalParameterValues
+         * Alias for this function on the child model object.
+         * use ExecutableModel::getGlobalParameterValues
          */
         double getGlobalParameterByIndex(const int &index);
 
@@ -1477,206 +1470,166 @@ namespace rr {
 #ifndef SWIG // deprecated methods not SWIG'ed
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(int getNumberOfReactions());
+        int getNumberOfReactions();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(double getReactionRate(const int &index));
+        double getReactionRate(const int &index);
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(double getRateOfChange(const int &index));
+        double getRateOfChange(const int &index);
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(std::vector<std::string> getRateOfChangeIds());
+        std::vector<std::string> getRateOfChangeIds();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
+        int getNumberOfCompartments();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(int getNumberOfCompartments());
+        void setCompartmentByIndex(const int &index, const double &value);
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(void setCompartmentByIndex(const int &index, const double &value));
+        double getCompartmentByIndex(const int &index);
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(double getCompartmentByIndex(const int &index));
+        std::vector<std::string> getCompartmentIds();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(std::vector<std::string> getCompartmentIds());
+        int getNumberOfBoundarySpecies();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(int getNumberOfBoundarySpecies());
+        void setBoundarySpeciesConcentrations(const std::vector<double> &values);
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(std::vector<double> getBoundarySpeciesConcentrations());
+        void setBoundarySpeciesAmounts(const std::vector<double> &values);
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(void setBoundarySpeciesConcentrations(const std::vector<double> &values));
+        int getNumberOfFloatingSpecies();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(void setBoundarySpeciesAmounts(const std::vector<double> &values));
+        double getFloatingSpeciesByIndex(int index);
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(int getNumberOfFloatingSpecies());
+        void setFloatingSpeciesByIndex(int index, double value);
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(double getFloatingSpeciesByIndex(int index));
+        std::vector<double> getFloatingSpeciesConcentrationsV();
 
         /**
-         * @internal
-         * @deprecated
-         */
-        RR_DEPRECATED(void setFloatingSpeciesByIndex(int index, double value));
-
-        /**
-         * @internal
-         * @deprecated
-         */
-        RR_DEPRECATED(std::vector<double> getFloatingSpeciesConcentrationsV());
-
-        /**
-        * @internal
-        * @deprecated
+        * Alias for this function on the child model object.
         */
-        RR_DEPRECATED(std::vector<double> getFloatingSpeciesAmountsV());
+        std::vector<double> getFloatingSpeciesAmountsV();
 
         /**
-        * @internal
-        * @deprecated
+        * Alias for this function on the child model object.
         */
-        RR_DEPRECATED(std::vector<double> getBoundarySpeciesConcentrationsV());
+        std::vector<double> getBoundarySpeciesConcentrationsV();
 
         /**
-        * @internal
-        * @deprecated
+        * Alias for this function on the child model object.
         */
-        RR_DEPRECATED(std::vector<double> getBoundarySpeciesAmountsV());
+        std::vector<double> getBoundarySpeciesAmountsV();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(std::vector<double> getFloatingSpeciesInitialConcentrations());
+        std::vector<double> getFloatingSpeciesInitialConcentrations();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(void setFloatingSpeciesConcentrations(const std::vector<double> &values));
+        void setFloatingSpeciesConcentrations(const std::vector<double> &values);
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(void setFloatingSpeciesInitialConcentrationByIndex(const int &index,
-                              const double &value));
+        void setFloatingSpeciesInitialConcentrationByIndex(const int &index,
+                              const double &value);
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(void setFloatingSpeciesInitialConcentrations(const std::vector<double> &values));
+        void setFloatingSpeciesInitialConcentrations(const std::vector<double> &values);
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(std::vector<std::string> getFloatingSpeciesIds());
+        std::vector<std::string> getFloatingSpeciesIds();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(std::vector<std::string> getFloatingSpeciesInitialConditionIds());
+        std::vector<std::string> getFloatingSpeciesInitialConditionIds();
 
         /**
-         * @internal
-         * @deprecated use ExecutableModel::getNumGlobalParameters
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(size_t getNumberOfGlobalParameters());
+        size_t getNumberOfGlobalParameters();
 
         /**
-         * @internal
-         * @deprecated use ExecutableModel::setGlobalParameterValues
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(void setGlobalParameterByIndex(const int index, const double value));
+        void setGlobalParameterByIndex(const int index, const double value);
 
 
         /**
-         * @internal
-         * @deprecated use ExecutableModel::getGlobalParameterValues
+         * Alias for this function on the child model object.
+         * use ExecutableModel::getGlobalParameterValues
          */
-        RR_DEPRECATED(std::vector<double> getGlobalParameterValues());
+        std::vector<double> getGlobalParameterValues();
 
         /**
          * @internal
-         * @deprecated
          */
         void evalModel();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          */
-        RR_DEPRECATED(int getNumberOfDependentSpecies());
+        int getNumberOfDependentSpecies();
 
 
         /**
-         * @internal
-         * @deprecated, use ExecutableModel::getReactionRates
+         * Alias for this function on the child model object.
+         * use ExecutableModel::getReactionRates
          */
-        RR_DEPRECATED(std::vector<double> getReactionRates());
+        std::vector<double> getReactionRates();
 
         /**
-         * @internal
-         * @deprecated
+         * Alias for this function on the child model object.
          * returns a list of reaction ids obtained from
          * ExecutableModel::getReactionId
          */
-        RR_DEPRECATED(std::vector<std::string> getReactionIds());
+        std::vector<std::string> getReactionIds();
 
         /**
          * @internal

--- a/source/rrRoadRunnerData.h
+++ b/source/rrRoadRunnerData.h
@@ -27,11 +27,6 @@ using std::stringstream;
 
 class RoadRunner;
 
-/**
- * @deprecated
- *
- * DO NOT USE THIS, IT IS DEPRECATED AND WILL BE REMOVED.
- */
 class RR_DECLSPEC RoadRunnerData
 {
 

--- a/test/c_api_core/rrSBMLTestSuiteSimulation_CAPI.cpp
+++ b/test/c_api_core/rrSBMLTestSuiteSimulation_CAPI.cpp
@@ -2,7 +2,6 @@
 
 #include "rrException.h"
 #include "rrUtils.h"
-#include "rrRoadRunnerData.h"
 #include "rrSBMLTestSuiteSimulation_CAPI.h"
 #include "rrRoadRunner.h"
 #include "rrLogger.h"

--- a/wrappers/C/rrArrayList.h
+++ b/wrappers/C/rrArrayList.h
@@ -17,8 +17,7 @@ using std::string;
 
 /**
  * @internal
- * @deprecated
- * a proprietaty collection class that is massivly deprecated.
+ * a proprietaty collection class that is theoretically deprecated, but used extensively in rrc_api.cpp
  */
 class C_DECL_SPEC ArrayList
 {

--- a/wrappers/C/rrArrayListItem.h
+++ b/wrappers/C/rrArrayListItem.h
@@ -14,8 +14,7 @@ namespace rrc
 
 /**
  * @internal
- * @deprecated
- * a proprietaty collection class that is massivly deprecated.
+ * a proprietaty collection class that is theoretically deprecated, but used extensively in rrc_api.cpp
  */
 template <class T>
 class ArrayListItem : public ArrayListItemBase

--- a/wrappers/C/rrArrayListItemBase.h
+++ b/wrappers/C/rrArrayListItemBase.h
@@ -8,8 +8,7 @@ namespace rrc
 
 /**
  * @internal
- * @deprecated
- * a proprietaty collection class that is massivly deprecated.
+ * a proprietaty collection class that is theoretically deprecated, but used extensively in rrc_api.cpp
  */
 class C_DECL_SPEC ArrayListItemBase
 {

--- a/wrappers/C/rrcStringList.h
+++ b/wrappers/C/rrcStringList.h
@@ -15,7 +15,6 @@ using std::ostream;
 
 /**
  * @internal
- * @deprecated
  */
 class C_DECL_SPEC StringList
 {

--- a/wrappers/C/rrc_api.cpp
+++ b/wrappers/C/rrc_api.cpp
@@ -46,6 +46,7 @@
 #include <sstream>
 #include <fstream>
 #include "rrRoadRunner.h"
+#include "rrRoadRunnerData.h"
 #include "rrRoadRunnerOptions.h"
 #include "rrExecutableModel.h"
 #include "rrCompiler.h"

--- a/wrappers/C/rrc_cpp_support.cpp
+++ b/wrappers/C/rrc_cpp_support.cpp
@@ -9,6 +9,7 @@
 #include "rrc_utilities.h"
 #include "rrStringUtils.h"
 #include "rrRoadRunner.h"
+#include "rrRoadRunnerData.h"
 
 namespace rrc
 {

--- a/wrappers/C/rrc_cpp_support.h
+++ b/wrappers/C/rrc_cpp_support.h
@@ -54,7 +54,6 @@
 #pragma warning(disable: 26451)
 #endif
 
-#include "rrRoadRunnerData.h"
 #include "rrcStringList.h"
 #include "rrArrayList.h"
 #include "rrc_types.h"


### PR DESCRIPTION
Lots of things have been marked 'deprecated' in roadrunner for the last 7 years, but are still used.  In some cases, this just turned out to be a mistake, and the functions are actually useful.  In other cases, nobody ever went through and removed their use internally, so at this point, there's no good reason to deprecate them, either.  This just marks everything as non-deprecated.