### PR TITLE
Fix SWIG wrapping of various getX functions.

### DIFF
--- a/wrappers/Python/roadrunner/roadrunner.i
+++ b/wrappers/Python/roadrunner/roadrunner.i
@@ -2367,7 +2367,7 @@ namespace std { class ostream{}; }
     }
 
 
-    int setFloatingSpeciesAmounts(size_t leni, int const* indx, int lenv, double const *values) {
+    int setFloatingSpeciesAmounts(size_t leni, int const* indx, size_t lenv, double const *values) {
         if (leni != lenv) {
             PyErr_Format(PyExc_ValueError,
                          "Arrays of lengths (%d,%d) given",
@@ -2378,7 +2378,7 @@ namespace std { class ostream{}; }
     }
 
 
-    int setFloatingSpeciesConcentrations(int leni, int const* indx, int lenv, double const *values) {
+    int setFloatingSpeciesConcentrations(size_t leni, int const* indx, size_t lenv, double const *values) {
         if (leni != lenv) {
             PyErr_Format(PyExc_ValueError,
                          "Arrays of lengths (%d,%d) given",
@@ -2388,7 +2388,7 @@ namespace std { class ostream{}; }
         return $self->setFloatingSpeciesConcentrations(leni, indx, values);
     }
 
-    int setBoundarySpeciesConcentrations(int leni, int const* indx, int lenv, double const *values) {
+    int setBoundarySpeciesConcentrations(size_t leni, int const* indx, size_t lenv, double const *values) {
         if (leni != lenv) {
             PyErr_Format(PyExc_ValueError,
                          "Arrays of lengths (%d,%d) given",
@@ -2398,7 +2398,7 @@ namespace std { class ostream{}; }
         return $self->setBoundarySpeciesConcentrations(leni, indx, values);
     }
 
-    int setGlobalParameterValues(int leni, int const* indx, int lenv, double const *values) {
+    int setGlobalParameterValues(size_t leni, int const* indx, size_t lenv, double const *values) {
         if (leni != lenv) {
             PyErr_Format(PyExc_ValueError,
                          "Arrays of lengths (%d,%d) given",
@@ -2408,7 +2408,7 @@ namespace std { class ostream{}; }
         return $self->setGlobalParameterValues(leni, indx, values);
     }
 
-    int setCompartmentVolumes(int leni, int const* indx, int lenv, double const *values) {
+    int setCompartmentVolumes(size_t leni, int const* indx, size_t lenv, double const *values) {
         if (leni != lenv) {
             PyErr_Format(PyExc_ValueError,
                          "Arrays of lengths (%d,%d) given",
@@ -2418,7 +2418,7 @@ namespace std { class ostream{}; }
         return $self->setCompartmentVolumes(leni, indx, values);
     }
 
-    int setConservedMoietyValues(int leni, int const* indx, int lenv, double const *values) {
+    int setConservedMoietyValues(size_t leni, int const* indx, size_t lenv, double const *values) {
         if (leni != lenv) {
             PyErr_Format(PyExc_ValueError,
                          "Arrays of lengths (%d,%d) given",
@@ -2428,7 +2428,7 @@ namespace std { class ostream{}; }
         return $self->setConservedMoietyValues(leni, indx, values);
     }
 
-    int setFloatingSpeciesInitConcentrations(int leni, int const* indx, int lenv, double const *values) {
+    int setFloatingSpeciesInitConcentrations(size_t leni, int const* indx, size_t lenv, double const *values) {
         if (leni != lenv) {
             PyErr_Format(PyExc_ValueError,
                          "Arrays of lengths (%d,%d) given",
@@ -2439,7 +2439,7 @@ namespace std { class ostream{}; }
     }
 
 
-    int setFloatingSpeciesInitAmounts(int leni, int const* indx, int lenv, double const *values) {
+    int setFloatingSpeciesInitAmounts(size_t leni, int const* indx, size_t lenv, double const *values) {
         if (leni != lenv) {
             PyErr_Format(PyExc_ValueError,
                          "Arrays of lengths (%d,%d) given",
@@ -2450,7 +2450,7 @@ namespace std { class ostream{}; }
     }
 
 
-    int setCompartmentInitVolumes(int leni, int const* indx, int lenv, double const *values) {
+    int setCompartmentInitVolumes(size_t leni, int const* indx, size_t lenv, double const *values) {
         if (leni != lenv) {
             PyErr_Format(PyExc_ValueError,
                          "Arrays of lengths (%d,%d) given",
@@ -2461,7 +2461,7 @@ namespace std { class ostream{}; }
     }
 
 
-    int setFloatingSpeciesInitConcentrations(int leni, int const* indx, int lenv, double const *values) {
+    int setFloatingSpeciesInitConcentrations(size_t leni, int const* indx, size_t lenv, double const *values) {
         if (leni != lenv) {
             PyErr_Format(PyExc_ValueError,
                          "Arrays of lengths (%d,%d) given",
@@ -2471,7 +2471,7 @@ namespace std { class ostream{}; }
         return $self->setFloatingSpeciesInitConcentrations(leni, indx, values);
     }
 
-    int setFloatingSpeciesInitAmounts(int leni, int const* indx, int lenv, double const *values) {
+    int setFloatingSpeciesInitAmounts(size_t leni, int const* indx, size_t lenv, double const *values) {
         if (leni != lenv) {
             PyErr_Format(PyExc_ValueError,
                          "Arrays of lengths (%d,%d) given",
@@ -2482,7 +2482,7 @@ namespace std { class ostream{}; }
     }
 
 
-    int setCompartmentInitVolumes(int leni, int const* indx, int lenv, double const *values) {
+    int setCompartmentInitVolumes(size_t leni, int const* indx, size_t lenv, double const *values) {
         if (leni != lenv) {
             PyErr_Format(PyExc_ValueError,
                          "Arrays of lengths (%d,%d) given",


### PR DESCRIPTION
This turned out to be an issue with SWIG changing, as far as I can tell--it used to translate a Python array into 'int len, type* values', and now it translates it into 'size_t len, type* values', so our old 'int/type' prototype functions no longer matched.  Happily, that meant that it was a relatively straightforward fix.

Fixes #817.