### PR TITLE
Add the ability to set and get the name and id of SBML models.

### DIFF
--- a/source/SBMLValidator.cpp
+++ b/source/SBMLValidator.cpp
@@ -165,6 +165,19 @@ std::string fixMissingStoich(const std::string sbml) {
 
         Model *m = doc->getModel();
 
+        if (!m) {
+            if (doc->getNumErrors(libsbml::LIBSBML_SEV_ERROR) > 0)
+            {
+                const libsbml::SBMLError* err = doc->getError(0); //DEBUG should be doc->getErrorWithSeverity(0, libsbml::LIBSBML_SEV_ERROR); but won't work yet due to libsbml bug.  See https://github.com/sbmlteam/libsbml/pull/169
+                string errmsg = err->getMessage();
+                throw std::runtime_error("SBML document unable to be read.  Error from libsbml:\n" + doc->getErrorWithSeverity(0, libsbml::LIBSBML_SEV_ERROR)->getMessage());
+            }
+            //Otherwise, the document is fine, it just has no model:
+            std::string result = writeSBMLToStdString(doc);
+            delete doc;
+            return result;
+        }
+
         for (unsigned int j = 0; j<m->getNumReactions(); ++j) {
             Reaction* r = m->getReaction(j);
             if (!r)

--- a/source/llvm/LLVMModelDataSymbols.cpp
+++ b/source/llvm/LLVMModelDataSymbols.cpp
@@ -120,20 +120,24 @@ LLVMModelDataSymbols::LLVMModelDataSymbols() :
 }
 
 LLVMModelDataSymbols::LLVMModelDataSymbols(const libsbml::Model *model, unsigned options)
-    :   independentFloatingSpeciesSize(0),
-        independentBoundarySpeciesSize(0),
-        independentGlobalParameterSize(0),
-        independentCompartmentSize(0),
-        independentInitFloatingSpeciesSize(0),
-        independentInitBoundarySpeciesSize(0),
-        independentInitGlobalParameterSize(0),
-        independentInitCompartmentSize(0)
+    : independentFloatingSpeciesSize(0),
+    independentBoundarySpeciesSize(0),
+    independentGlobalParameterSize(0),
+    independentCompartmentSize(0),
+    independentInitFloatingSpeciesSize(0),
+    independentInitBoundarySpeciesSize(0),
+    independentInitGlobalParameterSize(0),
+    independentInitCompartmentSize(0)
 {
     assert(sizeof(modelDataFieldsNames) / sizeof(const char*)
-            == NotSafe_FloatingSpeciesAmounts + 1
-            && "wrong number of items in modelDataFieldsNames");
+        == NotSafe_FloatingSpeciesAmounts + 1
+        && "wrong number of items in modelDataFieldsNames");
 
     modelName = model->getName();
+    if (modelName.empty())
+    {
+        modelName = model->getId();
+    }
 
     // first go through the rules, see if they determine other stuff
     {

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -3039,10 +3039,50 @@ namespace rr {
     }
 
     std::string RoadRunner::getModelName() {
-        return impl->model ? impl->model->getModelName() : std::string("");
+        if (impl->document && impl->document->isSetModel())
+        {
+            libsbml::Model* model = impl->document->getModel();
+            if (model->isSetName())
+            {
+                return model->getName();
+            }
+        }
+        if (impl->model)
+        {
+            return impl->model->getModelName();
+        }
+        return "";
     }
 
-/**
+    void RoadRunner::setModelName(const string& name)
+    {
+        if (impl->document && impl->document->isSetModel())
+        {
+            impl->document->getModel()->setName(name);
+        }
+    }
+
+    std::string RoadRunner::getModelId() {
+        if (impl->document && impl->document->isSetModel())
+        {
+            libsbml::Model* model = impl->document->getModel();
+            if (model->isSetId())
+            {
+                return model->getId();
+            }
+        }
+        return "";
+    }
+
+    void RoadRunner::setModelId(const string& id)
+    {
+        if (impl->document && impl->document->isSetModel())
+        {
+            impl->document->getModel()->setId(id);
+        }
+    }
+
+ /**
  * find an symbol id in the model and set its value.
  */
     static void setSBMLValue(libsbml::Model *model, const std::string &id, double value) {

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -264,6 +264,21 @@ namespace rr {
         std::string getModelName();
 
         /**
+         * sets the model name if a model is loaded.
+         */
+        void setModelName(const std::string& name);
+
+        /**
+         * returns the model id if a model is loaded, empty std::string otherwise.
+         */
+        std::string getModelId();
+
+        /**
+         * sets the model id if a model is loaded.
+         */
+        void setModelId(const std::string& id);
+
+        /**
          * @brief Clears the currently loaded model and all associated memory
          * @details Deletes jitted code and libStruct data
          * @returns True if memory was freed, false if no model was loaded

--- a/test/model_editing/model_editing.cpp
+++ b/test/model_editing/model_editing.cpp
@@ -1524,3 +1524,33 @@ TEST_F(ModelEditingTests, CHECK_REGENERATE) {
 }
 
 
+TEST_F(ModelEditingTests, GET_SET_MODELNAME1) {
+    RoadRunner rri;
+    EXPECT_STREQ(rri.getModelName().c_str(), "");
+    rri.setModelName("test");
+    EXPECT_STREQ(rri.getModelName().c_str(), "test");
+}
+
+TEST_F(ModelEditingTests, GET_SET_MODELNAME2) {
+    RoadRunner rri("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version2/core\" level=\"3\" version=\"2\">\n  <model name=\"foo\"/>\n</sbml>\n");
+    EXPECT_STREQ(rri.getModelName().c_str(), "foo");
+    rri.setModelName("test");
+    EXPECT_STREQ(rri.getModelName().c_str(), "test");
+    EXPECT_STREQ(rri.getSBML().c_str(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version2/core\" level=\"3\" version=\"2\">\n  <model name=\"test\"/>\n</sbml>\n");
+}
+
+TEST_F(ModelEditingTests, GET_SET_MODELID1) {
+    RoadRunner rri;
+    EXPECT_STREQ(rri.getModelId().c_str(), "");
+    rri.setModelId("test");
+    EXPECT_STREQ(rri.getModelId().c_str(), "test");
+}
+
+TEST_F(ModelEditingTests, GET_SET_MODELID2) {
+    RoadRunner rri("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version2/core\" level=\"3\" version=\"2\">\n  <model id=\"foo\"/>\n</sbml>\n");
+    EXPECT_STREQ(rri.getModelId().c_str(), "foo");
+    rri.setModelId("test");
+    EXPECT_STREQ(rri.getModelId().c_str(), "test");
+    EXPECT_STREQ(rri.getSBML().c_str(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version2/core\" level=\"3\" version=\"2\">\n  <model id=\"test\"/>\n</sbml>\n");
+}
+

--- a/wrappers/C/rrc_nom_api.cpp
+++ b/wrappers/C/rrc_nom_api.cpp
@@ -22,6 +22,30 @@ char* rrcCallConv getModelName(RRHandle handle)
     catch_ptr_macro
 }
 
+void rrcCallConv setModelName(RRHandle handle, char* name)
+{
+    start_try
+        RoadRunner* rri = castToRoadRunner(handle);
+        rri->setModelName(name);
+    catch_void_macro
+}
+
+char* rrcCallConv getModelId(RRHandle handle)
+{
+    start_try
+        RoadRunner* rri = castToRoadRunner(handle);
+    return createText(rri->getModelId());
+    catch_ptr_macro
+}
+
+void rrcCallConv setModelId(RRHandle handle, char* id)
+{
+    start_try
+        RoadRunner* rri = castToRoadRunner(handle);
+    rri->setModelId(id);
+    catch_void_macro
+}
+
 int rrcCallConv getNumberOfRules(RRHandle handle)
 {
     start_try

--- a/wrappers/C/rrc_nom_api.h
+++ b/wrappers/C/rrc_nom_api.h
@@ -73,6 +73,33 @@ C_DECL_SPEC int rrcCallConv getNumberOfRules(RRHandle handle);
 C_DECL_SPEC char* rrcCallConv getModelName(RRHandle handle);
 
 
+/*!
+ \brief Sets the name of currently loaded SBML model
+ \param[in] handle Handle to a RoadRunner instance
+ \param[name] The new name to use
+ \ingroup NOM functions
+*/
+C_DECL_SPEC void rrcCallConv setModelName(RRHandle handle, char* name);
+
+
+/*!
+ \brief Returns the id of currently loaded SBML model
+ \param[in] handle Handle to a RoadRunner instance
+ \return Returns a char* containing the id if successful, NULL otherwise
+ \ingroup NOM functions
+*/
+C_DECL_SPEC char* rrcCallConv getModelId(RRHandle handle);
+
+
+/*!
+ \brief Sets the id of currently loaded SBML model
+ \param[in] handle Handle to a RoadRunner instance
+ \param[id] The new id to use
+ \ingroup NOM functions
+*/
+C_DECL_SPEC void rrcCallConv setModelId(RRHandle handle, char* id);
+
+
 //---------------------------------------------------------------------------
 #if defined(__cplusplus)
 }	//Extern "C"

--- a/wrappers/Python/roadrunner/roadrunner.i
+++ b/wrappers/Python/roadrunner/roadrunner.i
@@ -662,7 +662,6 @@ PyObject *Integrator_NewPythonObj(rr::Integrator* i) {
 //%ignore rr::RoadRunner::getStoichiometryMatrix;
 %ignore rr::RoadRunner::setNumPoints;
 //%ignore rr::RoadRunner::getConservationMatrix;
-%ignore rr::RoadRunner::getModelName;
 %ignore rr::RoadRunner::getTempFolder;
 %ignore rr::RoadRunner::setParameterValue;
 //%ignore rr::RoadRunner::getConservedMoietyIds;


### PR DESCRIPTION
There was already a roadrunner getModelName function and an executable model getModelName function (the former of which was explicitly excluded from the python interface), but this will allow users to set and get both the name and the id at will.  I also changed the model getModelName function so it uses the id if the name isn't set.

As part of testing this functionality, noticed that invalid SBML fails due to an invalid read, so fixed that to properly throw a more informative error.  In the course of doing that, found a libsbml bug, which I submitted a fix for (https://github.com/sbmlteam/libsbml/pull/169)