### PR TITLE
Fix for https://github.com/sys-bio/roadrunner/issues/515

### DIFF
--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -1063,7 +1063,7 @@ void LLVMExecutableModel::getIds(int types, std::list<std::string> &ids)
                 &rr::ExecutableModel::getGlobalParameterId, ids);
     }
 
-    // only get init values indepndent values, dep, with assignment rules
+    // only get init values independent values, dep, with assignment rules
     // always have the same value.
     //if (checkExact(SelectionRecord::_GLOBAL_PARAMETER | SelectionRecord::INITIAL, types)
     //        && (SelectionRecord::INDEPENDENT & types)) {
@@ -1616,6 +1616,24 @@ void LLVMExecutableModel::getEventIds(std::list<std::string>& out)
 {
     std::vector<std::string> eventIds = symbols->getEventIds();
     std::copy(eventIds.begin(), eventIds.end(), std::back_inserter(out));
+}
+
+void LLVMExecutableModel::getAssignmentRuleIds(std::list<std::string>& out)
+{
+    std::vector<std::string> arIds = symbols->getAssignmentRuleIds();
+    std::copy(arIds.begin(), arIds.end(), std::back_inserter(out));
+}
+
+void LLVMExecutableModel::getRateRuleIds(std::list<std::string>& out)
+{
+    std::vector<std::string> rrIds = symbols->getRateRuleIds();
+    std::copy(rrIds.begin(), rrIds.end(), std::back_inserter(out));
+}
+
+void LLVMExecutableModel::getInitialAssignmentIds(std::list<std::string>& out)
+{
+    std::vector<std::string> rrIds = symbols->getInitialAssignmentIds();
+    std::copy(rrIds.begin(), rrIds.end(), std::back_inserter(out));
 }
 
 void LLVMExecutableModel::setEventListener(size_t index,

--- a/source/llvm/LLVMExecutableModel.h
+++ b/source/llvm/LLVMExecutableModel.h
@@ -564,6 +564,9 @@ public:
     virtual int getEventIndex(const std::string& eid);
     virtual std::string getEventId(size_t index);
     virtual void getEventIds(std::list<std::string>& out);
+    virtual void getAssignmentRuleIds(std::list<std::string>& out);
+    virtual void getRateRuleIds(std::list<std::string>& out);
+    virtual void getInitialAssignmentIds(std::list<std::string>& out);
     virtual void setEventListener(size_t index, rr::EventListenerPtr eventHandler);
     virtual rr::EventListenerPtr getEventListener(size_t index);
 

--- a/source/llvm/LLVMModelDataSymbols.cpp
+++ b/source/llvm/LLVMModelDataSymbols.cpp
@@ -1746,6 +1746,31 @@ std::vector<std::string> LLVMModelDataSymbols::getEventIds() const
     return getIds(eventIds);
 }
 
+std::vector<std::string> LLVMModelDataSymbols::getAssignmentRuleIds() const
+{
+    std::vector<string> ret;
+    for (std::set<string>::iterator ar = assignmentRules.begin(); ar != assignmentRules.end(); ar++)
+    {
+        ret.push_back(*ar);
+    }
+    return ret;
+}
+
+std::vector<std::string> LLVMModelDataSymbols::getRateRuleIds() const
+{
+    return getIds(rateRules);
+}
+
+std::vector<std::string> LLVMModelDataSymbols::getInitialAssignmentIds() const
+{
+    std::vector<string> ret;
+    for (std::set<string>::iterator ia = initAssignmentRules.begin(); ia != initAssignmentRules.end(); ia++)
+    {
+        ret.push_back(*ia);
+    }
+    return ret;
+}
+
 std::string LLVMModelDataSymbols::getEventId(size_t indx) const
 {
     for (StringUIntMap::const_iterator i = eventIds.begin();

--- a/source/llvm/LLVMModelDataSymbols.h
+++ b/source/llvm/LLVMModelDataSymbols.h
@@ -573,6 +573,12 @@ public:
 
     std::vector<std::string> getEventIds() const;
 
+    std::vector<std::string> getAssignmentRuleIds() const;
+
+    std::vector<std::string> getRateRuleIds() const;
+
+    std::vector<std::string> getInitialAssignmentIds() const;
+
     std::string getEventId(size_t indx) const;
 
     int getEventIndex(const std::string& id) const;

--- a/source/rrExecutableModel.h
+++ b/source/rrExecutableModel.h
@@ -722,6 +722,12 @@ namespace rr {
 
         virtual void getEventIds(std::list<std::string>&) = 0;
 
+        virtual void getAssignmentRuleIds(std::list<std::string>&) = 0;
+
+        virtual void getRateRuleIds(std::list<std::string>&) = 0;
+
+        virtual void getInitialAssignmentIds(std::list<std::string>&) = 0;
+
         virtual void setEventListener(size_t index, EventListenerPtr eventHandler) = 0;
 
         virtual EventListenerPtr getEventListener(size_t index) = 0;

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -4658,6 +4658,36 @@ namespace rr {
         return std::vector<std::string>(list.begin(), list.end());
     }
 
+    std::vector<std::string> RoadRunner::getAssignmentRuleIds()
+    {
+        std::list<std::string> list;
+        if (impl->model) {
+            impl->model->getAssignmentRuleIds(list);
+        }
+
+        return std::vector<std::string>(list.begin(), list.end());
+    }
+
+    std::vector<std::string> RoadRunner::getRateRuleIds()
+    {
+        std::list<std::string> list;
+        if (impl->model) {
+            impl->model->getRateRuleIds(list);
+        }
+
+        return std::vector<std::string>(list.begin(), list.end());
+    }
+
+    std::vector<std::string> RoadRunner::getInitialAssignmentIds()
+    {
+        std::list<std::string> list;
+        if (impl->model) {
+            impl->model->getInitialAssignmentIds(list);
+        }
+
+        return std::vector<std::string>(list.begin(), list.end());
+    }
+
     std::vector<std::string> RoadRunner::getBoundarySpeciesConcentrationIds() {
         std::list<std::string> list;
 

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -1425,6 +1425,20 @@ namespace rr {
          */
         std::vector<std::string> getBoundarySpeciesIds();
 
+        /**
+         * Get the Ids of the elements assigned by assignment rules.
+         */
+        std::vector<std::string> getAssignmentRuleIds();
+
+        /**
+         * Get the Ids of the elements assigned by rate rules.
+         */
+        std::vector<std::string> getRateRuleIds();
+
+        /**
+         * Get the Ids of the elements with an initial assignment.
+         */
+        std::vector<std::string> getInitialAssignmentIds();
 
         /**
         * @brief Gets the ids for all boundary species concentrations

--- a/source/testing/CXXBrusselatorExecutableModel.cpp
+++ b/source/testing/CXXBrusselatorExecutableModel.cpp
@@ -360,6 +360,18 @@ namespace rrtesting {
     {
     }
 
+    void CXXBrusselatorExecutableModel::getAssignmentRuleIds(std::list<std::string>& out)
+    {
+    }
+
+    void CXXBrusselatorExecutableModel::getRateRuleIds(std::list<std::string>& out)
+    {
+    }
+
+    void CXXBrusselatorExecutableModel::getInitialAssignmentIds(std::list<std::string>& out)
+    {
+    }
+
     void CXXBrusselatorExecutableModel::setEventListener(size_t index,
                                                          rr::EventListenerPtr eventHandler) {
     }

--- a/source/testing/CXXBrusselatorExecutableModel.h
+++ b/source/testing/CXXBrusselatorExecutableModel.h
@@ -569,6 +569,9 @@ public:
     virtual int getEventIndex(const std::string& eid);
     virtual std::string getEventId(size_t index);
     virtual void getEventIds(std::list<std::string>& out) override;
+    virtual void getAssignmentRuleIds(std::list<std::string>& out);
+    virtual void getRateRuleIds(std::list<std::string>& out);
+    virtual void getInitialAssignmentIds(std::list<std::string>& out);
     virtual void setEventListener(size_t index, rr::EventListenerPtr eventHandler);
     virtual rr::EventListenerPtr getEventListener(size_t index);
 

--- a/source/testing/CXXEnzymeExecutableModel.cpp
+++ b/source/testing/CXXEnzymeExecutableModel.cpp
@@ -628,6 +628,18 @@ void CXXEnzymeExecutableModel::getEventIds(std::list<std::string>&)
 {
 }
 
+void CXXEnzymeExecutableModel::getAssignmentRuleIds(std::list<std::string>& out)
+{
+}
+
+void CXXEnzymeExecutableModel::getRateRuleIds(std::list<std::string>& out)
+{
+}
+
+void CXXEnzymeExecutableModel::getInitialAssignmentIds(std::list<std::string>& out)
+{
+}
+
 void CXXEnzymeExecutableModel::setEventListener(size_t index,
         rr::EventListenerPtr eventHandler)
 {

--- a/source/testing/CXXEnzymeExecutableModel.h
+++ b/source/testing/CXXEnzymeExecutableModel.h
@@ -588,6 +588,9 @@ public:
     virtual int getEventIndex(const std::string& eid);
     virtual std::string getEventId(size_t index);
     virtual void getEventIds(std::list<std::string>& out);
+    virtual void getAssignmentRuleIds(std::list<std::string>& out);
+    virtual void getRateRuleIds(std::list<std::string>& out);
+    virtual void getInitialAssignmentIds(std::list<std::string>& out);
     virtual void setEventListener(size_t index, rr::EventListenerPtr eventHandler);
     virtual rr::EventListenerPtr getEventListener(size_t index);
 

--- a/source/testing/CXXExecutableModel.cpp
+++ b/source/testing/CXXExecutableModel.cpp
@@ -440,6 +440,18 @@ std::string CXXExecutableModel::getEventId(int index)
 void CXXExecutableModel::getEventIds(std::list<std::string>&) {
 }
 
+void CXXExecutableModel::getAssignmentRuleIds(std::list<std::string>& out)
+{
+}
+
+void CXXExecutableModel::getRateRuleIds(std::list<std::string>& out)
+{
+}
+
+void CXXExecutableModel::getInitialAssignmentIds(std::list<std::string>& out)
+{
+}
+
 void CXXExecutableModel::setEventListener(int index,
         rr::EventListenerPtr eventHandler)
 {

--- a/source/testing/CXXExecutableModel.h
+++ b/source/testing/CXXExecutableModel.h
@@ -562,6 +562,9 @@ public:
     virtual int getEventIndex(const std::string& eid);
     virtual std::string getEventId(int index);
     virtual void getEventIds(std::list<std::string>& out);
+    virtual void getAssignmentRuleIds(std::list<std::string>& out);
+    virtual void getRateRuleIds(std::list<std::string>& out);
+    virtual void getInitialAssignmentIds(std::list<std::string>& out);
     virtual void setEventListener(int index, rr::EventListenerPtr eventHandler);
     virtual rr::EventListenerPtr getEventListener(int index);
 

--- a/source/testing/CXXPiecewiseExecutableModel.cpp
+++ b/source/testing/CXXPiecewiseExecutableModel.cpp
@@ -440,6 +440,18 @@ std::string CXXPiecewiseExecutableModel::getEventId(int index)
 void CXXPiecewiseExecutableModel::getEventIds(std::list<std::string>&) {
 }
 
+void CXXPiecewiseExecutableModel::getAssignmentRuleIds(std::list<std::string>& out)
+{
+}
+
+void CXXPiecewiseExecutableModel::getRateRuleIds(std::list<std::string>& out)
+{
+}
+
+void CXXPiecewiseExecutableModel::getInitialAssignmentIds(std::list<std::string>& out)
+{
+}
+
 void CXXPiecewiseExecutableModel::setEventListener(int index,
         rr::EventListenerPtr eventHandler)
 {

--- a/source/testing/CXXPiecewiseExecutableModel.h
+++ b/source/testing/CXXPiecewiseExecutableModel.h
@@ -570,6 +570,9 @@ public:
     virtual int getEventIndex(const std::string& eid);
     virtual std::string getEventId(int index);
     virtual void getEventIds(std::list<std::string> &out);
+    virtual void getAssignmentRuleIds(std::list<std::string>& out);
+    virtual void getRateRuleIds(std::list<std::string>& out);
+    virtual void getInitialAssignmentIds(std::list<std::string>& out);
     virtual void setEventListener(int index, rr::EventListenerPtr eventHandler);
     virtual rr::EventListenerPtr getEventListener(int index);
 

--- a/test/cxx_api_tests/RoadRunnerAPITests.cpp
+++ b/test/cxx_api_tests/RoadRunnerAPITests.cpp
@@ -978,51 +978,55 @@ TEST_F(RoadRunnerAPITests, removeCompartment){
 
 }
 
-/**
- * How can we verify that we have a new assignment rule?
- */
-TEST_F(RoadRunnerAPITests, DISABLED_addAssignmentRule){
+TEST_F(RoadRunnerAPITests, addAssignmentRule){
     RoadRunner rr(SimpleFlux().str());
+    rr.addParameter("STotal", 0);
     rr.addAssignmentRule("STotal", "S1+S2", true);
+    vector<string> ruleids = rr.getAssignmentRuleIds();
+    ASSERT_TRUE(ruleids.size() == 1);
+    EXPECT_STREQ(ruleids[0].c_str(), "STotal");
 }
 
-/**
- * Works, but how to verify that we have a new rate rule?
- */
-TEST_F(RoadRunnerAPITests, DISABLED_addRateRule){
+TEST_F(RoadRunnerAPITests, addRateRule){
     RoadRunner rr(SimpleFlux().str());
     rr.setBoundary("S2", true);
     rr.addRateRule("S2", "(kf/kb)*S1", true);
-    std::cout << rr.getSBML() << std::endl;
-    std::cout << *rr.simulate(0, 100, 101) << std::endl;
-
+    vector<string> ruleids = rr.getRateRuleIds();
+    ASSERT_TRUE(ruleids.size() == 1);
+    EXPECT_STREQ(ruleids[0].c_str(), "S2");
 }
 
-/**
- * How to test?
- */
-TEST_F(RoadRunnerAPITests, DISABLED_removeRules){
+TEST_F(RoadRunnerAPITests, removeRules){
     RoadRunner rr(SimpleFlux().str());
     rr.setBoundary("S2", true);
     rr.addRateRule("S2", "(kf/kb)*S1", true);
+    vector<string> ruleids = rr.getRateRuleIds();
+    ASSERT_TRUE(ruleids.size() == 1);
+    EXPECT_STREQ(ruleids[0].c_str(), "S2");
+
     rr.removeRules("S2", false, true);
+    ruleids = rr.getRateRuleIds();
+    ASSERT_TRUE(ruleids.size() == 0);
 }
 
-/**
- * Works but cannot currently getInitialAssignments with
- * current API, so can't test.
- */
 TEST_F(RoadRunnerAPITests, addInitialAssignment){
     RoadRunner rr(SimpleFlux().str());
     rr.addInitialAssignment("S1", "0.5*S2", true);
+    vector<string> ruleids = rr.getInitialAssignmentIds();
+    ASSERT_TRUE(ruleids.size() == 1);
+    EXPECT_STREQ(ruleids[0].c_str(), "S1");
 }
 
-/**
- * Again, how to test?
- */
-TEST_F(RoadRunnerAPITests, DISABLED_removeInitialAssignment){
+TEST_F(RoadRunnerAPITests, removeInitialAssignment){
     RoadRunner rr(SimpleFlux().str());
     rr.addInitialAssignment("S1", "0.5*S2", true);
+    vector<string> ruleids = rr.getInitialAssignmentIds();
+    ASSERT_TRUE(ruleids.size() == 1);
+    EXPECT_STREQ(ruleids[0].c_str(), "S2");
+
+    rr.removeInitialAssignment("S2", true);
+    ruleids = rr.getInitialAssignmentIds();
+    ASSERT_TRUE(ruleids.size() == 0);
 }
 
 /**

--- a/test/cxx_api_tests/RoadRunnerAPITests.cpp
+++ b/test/cxx_api_tests/RoadRunnerAPITests.cpp
@@ -1022,9 +1022,9 @@ TEST_F(RoadRunnerAPITests, removeInitialAssignment){
     rr.addInitialAssignment("S1", "0.5*S2", true);
     vector<string> ruleids = rr.getInitialAssignmentIds();
     ASSERT_TRUE(ruleids.size() == 1);
-    EXPECT_STREQ(ruleids[0].c_str(), "S2");
+    EXPECT_STREQ(ruleids[0].c_str(), "S1");
 
-    rr.removeInitialAssignment("S2", true);
+    rr.removeInitialAssignment("S1", true);
     ruleids = rr.getInitialAssignmentIds();
     ASSERT_TRUE(ruleids.size() == 0);
 }

--- a/test/mockups/MockExecutableModel.h
+++ b/test/mockups/MockExecutableModel.h
@@ -96,6 +96,9 @@ public:
     MOCK_METHOD(int, getEventIndex, (const std::string &eid), (override));
     MOCK_METHOD(std::string, getEventId, (size_t index), (override));
     MOCK_METHOD(void, getEventIds, (std::list<std::string> & ), (override));
+    MOCK_METHOD(void, getAssignmentRuleIds, (std::list<std::string>&), (override));
+    MOCK_METHOD(void, getRateRuleIds, (std::list<std::string>&), (override));
+    MOCK_METHOD(void, getInitialAssignmentIds, (std::list<std::string>&), (override));
     MOCK_METHOD(void, setEventListener, (size_t index, EventListenerPtr eventHandler), (override));
     MOCK_METHOD(EventListenerPtr, getEventListener, (size_t index), (override));
     MOCK_METHOD(double, getFloatingSpeciesAmountRate, (size_t index,const double *reactionRates), (override));


### PR DESCRIPTION
Implements 'getAssignmentRuleIds', 'getRateRuleIds', and 'getInitialAssignmentIds'.  It then uses them in some previously-disabled tests, which can now be actually tested.