### PR TITLE
Implement maximum_step_size and ignore initial_time_step for Gillespie.

### DIFF
--- a/source/GillespieIntegrator.cpp
+++ b/source/GillespieIntegrator.cpp
@@ -191,7 +191,7 @@ namespace rr
         // Set default integrator settings.
         addSetting("seed",                  std::uint64_t(defaultSeed()), "Seed", "Set the seed into the random engine. (ulong)", "(ulong) Set the seed into the random engine.");
         addSetting("variable_step_size",    Setting(true), "Variable Step Size", "Perform a variable time step simulation. (bool)", "(bool) Enabling this setting will allow the integrator to adapt the size of each time step. This will result in a non-uniform time column.  The number of steps or points will be ignored, and the max number of output rows will be used instead.");
-        addSetting("initial_time_step",     Setting(0.0),   "Initial Time Step", "Specifies the initial time step size. (double)", "(double) Specifies the initial time step size.");
+        //addSetting("initial_time_step",     Setting(0.0),   "Initial Time Step", "Specifies the initial time step size. (double)", "(double) Specifies the initial time step size.");
         addSetting("minimum_time_step",     Setting(0.0),   "Minimum Time Step", "Specifies the minimum absolute value of step size allowed. (double)", "(double) The minimum absolute value of step size allowed.");
         addSetting("maximum_time_step",     Setting(0.0),   "Maximum Time Step", "Specifies the maximum absolute value of step size allowed. (double)", "(double) The maximum absolute value of step size allowed.");
         addSetting("nonnegative",           Setting(false), "Non-negative species only", "Prevents species amounts from going negative during a simulation. (bool)", "(bool) Enforce non-negative species constraint.");
@@ -204,6 +204,11 @@ namespace rr
 		bool singleStep;
 		bool varStep = getValue("variable_step_size").get<bool>();
 		auto minTimeStep = getValue("minimum_time_step").get<double>();
+		auto maxTimeStep = getValue("maximum_time_step").get<double>();
+		if (maxTimeStep > minTimeStep)
+		{
+			hstep = std::min(hstep, maxTimeStep);
+		}
 
 		if (varStep)
 		{
@@ -274,7 +279,7 @@ namespace rr
 			else
 			{
 				// no reaction occurs
-				return std::numeric_limits<double>::infinity();
+				return tf;
 			}
 			if (!singleStep && t + tau > tf)        // if time exhausted, don't allow reaction to proceed
 			{

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1865,8 +1865,8 @@ namespace rr {
                     tout = self.integrator->integrate(tout, timeEnd - tout);
 
 
-                    if (!isfinite(tout) || (tout == timeEnd)) {
-                        // time step is at infinity or zero so bail, but get the last value
+                    if (tout >= timeEnd) {
+                        // time step is at infinity or maximum so bail, but get the last value
                         getSelectedValues(row, timeEnd);
                         results.push_back(row);
                         break;

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1864,8 +1864,10 @@ namespace rr {
                                              << ", end: " << timeEnd;
                     tout = self.integrator->integrate(tout, timeEnd - tout);
 
-
-                    if (tout >= timeEnd) {
+                    //If tout is larger than timeEnd but not infinite, this is actually OK, because
+                    // it means that we're just taking a certain number of steps and don't care
+                    // about the time.
+                    if (!isfinite(tout) || (tout == timeEnd)) {
                         // time step is at infinity or maximum so bail, but get the last value
                         getSelectedValues(row, timeEnd);
                         results.push_back(row);

--- a/test/cxx_api_tests/GillespieTests.cpp
+++ b/test/cxx_api_tests/GillespieTests.cpp
@@ -41,3 +41,39 @@ TEST_F(GillespieTests, SetSeedUsingInactiveIntegrator){
     ASSERT_EQ(4, seed);
 }
 
+TEST_F(GillespieTests, MaxStepSize) {
+    RoadRunner rr(3, 1);
+    rr.addCompartment("comp", 1, false);
+    rr.addSpeciesAmount("S1", "comp", 2);
+    rr.setIntegrator("gillespie");
+    rr.getIntegrator()->setValue("maximum_time_step", 25.0);
+    EXPECT_TRUE(rr.getIntegrator()->getValue("maximum_time_step") == 25.0);
+
+    const ls::DoubleMatrix* results = rr.simulate(0, 55, 25);
+    //'results' should have points at 0, 25, 50, and 55, because of the max step size.
+    ASSERT_EQ(results->RSize(), 4);
+    EXPECT_EQ(results->Element(0, 0), 0);
+    EXPECT_NEAR(results->Element(1, 0), 25, 0.001);
+    EXPECT_NEAR(results->Element(2, 0), 50, 0.001);
+    EXPECT_NEAR(results->Element(3, 0), 55, 0.001);
+
+    EXPECT_EQ(results->Element(0, 1), 2.0);
+    EXPECT_EQ(results->Element(1, 1), 2.0);
+    EXPECT_EQ(results->Element(2, 1), 2.0);
+    EXPECT_EQ(results->Element(3, 1), 2.0);
+
+
+    rr.getIntegrator()->setValue("maximum_time_step", 0.0);
+    results = rr.simulate(0, 55, 25);
+    ASSERT_EQ(results->RSize(), 2);
+    EXPECT_EQ(results->Element(0, 0), 0);
+    EXPECT_NEAR(results->Element(1, 0), 55, 0.001);
+
+
+    rr.getIntegrator()->setValue("maximum_time_step", 100.0);
+    results = rr.simulate(0, 55, 25);
+    ASSERT_EQ(results->RSize(), 2);
+    EXPECT_EQ(results->Element(0, 0), 0);
+    EXPECT_NEAR(results->Element(1, 0), 55, 0.001);
+}
+


### PR DESCRIPTION
Neither were being used; initial_time_step doesn't seem to be compatible with the gillespie algorithm, but the max did, so that's now implemented.  Slightly adjusted roadrunner's test condition since exactly comparing calculated doubles isn't a super great idea.