### PR TITLE
Enable negative start times.

### DIFF
--- a/source/CVODEIntegrator.h
+++ b/source/CVODEIntegrator.h
@@ -267,7 +267,7 @@ namespace rr {
         SUNLinearSolver linSolver = nullptr;
 
         IntegratorListenerPtr listener;
-        double lastEventTime;
+        double mLastEventTime;
         bool variableStepPendingEvent;
         bool variableStepTimeEndEvent;
         std::vector<double> variableStepPostEventState;

--- a/source/GillespieIntegrator.cpp
+++ b/source/GillespieIntegrator.cpp
@@ -371,7 +371,7 @@ namespace rr
     {
         std::vector<unsigned char> initialEventStatus(mModel->getEventTriggers(0, nullptr, nullptr), false);
         mModel->getEventTriggers(initialEventStatus.size(), nullptr, initialEventStatus.empty() ? nullptr : &initialEventStatus[0]);
-        applyEvents(0, initialEventStatus);
+        applyEvents(mIntegrationStartTime, initialEventStatus);
     }
 
     void GillespieIntegrator::applyEvents(double timeEnd, std::vector<unsigned char> &prevEventStatus)
@@ -385,14 +385,12 @@ namespace rr
             return;
         }
 
-        if (t0 <= 0.0) {
-            if (stateVector)
-            {
-                mModel->getStateVector(stateVector);
-            }
-
-            testRootsAtInitialTime();
+        if (stateVector)
+        {
+            mModel->getStateVector(stateVector);
         }
+
+        testRootsAtInitialTime();
 
         mModel->setTime(t0);
 

--- a/source/Integrator.cpp
+++ b/source/Integrator.cpp
@@ -32,7 +32,10 @@ namespace rr
 		INTEGRATOR
 	  ------------------------------------------------------------------------------------------*/
 	Integrator::Integrator(ExecutableModel *model)
-	    : Solver(model){}
+        : Solver(model)
+        , mIntegrationStartTime(0.0)
+    {
+    }
 
     void Integrator::syncWithModel(ExecutableModel* m) {}
 
@@ -74,5 +77,11 @@ namespace rr
 		std::vector<double> v;
 		return v;
 	}
+
+    void Integrator::setIntegrationStartTime(double time)
+    {
+        mIntegrationStartTime = time;
+    }
+
 
 }

--- a/source/Integrator.cpp
+++ b/source/Integrator.cpp
@@ -37,6 +37,12 @@ namespace rr
     {
     }
 
+    Integrator::Integrator()
+        : Solver()
+        , mIntegrationStartTime(0.0)
+    {
+    }
+
     void Integrator::syncWithModel(ExecutableModel* m) {}
 
     void Integrator::loadConfigSettings() {}

--- a/source/Integrator.h
+++ b/source/Integrator.h
@@ -78,6 +78,8 @@ namespace rr {
 
         explicit Integrator(ExecutableModel* model);
 
+        Integrator();
+
         virtual ~Integrator() {};
 
         virtual IntegrationMethod getIntegrationMethod() const = 0;

--- a/source/Integrator.h
+++ b/source/Integrator.h
@@ -140,6 +140,12 @@ namespace rr {
         */
         virtual std::string toRepr() const;
         /* !-- END OF CARRYOVER METHODS */
+
+        void setIntegrationStartTime(double time);
+
+    protected:
+        double mIntegrationStartTime;
+
     };
 
 

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -172,6 +172,7 @@ int LLVMExecutableModel::setValues(bool (*funcPtr)(LLVMModelData*, int, double),
 }
 
 LLVMExecutableModel::LLVMExecutableModel() :
+    ExecutableModel(),
     symbols(0),
     modelData(0),
     conversionFactor(1.0),
@@ -213,11 +214,11 @@ LLVMExecutableModel::LLVMExecutableModel() :
     flags(defaultFlags())
 {
     std::srand((unsigned)std::time(0));
-    mIntegrationStartTime = 0.0;
 }
 
 LLVMExecutableModel::LLVMExecutableModel(
     const std::shared_ptr<ModelResources>& rc, LLVMModelData* modelData) :
+    ExecutableModel(),
     resources(rc),
     symbols(rc->symbols),
     modelData(modelData),
@@ -261,8 +262,9 @@ LLVMExecutableModel::LLVMExecutableModel(
     flags(defaultFlags())
 {
 
-    modelData->time = -std::numeric_limits<double>::infinity();; // time is initially before simulation starts
-    mIntegrationStartTime = 0.0;
+    //The key here is that 'time' has to be less than 'mIntegrationStartTime' for events to work.  Not sure whether it actually has to be -inf, but it can't hurt?  See T0EventFiring tests, particularly 1120 in the SBML test suite (test_semantic_STS).  The actual integration start time is set in 'simulate'. --LS
+    modelData->time = -std::numeric_limits<double>::infinity(); // time is initially before simulation starts
+    // mIntegrationStartTime defaults to zero in constructor;
 
     std::srand((unsigned)std::time(0));
 
@@ -272,6 +274,7 @@ LLVMExecutableModel::LLVMExecutableModel(
 }
 
 LLVMExecutableModel::LLVMExecutableModel(std::istream& in, uint modelGeneratorOpt) :
+    ExecutableModel(),
 	resources(new ModelResources()),
 	dirty(0),
 	conversionFactor(1.0),
@@ -322,6 +325,7 @@ LLVMExecutableModel::LLVMExecutableModel(std::istream& in, uint modelGeneratorOp
     pendingEvents.loadState(in, *this);
     rr::loadBinary(in, eventAssignTimes);
     rr::loadBinary(in, tieBreakMap);
+    rr::loadBinary(in, mIntegrationStartTime);
 }
 
 LLVMExecutableModel::~LLVMExecutableModel()
@@ -2527,6 +2531,7 @@ void LLVMExecutableModel::saveState(std::ostream& out)
 	pendingEvents.saveState(out);
 	rr::saveBinary(out, eventAssignTimes);
 	rr::saveBinary(out, tieBreakMap);
+    rr::saveBinary(out, mIntegrationStartTime);
 }
 
 

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -264,7 +264,7 @@ LLVMExecutableModel::LLVMExecutableModel(
 
     //The key here is that 'time' has to be less than 'mIntegrationStartTime' for events to work.  Not sure whether it actually has to be -inf, but it can't hurt?  See T0EventFiring tests, particularly 1120 in the SBML test suite (test_semantic_STS).  The actual integration start time is set in 'simulate'. --LS
     modelData->time = -std::numeric_limits<double>::infinity(); // time is initially before simulation starts
-    // mIntegrationStartTime defaults to zero in constructor;
+    // mIntegrationStartTime defaults to zero in constructor.
 
     std::srand((unsigned)std::time(0));
 

--- a/source/llvm/LLVMExecutableModel.h
+++ b/source/llvm/LLVMExecutableModel.h
@@ -622,7 +622,7 @@ private:
     /******************************************************************************/
 private:
     /**
-     * the model generator maintians a cached of generated models.
+     * the model generator maintians a cache of generated models.
      */
 
     LLVMModelData *modelData;

--- a/source/llvm/LLVMExecutableModel.h
+++ b/source/llvm/LLVMExecutableModel.h
@@ -493,20 +493,7 @@ public:
         return getEventPriorityPtr(modelData, event);
     }
 
-    inline bool getEventTrigger(size_t event)
-    {
-        assert(event < symbols->getEventAttributes().size()
-                        && "event out of bounds");
-        if (modelData->time >= 0.0)
-        {
-            return getEventTriggerPtr(modelData, event);
-        }
-        else
-        {
-            return symbols->getEventAttributes()[event] & EventInitialValue
-                    ? true : false;
-        }
-    }
+    bool getEventTrigger(size_t event);
 
     inline bool getEventUseValuesFromTriggerTime(size_t event)
     {

--- a/source/rrExecutableModel.cpp
+++ b/source/rrExecutableModel.cpp
@@ -34,103 +34,105 @@ static void dump_array(std::ostream &os, int n, const numeric_type *p)
 namespace rr
 {
 
-std::ostream& operator <<(std::ostream &stream, ExecutableModel* model)
-{
-    model->print(stream);
+    ExecutableModel::ExecutableModel()
+        : mIntegrationStartTime(0.0)
+    {
+    }
 
-    double *tmp;
+    std::ostream& operator <<(std::ostream& stream, ExecutableModel* model)
+    {
+        model->print(stream);
 
-    int nFloat = model->getNumFloatingSpecies();
-    int nBound = model->getNumBoundarySpecies();
-    int nComp = model->getNumCompartments();
-    int nGlobalParam = model->getNumGlobalParameters();
-    int nEvents = model->getNumEvents();
-    int nReactions = model->getNumReactions();
+        double* tmp;
 
-    stream << "* Calculated Values *" << std::endl;
+        int nFloat = model->getNumFloatingSpecies();
+        int nBound = model->getNumBoundarySpecies();
+        int nComp = model->getNumCompartments();
+        int nGlobalParam = model->getNumGlobalParameters();
+        int nEvents = model->getNumEvents();
+        int nReactions = model->getNumReactions();
 
-    tmp = new double[nFloat];
-    model->getFloatingSpeciesAmounts(nFloat, 0, tmp);
-    stream << "FloatingSpeciesAmounts:" << std::endl;
-    dump_array(stream, nFloat, tmp);
+        stream << "* Calculated Values *" << std::endl;
 
-    model->getFloatingSpeciesConcentrations(nFloat, 0, tmp);
-    stream << "FloatingSpeciesConcentrations:" << std::endl;
-    dump_array(stream, nFloat, tmp);
+        tmp = new double[nFloat];
+        model->getFloatingSpeciesAmounts(nFloat, 0, tmp);
+        stream << "FloatingSpeciesAmounts:" << std::endl;
+        dump_array(stream, nFloat, tmp);
 
-    model->getFloatingSpeciesInitAmounts(nFloat, 0, tmp);
-    stream << "FloatingSpeciesInitAmounts:" << std::endl;
-    dump_array(stream, nFloat, tmp);
+        model->getFloatingSpeciesConcentrations(nFloat, 0, tmp);
+        stream << "FloatingSpeciesConcentrations:" << std::endl;
+        dump_array(stream, nFloat, tmp);
 
-    model->getFloatingSpeciesInitConcentrations(nFloat, 0, tmp);
-    stream << "FloatingSpeciesInitConcentrations:" << std::endl;
-    dump_array(stream, nFloat, tmp);
-    delete[] tmp;
+        model->getFloatingSpeciesInitAmounts(nFloat, 0, tmp);
+        stream << "FloatingSpeciesInitAmounts:" << std::endl;
+        dump_array(stream, nFloat, tmp);
 
-    tmp = new double[nReactions];
-    model->getReactionRates(nReactions, 0, tmp);
-    stream << "Reaction Rates:" << std::endl;
-    dump_array(stream, nReactions, tmp);
-    delete [] tmp;
+        model->getFloatingSpeciesInitConcentrations(nFloat, 0, tmp);
+        stream << "FloatingSpeciesInitConcentrations:" << std::endl;
+        dump_array(stream, nFloat, tmp);
+        delete[] tmp;
 
-    tmp = new double[nBound];
-    model->getBoundarySpeciesAmounts(nBound, 0, tmp);
-    stream << "BoundarySpeciesAmounts:" << std::endl;
-    dump_array(stream, nBound, tmp);
+        tmp = new double[nReactions];
+        model->getReactionRates(nReactions, 0, tmp);
+        stream << "Reaction Rates:" << std::endl;
+        dump_array(stream, nReactions, tmp);
+        delete[] tmp;
 
-    model->getBoundarySpeciesConcentrations(nBound, 0, tmp);
-    stream << "BoundarySpeciesConcentrations:" << std::endl;
-    dump_array(stream, nBound, tmp);
+        tmp = new double[nBound];
+        model->getBoundarySpeciesAmounts(nBound, 0, tmp);
+        stream << "BoundarySpeciesAmounts:" << std::endl;
+        dump_array(stream, nBound, tmp);
 
-    model->getBoundarySpeciesInitAmounts(nBound, 0, tmp);
-    stream << "BoundarySpeciesInitAmounts:" << std::endl;
-    dump_array(stream, nBound, tmp);
+        model->getBoundarySpeciesConcentrations(nBound, 0, tmp);
+        stream << "BoundarySpeciesConcentrations:" << std::endl;
+        dump_array(stream, nBound, tmp);
 
-    model->getBoundarySpeciesInitConcentrations(nBound, 0, tmp);
-    stream << "BoundarySpeciesInitConcentrations:" << std::endl;
-    dump_array(stream, nBound, tmp);
-    delete[] tmp;
+        model->getBoundarySpeciesInitAmounts(nBound, 0, tmp);
+        stream << "BoundarySpeciesInitAmounts:" << std::endl;
+        dump_array(stream, nBound, tmp);
 
-    tmp = new double[nComp];
-    model->getCompartmentVolumes(nComp, 0, tmp);
-    stream << "CompartmentVolumes:" << std::endl;
-    dump_array(stream, nComp, tmp);
-    delete [] tmp;
+        model->getBoundarySpeciesInitConcentrations(nBound, 0, tmp);
+        stream << "BoundarySpeciesInitConcentrations:" << std::endl;
+        dump_array(stream, nBound, tmp);
+        delete[] tmp;
 
-    tmp = new double[nComp];
-    model->getCompartmentInitVolumes(nComp, 0, tmp);
-    stream << "InitCompartmentVolumes:" << std::endl;
-    dump_array(stream, nComp, tmp);
-    delete[] tmp;
+        tmp = new double[nComp];
+        model->getCompartmentVolumes(nComp, 0, tmp);
+        stream << "CompartmentVolumes:" << std::endl;
+        dump_array(stream, nComp, tmp);
+        delete[] tmp;
 
-    tmp = new double[nGlobalParam];
-    model->getGlobalParameterValues(nGlobalParam, 0, tmp);
-    stream << "GlobalParameters:" << std::endl;
-    dump_array(stream, nGlobalParam, tmp);
+        tmp = new double[nComp];
+        model->getCompartmentInitVolumes(nComp, 0, tmp);
+        stream << "InitCompartmentVolumes:" << std::endl;
+        dump_array(stream, nComp, tmp);
+        delete[] tmp;
 
-    model->getGlobalParameterInitValues(nGlobalParam, 0, tmp);
-    stream << "Init GlobalParameters:" << std::endl;
-    dump_array(stream, nGlobalParam, tmp);
-    delete [] tmp;
+        tmp = new double[nGlobalParam];
+        model->getGlobalParameterValues(nGlobalParam, 0, tmp);
+        stream << "GlobalParameters:" << std::endl;
+        dump_array(stream, nGlobalParam, tmp);
 
-    unsigned char *tmpEvents = new unsigned char[nEvents];
-    model->getEventTriggers(nEvents, 0, tmpEvents);
-    stream << "Events Trigger Status:" << std::endl;
-    dump_array(stream, nEvents, (bool*)tmpEvents);
-    delete [] tmpEvents;
+        model->getGlobalParameterInitValues(nGlobalParam, 0, tmp);
+        stream << "Init GlobalParameters:" << std::endl;
+        dump_array(stream, nGlobalParam, tmp);
+        delete[] tmp;
 
-    stream << std::endl;
+        unsigned char* tmpEvents = new unsigned char[nEvents];
+        model->getEventTriggers(nEvents, 0, tmpEvents);
+        stream << "Events Trigger Status:" << std::endl;
+        dump_array(stream, nEvents, (bool*)tmpEvents);
+        delete[] tmpEvents;
 
-    return stream;
-}
+        stream << std::endl;
+
+        return stream;
+    }
 
 
-
-
-
-void ExecutableModel::setIntegrationStartTime(double time)
-{
-    mIntegrationStartTime = time;
-}
+    void ExecutableModel::setIntegrationStartTime(double time)
+    {
+        mIntegrationStartTime = time;
+    }
 
 } // namespace rr

--- a/source/rrExecutableModel.cpp
+++ b/source/rrExecutableModel.cpp
@@ -128,4 +128,9 @@ std::ostream& operator <<(std::ostream &stream, ExecutableModel* model)
 
 
 
+void ExecutableModel::setIntegrationStartTime(double time)
+{
+    mIntegrationStartTime = time;
+}
+
 } // namespace rr

--- a/source/rrExecutableModel.h
+++ b/source/rrExecutableModel.h
@@ -811,9 +811,13 @@ namespace rr {
             out << "Saving state not implemented for this model type";
         }
 
+        void setIntegrationStartTime(double time);
+
         friend class RoadRunner;
 
     protected:
+
+        double mIntegrationStartTime;
 
         /**
          * is integration is currently proceeding.

--- a/source/rrExecutableModel.h
+++ b/source/rrExecutableModel.h
@@ -123,6 +123,8 @@ namespace rr {
          * @brief Returns a human-readable description of the code generation backend,
          * e.g. LLVM, legacy C, etc.
          */
+        ExecutableModel();
+
         virtual std::string getExecutableModelDesc() const = 0;
 
         /**
@@ -811,7 +813,7 @@ namespace rr {
             out << "Saving state not implemented for this model type";
         }
 
-        void setIntegrationStartTime(double time);
+        virtual void setIntegrationStartTime(double time);
 
         friend class RoadRunner;
 

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1776,6 +1776,8 @@ namespace rr {
 
         const double timeEnd = self.simulateOpt.duration + self.simulateOpt.start;
         const double timeStart = self.simulateOpt.start;
+        self.integrator->setIntegrationStartTime(self.simulateOpt.start);
+        self.model->setIntegrationStartTime(self.simulateOpt.start);
 
         impl->simulatedSinceReset = true;
 
@@ -4777,9 +4779,8 @@ namespace rr {
     void RoadRunner::applySimulateOptions() {
         get_self();
 
-        if (self.simulateOpt.duration < 0 || self.simulateOpt.start < 0
-            || self.simulateOpt.steps < 0) {
-            throw std::invalid_argument("duration, startTime and steps must be non-negative");
+        if (self.simulateOpt.duration < 0 || self.simulateOpt.steps < 0) {
+            throw std::invalid_argument("duration and steps must be non-negative");
         }
 
         // This one creates the list of what we will look at in the result

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1774,10 +1774,11 @@ namespace rr {
 
         applySimulateOptions();
 
-        const double timeEnd = self.simulateOpt.duration + self.simulateOpt.start;
         const double timeStart = self.simulateOpt.start;
         self.integrator->setIntegrationStartTime(self.simulateOpt.start);
         self.model->setIntegrationStartTime(self.simulateOpt.start);
+
+        const double timeEnd = self.simulateOpt.duration + self.simulateOpt.start;
 
         impl->simulatedSinceReset = true;
 

--- a/source/rrRoadRunnerOptions.cpp
+++ b/source/rrRoadRunnerOptions.cpp
@@ -241,18 +241,12 @@ namespace rr {
                     throw std::invalid_argument(err.str());
                 }
             }
-            if (start < 0) {
-                std::stringstream err;
-                err << "The first entry in the 'times' vector must be zero or greater.  The current value is " << start << ".";
-                throw std::invalid_argument(err.str());
-
-            }
             double prev = start;
             for (size_t tv = 1; tv < times.size(); tv++) {
                 double hstep = times[tv] - prev;
                 if (hstep <= 0) {
                     std::stringstream err;
-                    err << "The 'times' setting must be a vector of time values that start at zero or more and increase along the vector.  The value " << times[tv] << " is less than or equal to the previous value of " << prev << ".";
+                    err << "The 'times' setting must be a vector of time values that start at the time value at the initial state of the model and increase along the vector.  The value " << times[tv] << " is less than or equal to the previous value of " << prev << ".";
                     throw std::invalid_argument(err.str());
                 }
                 prev = times[tv];

--- a/source/testing/CXXBrusselatorExecutableModel.cpp
+++ b/source/testing/CXXBrusselatorExecutableModel.cpp
@@ -13,9 +13,10 @@ using rr::Logger;
 
 namespace rrtesting {
 
-    CXXBrusselatorExecutableModel::CXXBrusselatorExecutableModel(const rr::Dictionary *dict) {
+    CXXBrusselatorExecutableModel::CXXBrusselatorExecutableModel(const rr::Dictionary *dict)
+       : ExecutableModel()
+    {
         rrLog(Logger::LOG_NOTICE) << __FUNC__;
-        mIntegrationStartTime = 0.0;
     }
 
     CXXBrusselatorExecutableModel::~CXXBrusselatorExecutableModel() {

--- a/source/testing/CXXBrusselatorExecutableModel.cpp
+++ b/source/testing/CXXBrusselatorExecutableModel.cpp
@@ -15,6 +15,7 @@ namespace rrtesting {
 
     CXXBrusselatorExecutableModel::CXXBrusselatorExecutableModel(const rr::Dictionary *dict) {
         rrLog(Logger::LOG_NOTICE) << __FUNC__;
+        mIntegrationStartTime = 0.0;
     }
 
     CXXBrusselatorExecutableModel::~CXXBrusselatorExecutableModel() {

--- a/source/testing/CXXEnzymeExecutableModel.cpp
+++ b/source/testing/CXXEnzymeExecutableModel.cpp
@@ -20,8 +20,8 @@ namespace rrtesting
 
 
 CXXEnzymeExecutableModel::CXXEnzymeExecutableModel(const rr::Dictionary* dict)
+       : ExecutableModel()
 {
-    mIntegrationStartTime = 0.0;
     rrLog(Logger::LOG_NOTICE) << __FUNC__;
 
     volumes = new double[1];

--- a/source/testing/CXXEnzymeExecutableModel.cpp
+++ b/source/testing/CXXEnzymeExecutableModel.cpp
@@ -21,6 +21,7 @@ namespace rrtesting
 
 CXXEnzymeExecutableModel::CXXEnzymeExecutableModel(const rr::Dictionary* dict)
 {
+    mIntegrationStartTime = 0.0;
     rrLog(Logger::LOG_NOTICE) << __FUNC__;
 
     volumes = new double[1];

--- a/source/testing/CXXExecutableModel.cpp
+++ b/source/testing/CXXExecutableModel.cpp
@@ -17,6 +17,7 @@ namespace rrtesting
 CXXExecutableModel::CXXExecutableModel(const rr::Dictionary* dict)
 {
     rrLog(Logger::LOG_NOTICE) << __FUNC__;
+    mIntegrationStartTime = 0.0;
 }
 
 CXXExecutableModel::~CXXExecutableModel()

--- a/source/testing/CXXExecutableModel.cpp
+++ b/source/testing/CXXExecutableModel.cpp
@@ -15,9 +15,9 @@ namespace rrtesting
 {
 
 CXXExecutableModel::CXXExecutableModel(const rr::Dictionary* dict)
+       : ExecutableModel()
 {
     rrLog(Logger::LOG_NOTICE) << __FUNC__;
-    mIntegrationStartTime = 0.0;
 }
 
 CXXExecutableModel::~CXXExecutableModel()

--- a/source/testing/CXXPiecewiseExecutableModel.cpp
+++ b/source/testing/CXXPiecewiseExecutableModel.cpp
@@ -15,9 +15,9 @@ namespace rrtesting
 {
 
 CXXPiecewiseExecutableModel::CXXPiecewiseExecutableModel(const rr::Dictionary* dict)
+       : ExecutableModel()
 {
     rrLog(Logger::LOG_NOTICE) << __FUNC__;
-    mIntegrationStartTime = 0.0;
 }
 
 CXXPiecewiseExecutableModel::~CXXPiecewiseExecutableModel()

--- a/source/testing/CXXPiecewiseExecutableModel.cpp
+++ b/source/testing/CXXPiecewiseExecutableModel.cpp
@@ -17,6 +17,7 @@ namespace rrtesting
 CXXPiecewiseExecutableModel::CXXPiecewiseExecutableModel(const rr::Dictionary* dict)
 {
     rrLog(Logger::LOG_NOTICE) << __FUNC__;
+    mIntegrationStartTime = 0.0;
 }
 
 CXXPiecewiseExecutableModel::~CXXPiecewiseExecutableModel()

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -21,9 +21,30 @@ public:
 };
 
 
-TEST_F(ModelAnalysisTests, SimulateFromNegativeStart) {
+TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStart) {
     //rr::Logger::setLevel(rr::Logger::LOG_DEBUG);
     RoadRunner rr((modelAnalysisModelsDir / "negstart_event.xml").string());
+    SimulateOptions opt;
+    opt.start = -2;
+    opt.duration = 10;
+    opt.steps = 120;
+    const ls::DoubleMatrix* result = rr.simulate(&opt);
+    ASSERT_EQ(result->CSize(), 2);
+    ASSERT_EQ(result->RSize(), 121);
+    //Spot checks for when the events fire.
+    EXPECT_NEAR(result->Element(2, 1), 3.083, 0.01);
+    EXPECT_NEAR(result->Element(23, 1), 3.008, 0.01);
+    EXPECT_NEAR(result->Element(44, 1), 4.933, 0.01);
+    EXPECT_NEAR(result->Element(45, 1), 3.025, 0.01);
+    EXPECT_NEAR(result->Element(61, 1), 0.092, 0.01);
+    EXPECT_NEAR(result->Element(115, 1), 3.042, 0.01);
+
+}
+
+TEST_F(ModelAnalysisTests, SimulateGillespieFromNegativeStart) {
+    //rr::Logger::setLevel(rr::Logger::LOG_DEBUG);
+    RoadRunner rr((modelAnalysisModelsDir / "negstart_event.xml").string());
+    rr.setIntegrator("gillespie");
     SimulateOptions opt;
     opt.start = -2;
     opt.duration = 10;

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -21,8 +21,8 @@ public:
 };
 
 
-TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStart) {
-    //rr::Logger::setLevel(rr::Logger::LOG_DEBUG);
+TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStartGeneral) {
+    //Event:  at S1 > 500: S1 = 300;
     RoadRunner rr((modelAnalysisModelsDir / "negstart_event.xml").string());
     SimulateOptions opt;
     opt.start = -2;
@@ -32,27 +32,207 @@ TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStart) {
     ASSERT_EQ(result->CSize(), 2);
     ASSERT_EQ(result->RSize(), 121);
     //Spot checks for when the events fire.
-    EXPECT_NEAR(result->Element(2, 1), 3.083, 0.01);
-    EXPECT_NEAR(result->Element(23, 1), 3.008, 0.01);
-    EXPECT_NEAR(result->Element(44, 1), 4.933, 0.01);
-    EXPECT_NEAR(result->Element(45, 1), 3.025, 0.01);
-    EXPECT_NEAR(result->Element(61, 1), 0.092, 0.01);
-    EXPECT_NEAR(result->Element(115, 1), 3.042, 0.01);
+    EXPECT_NEAR(result->Element(2, 1), 308.3, 1);
+    EXPECT_NEAR(result->Element(23, 1), 300.8, 1);
+    EXPECT_NEAR(result->Element(44, 1), 493.3, 1);
+    EXPECT_NEAR(result->Element(45, 1), 302.5, 1);
+    EXPECT_NEAR(result->Element(67, 1), 304.2, 1);
+    EXPECT_NEAR(result->Element(89, 1), 305.8, 1);
 
 }
 
-TEST_F(ModelAnalysisTests, SimulateGillespieFromNegativeStart) {
-    //rr::Logger::setLevel(rr::Logger::LOG_DEBUG);
-    RoadRunner rr((modelAnalysisModelsDir / "negstart_event.xml").string());
-    rr.setIntegrator("gillespie");
+TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStart_Time) {
+    //Event:  at time > -1.1: S1 = 0;
+    RoadRunner rr((modelAnalysisModelsDir / "negstart_event_time.xml").string());
     SimulateOptions opt;
     opt.start = -2;
     opt.duration = 10;
     opt.steps = 120;
     const ls::DoubleMatrix* result = rr.simulate(&opt);
-    //std::cout << *result;
-
+    ASSERT_EQ(result->CSize(), 2);
+    ASSERT_EQ(result->RSize(), 121);
+    //Spot checks for when the events fire.
+    EXPECT_NEAR(result->Element(2, 1), 508.3, 1);
+    EXPECT_NEAR(result->Element(11, 1), 1.8, 1);
+    EXPECT_NEAR(result->Element(24, 1), 121, 1);
+    EXPECT_NEAR(result->Element(120, 1), 1001, 1);
 }
+
+TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStart_TimeDelay) {
+    //Event:  at 0.5 after time > -1.1: S1 = 0;
+    RoadRunner rr((modelAnalysisModelsDir / "negstart_event_time_delay.xml").string());
+    SimulateOptions opt;
+    opt.start = -2;
+    opt.duration = 10;
+    opt.steps = 120;
+    const ls::DoubleMatrix* result = rr.simulate(&opt);
+    ASSERT_EQ(result->CSize(), 2);
+    ASSERT_EQ(result->RSize(), 121);
+    //Spot checks for when the events fire.
+    EXPECT_NEAR(result->Element(2, 1), 508.3, 1);
+    EXPECT_NEAR(result->Element(17, 1), 1.8, 1);
+    EXPECT_NEAR(result->Element(24, 1), 66, 1);
+    EXPECT_NEAR(result->Element(120, 1), 946, 1);
+}
+
+TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStart_T0fire) {
+    //Event:  at S1 > 500, t0=false: S1 = 300;
+    RoadRunner rr((modelAnalysisModelsDir / "negstart_event_t0fire.xml").string());
+    SimulateOptions opt;
+    opt.start = -2;
+    opt.duration = 10;
+    opt.steps = 120;
+    const ls::DoubleMatrix* result = rr.simulate(&opt);
+    ASSERT_EQ(result->CSize(), 2);
+    ASSERT_EQ(result->RSize(), 121);
+    //Spot checks for when the events fire.
+    EXPECT_EQ(result->Element(0, 1), 300);
+    EXPECT_NEAR(result->Element(21, 1), 492.5, 1);
+    EXPECT_NEAR(result->Element(22, 1), 301.7, 1);
+    EXPECT_NEAR(result->Element(44, 1), 303.3, 1);
+    EXPECT_NEAR(result->Element(120, 1), 400, 1);
+}
+
+TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStart_Combo) {
+    //Events:  E0: at 0.3 after time > -1: S1 = 0;
+    //         E1: at time > 1: S1 = 100;
+    //         E2: at 0.5 after S1 > 500: S1 = 300;
+    RoadRunner rr((modelAnalysisModelsDir / "negstart_event_combo.xml").string());
+    SimulateOptions opt;
+    opt.start = -2;
+    opt.duration = 10;
+    opt.steps = 120;
+    const ls::DoubleMatrix* result = rr.simulate(&opt);
+    ASSERT_EQ(result->CSize(), 2);
+    ASSERT_EQ(result->RSize(), 121);
+    //Spot checks for when the events fire.
+    EXPECT_NEAR(result->Element(2, 1), 508.3, 1);
+    EXPECT_NEAR(result->Element(8, 1), 308.3, 1);
+    EXPECT_NEAR(result->Element(16, 1), 3.7, 1);
+    EXPECT_NEAR(result->Element(36, 1), 187.0, 1);
+    EXPECT_NEAR(result->Element(37, 1), 109.2, 1);
+    EXPECT_NEAR(result->Element(80, 1), 503.3, 1);
+    EXPECT_NEAR(result->Element(86, 1), 303.3, 1);
+    EXPECT_NEAR(result->Element(120, 1), 360, 1);
+}
+
+//T0 event firing when start != 0 is generally broken, not only for negative starts.  Disabling for now; will file separate issue.
+TEST_F(ModelAnalysisTests, DISABLED_SimulateCVODEFromNegativeStart_T0fireDelay) {
+    //Event:  at 0.5 after S1 > 500, t0=false: S1 = 300;
+    RoadRunner rr((modelAnalysisModelsDir / "negstart_event_t0fire_delay.xml").string());
+    SimulateOptions opt;
+    opt.start = -2;
+    opt.duration = 10;
+    opt.steps = 120;
+    const ls::DoubleMatrix* result = rr.simulate(&opt);
+    ASSERT_EQ(result->CSize(), 2);
+    ASSERT_EQ(result->RSize(), 121);
+    //Spot checks for when the events fire.
+    //EXPECT_NEAR(result->Element(0, 1), 550, 1);
+    //EXPECT_NEAR(result->Element(21, 1), 492.5, 1);
+    //EXPECT_NEAR(result->Element(22, 1), 301.7, 1);
+    //EXPECT_NEAR(result->Element(44, 1), 303.3, 1);
+    //EXPECT_NEAR(result->Element(120, 1), 400, 1);
+    std::cout << *result;
+}
+
+TEST_F(ModelAnalysisTests, SimulateGillespieFromNegativeStart_General) {
+    //Event:  at S1 > 500: S1 = 300;
+    RoadRunner rr((modelAnalysisModelsDir / "negstart_event.xml").string());
+    rr.setIntegrator("gillespie");
+    rr.getIntegrator()->setValue("variable_step_size", false);
+    SimulateOptions opt;
+    opt.start = -2;
+    opt.duration = 10;
+    opt.steps = 120;
+    const ls::DoubleMatrix* result = rr.simulate(&opt);
+
+    for (int i = 0; i <= opt.steps; i++)
+    {
+        EXPECT_LE(result->Element(i, 1), 500);
+        EXPECT_GE(result->Element(i, 1), 300);
+    }
+}
+
+TEST_F(ModelAnalysisTests, SimulateGillespieFromNegativeStart_Time) {
+    //Event:  at time > -1.1: S1 = 0;
+    RoadRunner rr((modelAnalysisModelsDir / "negstart_event_time.xml").string());
+    rr.setIntegrator("gillespie");
+    rr.getIntegrator()->setValue("variable_step_size", false);
+    SimulateOptions opt;
+    opt.start = -2;
+    opt.duration = 10;
+    opt.steps = 120;
+    const ls::DoubleMatrix* result = rr.simulate(&opt);
+
+    EXPECT_LE(result->Element(11, 1), 20);
+    EXPECT_NEAR(result->Element(24, 1), 100, 50);
+}
+
+TEST_F(ModelAnalysisTests, SimulateGillespieFromNegativeStart_Time_Delay) {
+    //Event:  at 0.5 after time > -1.1: S1 = 0;
+    RoadRunner rr((modelAnalysisModelsDir / "negstart_event_time_delay.xml").string());
+    rr.setIntegrator("gillespie");
+    rr.getIntegrator()->setValue("variable_step_size", false);
+    SimulateOptions opt;
+    opt.start = -2;
+    opt.duration = 10;
+    opt.steps = 120;
+    const ls::DoubleMatrix* result = rr.simulate(&opt);
+
+    EXPECT_GE(result->Element(2, 1), 500);
+    EXPECT_LE(result->Element(17, 1), 20);
+    EXPECT_NEAR(result->Element(24, 1), 66, 30);
+    EXPECT_NEAR(result->Element(120, 1), 946, 50);
+}
+
+TEST_F(ModelAnalysisTests, SimulateGillespieFromNegativeStart_T0fire) {
+    //Event:  at S1 > 500, t0=false: S1 = 300;
+    RoadRunner rr((modelAnalysisModelsDir / "negstart_event_t0fire.xml").string());
+    rr.setIntegrator("gillespie");
+    rr.getIntegrator()->setValue("variable_step_size", false);
+    SimulateOptions opt;
+    opt.start = -2;
+    opt.duration = 10;
+    opt.steps = 120;
+    const ls::DoubleMatrix* result = rr.simulate(&opt);
+
+    EXPECT_EQ(result->Element(0, 1), 300);
+    for (int i = 1; i <= opt.steps; i++)
+    {
+        EXPECT_LE(result->Element(i, 1), 500);
+        EXPECT_GE(result->Element(i, 1), 300);
+    }
+}
+
+TEST_F(ModelAnalysisTests, SimulateGillespieFromNegativeStart_Combo) {
+    //Events:  E0: at 0.3 after time > -1: S1 = 0;
+    //         E1: at time > 1: S1 = 100;
+    //         E2: at 0.5 after S1 > 500: S1 = 300;
+    RoadRunner rr((modelAnalysisModelsDir / "negstart_event_combo.xml").string());
+    rr.setIntegrator("gillespie");
+    rr.getIntegrator()->setValue("variable_step_size", false);
+    SimulateOptions opt;
+    opt.start = -2;
+    opt.duration = 10;
+    opt.steps = 120;
+    const ls::DoubleMatrix* result = rr.simulate(&opt);
+
+    EXPECT_NEAR(result->Element(2, 1), 508, 10);
+    EXPECT_NEAR(result->Element(8, 1), 308, 10);
+    EXPECT_LE(result->Element(16, 1), 15);
+    EXPECT_NEAR(result->Element(36, 1), 187, 20);
+    EXPECT_NEAR(result->Element(37, 1), 110, 10);
+    EXPECT_NEAR(result->Element(80, 1), 503, 30);
+    EXPECT_NEAR(result->Element(86, 1), 304, 10);
+    EXPECT_NEAR(result->Element(120, 1), 360, 40);
+    for (int i = 1; i <= opt.steps; i++)
+    {
+        EXPECT_LE(result->Element(i, 1), 580);
+        EXPECT_GE(result->Element(i, 1), 0);
+    }
+}
+
 
 TEST_F(ModelAnalysisTests, GetRateOfConservedSpecies) {
     RoadRunner rr((modelAnalysisModelsDir / "conserved_cycle.xml").string());

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -234,8 +234,140 @@ TEST_F(ModelAnalysisTests, SimulateGillespieFromNegativeStart_Combo) {
 }
 
 
+TEST_F(ModelAnalysisTests, NonZeroStarts_CVODE) {
+    //Event:  at S1 > 500, t0=false: S1 = 300;
+    RoadRunner rr((modelAnalysisModelsDir / "BIOMD0000000035_url.xml").string());
+    rr.setIntegrator("cvode");
+    //rr.getIntegrator()->setValue("variable_step_size", false);
+    SimulateOptions opt;
+    opt.start = 0;
+    opt.duration = 10;
+    opt.steps = 50;
+    ls::DoubleMatrix s0result(*(rr.simulate(&opt)));
+    rr.reset(SelectionRecord::SelectionType::ALL);
+    opt.start = -2;
+    ls::DoubleMatrix sneg2result(*(rr.simulate(&opt)));
+    rr.reset(SelectionRecord::SelectionType::ALL);
+    opt.start = 2;
+    ls::DoubleMatrix s2result(*(rr.simulate(&opt)));
+
+
+    for (int i = 0; i <= opt.steps; i++)
+    {
+        EXPECT_NEAR(s0result.Element(i, 0), sneg2result.Element(i, 0) + 2, 0.01);
+        EXPECT_NEAR(s0result.Element(i, 0), s2result.Element(i, 0) - 2, 0.01);
+
+        for (int j = 1; j < s0result.CSize(); j++)
+        {
+            EXPECT_NEAR(s0result.Element(i, j), sneg2result.Element(i, j), 0.01);
+            EXPECT_NEAR(s0result.Element(i, j), s2result.Element(i, j), 0.01);
+        }
+    }
+}
+
+
+
+TEST_F(ModelAnalysisTests, NonZeroStarts_RK4) {
+    //Event:  at S1 > 500, t0=false: S1 = 300;
+    RoadRunner rr((modelAnalysisModelsDir / "threestep.xml").string());
+    rr.setIntegrator("rk4");
+    //rr.getIntegrator()->setValue("variable_step_size", false);
+    SimulateOptions opt;
+    opt.start = 0;
+    opt.duration = 10;
+    opt.steps = 50;
+    ls::DoubleMatrix s0result(*(rr.simulate(&opt)));
+    rr.reset(SelectionRecord::SelectionType::ALL);
+    opt.start = -2;
+    ls::DoubleMatrix sneg2result(*(rr.simulate(&opt)));
+    rr.reset(SelectionRecord::SelectionType::ALL);
+    opt.start = 2;
+    ls::DoubleMatrix s2result(*(rr.simulate(&opt)));
+
+
+    for (int i = 0; i <= opt.steps; i++)
+    {
+        EXPECT_NEAR(s0result.Element(i, 0), sneg2result.Element(i, 0) + 2, 0.01);
+        EXPECT_NEAR(s0result.Element(i, 0), s2result.Element(i, 0) - 2, 0.01);
+
+        for (int j = 1; j < s0result.CSize(); j++)
+        {
+            EXPECT_NEAR(s0result.Element(i, j), sneg2result.Element(i, j), 0.01);
+            EXPECT_NEAR(s0result.Element(i, j), s2result.Element(i, j), 0.01);
+        }
+    }
+}
+
+
+
+TEST_F(ModelAnalysisTests, NonZeroStarts_RK45) {
+    //Event:  at S1 > 500, t0=false: S1 = 300;
+    RoadRunner rr((modelAnalysisModelsDir / "threestep.xml").string());
+    rr.setIntegrator("rk45");
+    rr.getIntegrator()->setValue("variable_step_size", false);
+    SimulateOptions opt;
+    opt.start = 0;
+    opt.duration = 10;
+    opt.steps = 50;
+    ls::DoubleMatrix s0result(*(rr.simulate(&opt)));
+    rr.reset(SelectionRecord::SelectionType::ALL);
+    opt.start = -2;
+    ls::DoubleMatrix sneg2result(*(rr.simulate(&opt)));
+    rr.reset(SelectionRecord::SelectionType::ALL);
+    opt.start = 2;
+    ls::DoubleMatrix s2result(*(rr.simulate(&opt)));
+
+
+    for (int i = 0; i <= opt.steps; i++)
+    {
+        EXPECT_NEAR(s0result.Element(i, 0), sneg2result.Element(i, 0) + 2, 0.01);
+        EXPECT_NEAR(s0result.Element(i, 0), s2result.Element(i, 0) - 2, 0.01);
+
+        for (int j = 1; j < s0result.CSize(); j++)
+        {
+            EXPECT_NEAR(s0result.Element(i, j), sneg2result.Element(i, j), 0.01);
+            EXPECT_NEAR(s0result.Element(i, j), s2result.Element(i, j), 0.01);
+        }
+    }
+}
+
+
+//I don't think setting the seed is working for this one.
+TEST_F(ModelAnalysisTests, DISABLED_NonZeroStarts_Gillespie) {
+    RoadRunner rr((modelAnalysisModelsDir / "threestep.xml").string());
+    rr.setIntegrator("gillespie");
+    rr.getIntegrator()->setValue("variable_step_size", false);
+    rr.getIntegrator()->setValue("seed", 1001);
+    SimulateOptions opt;
+    opt.start = 0;
+    opt.duration = 10;
+    opt.steps = 50;
+    ls::DoubleMatrix s0result(*(rr.simulate(&opt)));
+    rr.reset(SelectionRecord::SelectionType::ALL);
+    opt.start = -2;
+    ls::DoubleMatrix sneg2result(*(rr.simulate(&opt)));
+    rr.reset(SelectionRecord::SelectionType::ALL);
+    opt.start = 2;
+    ls::DoubleMatrix s2result(*(rr.simulate(&opt)));
+
+
+    for (int i = 0; i <= opt.steps; i++)
+    {
+        EXPECT_NEAR(s0result.Element(i, 0), sneg2result.Element(i, 0) + 2, 0.01);
+        EXPECT_NEAR(s0result.Element(i, 0), s2result.Element(i, 0) - 2, 0.01);
+
+        for (int j = 1; j < s0result.CSize(); j++)
+        {
+            EXPECT_NEAR(s0result.Element(i, j), sneg2result.Element(i, j), 0.01);
+            EXPECT_NEAR(s0result.Element(i, j), s2result.Element(i, j), 0.01);
+        }
+    }
+}
+
+
+
 TEST_F(ModelAnalysisTests, GetRateOfConservedSpecies) {
-    RoadRunner rr((modelAnalysisModelsDir / "conserved_cycle.xml").string());
+        RoadRunner rr((modelAnalysisModelsDir / "conserved_cycle.xml").string());
     rr.setConservedMoietyAnalysis(true);
 
     EXPECT_THROW(

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -21,6 +21,18 @@ public:
 };
 
 
+TEST_F(ModelAnalysisTests, SimulateFromNegativeStart) {
+    //rr::Logger::setLevel(rr::Logger::LOG_DEBUG);
+    RoadRunner rr((modelAnalysisModelsDir / "negstart_event.xml").string());
+    SimulateOptions opt;
+    opt.start = -2;
+    opt.duration = 10;
+    opt.steps = 120;
+    const ls::DoubleMatrix* result = rr.simulate(&opt);
+    //std::cout << *result;
+
+}
+
 TEST_F(ModelAnalysisTests, GetRateOfConservedSpecies) {
     RoadRunner rr((modelAnalysisModelsDir / "conserved_cycle.xml").string());
     rr.setConservedMoietyAnalysis(true);

--- a/test/models/ModelAnalysis/negstart_event.xml
+++ b/test/models/ModelAnalysis/negstart_event.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.3. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="S1" compartment="default_compartment" initialConcentration="4.9" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfReactions>
+      <reaction id="J0" reversible="true">
+        <listOfProducts>
+          <speciesReference species="S1" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <cn> 1.1 </cn>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+    <listOfEvents>
+      <event id="E0" useValuesFromTriggerTime="true">
+        <trigger initialValue="true" persistent="true">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <gt/>
+              <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+              <cn type="integer"> 3 </cn>
+            </apply>
+          </math>
+        </trigger>
+        <listOfEventAssignments>
+          <eventAssignment variable="S1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <cn type="integer"> 0 </cn>
+            </math>
+          </eventAssignment>
+        </listOfEventAssignments>
+      </event>
+      <event id="E1" useValuesFromTriggerTime="true">
+        <trigger initialValue="true" persistent="true">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <gt/>
+              <ci> S1 </ci>
+              <cn type="integer"> 5 </cn>
+            </apply>
+          </math>
+        </trigger>
+        <listOfEventAssignments>
+          <eventAssignment variable="S1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <cn type="integer"> 3 </cn>
+            </math>
+          </eventAssignment>
+        </listOfEventAssignments>
+      </event>
+    </listOfEvents>
+  </model>
+</sbml>

--- a/test/models/ModelAnalysis/negstart_event_combo.xml
+++ b/test/models/ModelAnalysis/negstart_event_combo.xml
@@ -21,6 +21,47 @@
       </reaction>
     </listOfReactions>
     <listOfEvents>
+      <event id="E0" useValuesFromTriggerTime="true">
+        <trigger initialValue="true" persistent="true">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <gt/>
+              <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+              <cn type="integer"> -1 </cn>
+            </apply>
+          </math>
+        </trigger>
+        <delay>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <cn> 0.3 </cn>
+          </math>
+        </delay>
+        <listOfEventAssignments>
+          <eventAssignment variable="S1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <cn type="integer"> 0 </cn>
+            </math>
+          </eventAssignment>
+        </listOfEventAssignments>
+      </event>
+      <event id="E1" useValuesFromTriggerTime="true">
+        <trigger initialValue="true" persistent="true">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <gt/>
+              <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+              <cn type="integer"> 1 </cn>
+            </apply>
+          </math>
+        </trigger>
+        <listOfEventAssignments>
+          <eventAssignment variable="S1">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <cn type="integer"> 100 </cn>
+            </math>
+          </eventAssignment>
+        </listOfEventAssignments>
+      </event>
       <event id="E2" useValuesFromTriggerTime="true">
         <trigger initialValue="true" persistent="true">
           <math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -31,6 +72,11 @@
             </apply>
           </math>
         </trigger>
+        <delay>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <cn> 0.5 </cn>
+          </math>
+        </delay>
         <listOfEventAssignments>
           <eventAssignment variable="S1">
             <math xmlns="http://www.w3.org/1998/Math/MathML">

--- a/test/models/ModelAnalysis/negstart_event_delay.xml
+++ b/test/models/ModelAnalysis/negstart_event_delay.xml
@@ -31,6 +31,11 @@
             </apply>
           </math>
         </trigger>
+        <delay>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <cn> 0.44 </cn>
+          </math>
+        </delay>
         <listOfEventAssignments>
           <eventAssignment variable="S1">
             <math xmlns="http://www.w3.org/1998/Math/MathML">

--- a/test/models/ModelAnalysis/negstart_event_t0fire.xml
+++ b/test/models/ModelAnalysis/negstart_event_t0fire.xml
@@ -6,7 +6,7 @@
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" compartment="default_compartment" initialConcentration="490" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" compartment="default_compartment" initialConcentration="550" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
       <reaction id="J0" reversible="true">
@@ -22,7 +22,7 @@
     </listOfReactions>
     <listOfEvents>
       <event id="E2" useValuesFromTriggerTime="true">
-        <trigger initialValue="true" persistent="true">
+        <trigger initialValue="false" persistent="true">
           <math xmlns="http://www.w3.org/1998/Math/MathML">
             <apply>
               <gt/>

--- a/test/models/ModelAnalysis/negstart_event_t0fire_delay.xml
+++ b/test/models/ModelAnalysis/negstart_event_t0fire_delay.xml
@@ -6,7 +6,7 @@
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species id="S1" compartment="default_compartment" initialConcentration="490" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S1" compartment="default_compartment" initialConcentration="550" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
       <reaction id="J0" reversible="true">
@@ -22,7 +22,7 @@
     </listOfReactions>
     <listOfEvents>
       <event id="E2" useValuesFromTriggerTime="true">
-        <trigger initialValue="true" persistent="true">
+        <trigger initialValue="false" persistent="true">
           <math xmlns="http://www.w3.org/1998/Math/MathML">
             <apply>
               <gt/>
@@ -31,6 +31,11 @@
             </apply>
           </math>
         </trigger>
+        <delay>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <cn> 0.5 </cn>
+          </math>
+        </delay>
         <listOfEventAssignments>
           <eventAssignment variable="S1">
             <math xmlns="http://www.w3.org/1998/Math/MathML">

--- a/test/models/ModelAnalysis/negstart_event_time.xml
+++ b/test/models/ModelAnalysis/negstart_event_time.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.3. -->
-<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
   <model metaid="__main" id="__main">
     <listOfCompartments>
       <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
@@ -9,7 +9,7 @@
       <species id="S1" compartment="default_compartment" initialConcentration="490" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfReactions>
-      <reaction id="J0" reversible="true">
+      <reaction id="J0" reversible="true" fast="false">
         <listOfProducts>
           <speciesReference species="S1" stoichiometry="1" constant="true"/>
         </listOfProducts>
@@ -21,20 +21,20 @@
       </reaction>
     </listOfReactions>
     <listOfEvents>
-      <event id="E2" useValuesFromTriggerTime="true">
+      <event id="E0" useValuesFromTriggerTime="true">
         <trigger initialValue="true" persistent="true">
           <math xmlns="http://www.w3.org/1998/Math/MathML">
             <apply>
               <gt/>
-              <ci> S1 </ci>
-              <cn type="integer"> 500 </cn>
+              <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+              <cn> -1.1 </cn>
             </apply>
           </math>
         </trigger>
         <listOfEventAssignments>
           <eventAssignment variable="S1">
             <math xmlns="http://www.w3.org/1998/Math/MathML">
-              <cn type="integer"> 300 </cn>
+              <cn type="integer"> 0 </cn>
             </math>
           </eventAssignment>
         </listOfEventAssignments>

--- a/test/models/ModelAnalysis/negstart_event_time_delay.xml
+++ b/test/models/ModelAnalysis/negstart_event_time_delay.xml
@@ -21,20 +21,25 @@
       </reaction>
     </listOfReactions>
     <listOfEvents>
-      <event id="E2" useValuesFromTriggerTime="true">
+      <event id="E0" useValuesFromTriggerTime="true">
         <trigger initialValue="true" persistent="true">
           <math xmlns="http://www.w3.org/1998/Math/MathML">
             <apply>
               <gt/>
-              <ci> S1 </ci>
-              <cn type="integer"> 500 </cn>
+              <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+              <cn> -1.1 </cn>
             </apply>
           </math>
         </trigger>
+        <delay>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <cn> 0.5 </cn>
+          </math>
+        </delay>
         <listOfEventAssignments>
           <eventAssignment variable="S1">
             <math xmlns="http://www.w3.org/1998/Math/MathML">
-              <cn type="integer"> 300 </cn>
+              <cn type="integer"> 0 </cn>
             </math>
           </eventAssignment>
         </listOfEventAssignments>

--- a/test/models/ModelAnalysis/threestep.xml
+++ b/test/models/ModelAnalysis/threestep.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.3. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="S1" compartment="default_compartment" initialConcentration="10" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S2" compartment="default_compartment" initialConcentration="1" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S3" compartment="default_compartment" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S4" compartment="default_compartment" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfReactions>
+      <reaction id="J1" reversible="true">
+        <listOfReactants>
+          <speciesReference species="S1" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="S2" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <cn> 1.3 </cn>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="J2" reversible="true">
+        <listOfReactants>
+          <speciesReference species="S2" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="S3" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <cn> 0.4 </cn>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="J3" reversible="true">
+        <listOfReactants>
+          <speciesReference species="S3" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="S4" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <cn> 0.5 </cn>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/semantic_STS/sbml_test_suite.cpp
+++ b/test/semantic_STS/sbml_test_suite.cpp
@@ -247,10 +247,10 @@ public:
 };
 
 
-TEST_F(SbmlTestSuite, test_single)
+TEST_F(SbmlTestSuite, DISABLED_test_single)
 {
     // Use when need to run one test.
-    EXPECT_TRUE(RunTest(26));
+    EXPECT_TRUE(RunTest(1120));
 }
 TEST_F(SbmlTestSuite, t1)
 {


### PR DESCRIPTION
I thought this would be much more difficult than it turned out to be, because our current 'start' time is not 'time to start collecting data' but 'the time that the model is currently in', which is quite different!

The trickiest part of this turns out to be events, which had t0=0.0 hard-coded in quite a number of places.  Still need to test more, but many things now work with negative start times--events can fire pre-0.0, even.  So hey!