### PR TITLE
Modern LLVM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ install-release
 build-debug
 build-release
 install-debug
-roadrunner-install-rel
+roadrunner-install-*
 
 # temp.
 sundials

--- a/source/llvm/LLVMCompiler.cpp
+++ b/source/llvm/LLVMCompiler.cpp
@@ -73,7 +73,7 @@ std::string LLVMCompiler::getProcessTriple()
 
 std::string LLVMCompiler::getHostCPUName()
 {
-    return llvm::sys::getHostCPUName();
+    return llvm::sys::getHostCPUName().str();
 }
 
 std::string LLVMCompiler::getVersion()

--- a/source/llvm/LLVMIncludes.h
+++ b/source/llvm/LLVMIncludes.h
@@ -28,6 +28,12 @@
 #pragma warning( disable : 4244 )
 #endif
 
+
+#if (LLVM_VERSION_MAJOR >= 12)
+#include "llvm/Transforms/InstCombine/InstCombine.h"
+
+#endif
+
 #if (LLVM_VERSION_MAJOR >= 6)
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/DerivedTypes.h>

--- a/source/llvm/ModelDataIRBuilder.cpp
+++ b/source/llvm/ModelDataIRBuilder.cpp
@@ -151,13 +151,27 @@ llvm::Value* ModelDataIRBuilder::createGEP(ModelDataFields field,
     }
 }
 
+/**
+ * @brief abstract out the llvm::StructType::getTypeByName which
+ * has been removed in llvm 12.
+ */
+llvm::StructType *getTypeByName(llvm::Module *module, std::string name)
+{
+    llvm::StructType *t;
+#if LLVM_VERSION_MAJOR >= 12
+    t = llvm::StructType::getTypeByName(module->getContext(), name);
+#else
+    t = module->getTypeByName(name);
+#endif
+  return t;
+}
 
 
 
 llvm::StructType* ModelDataIRBuilder::getCSRSparseStructType(
         llvm::Module* module, llvm::ExecutionEngine* engine)
 {
-    StructType *structType = module->getTypeByName(csr_matrixName);
+    StructType *structType = getTypeByName(module, csr_matrixName);
 
     if (!structType)
     {
@@ -620,7 +634,7 @@ void ModelDataIRBuilder::validateStruct(llvm::Value* s,
 llvm::StructType *ModelDataIRBuilder::createModelDataStructType(llvm::Module *module,
         llvm::ExecutionEngine *engine, LLVMModelDataSymbols const& symbols)
 {
-    StructType *structType = module->getTypeByName(LLVMModelDataName);
+    StructType *structType = getTypeByName(module, LLVMModelDataName);
 
     if (!structType)
     {
@@ -718,7 +732,7 @@ llvm::StructType *ModelDataIRBuilder::createModelDataStructType(llvm::Module *mo
 
 llvm::StructType *ModelDataIRBuilder::getStructType(llvm::Module *module)
 {
-    StructType *structType = module->getTypeByName(LLVMModelDataName);
+    StructType *structType = getTypeByName(module, LLVMModelDataName);
 
     if (structType == 0)
     {


### PR DESCRIPTION
I thought I'd give this another pop and it turned out to not be all that hard. This PR uses `'ifdefs` to switch between llvm versions at critical spots in the roadrunner code. I've tested the build on Windows with both llvm-6 and llvm-12. We observe a modest performance improvement just by switching to llvm-12. The latest llvm version is 13, but since I installed the modern llvm via vcpkg I've only tested version 12. 

As a very (very) rough performance measure, here's how long it took to run  [this](http://sys-bio.github.io/roadrunner/docs-build/parallel/parallel_index.html#serial-code) example from the docs (see below).

Modern LLVM still provides access to the MCJit, which is used by roadrunner - even though this is largely a deprecated API. More performance improvements may yet be gained by switching to their modern "ORC" Jit.

```
llvm 6
-------
Took 86.46492576599121 seconds to run 1000000 stochastic simulations on 1 core
Platform: Windows-10-10.0.22000-SP0
python_version: 3.9.5.final.0 (64 bit)
Processor: 11th Gen Intel(R) Core(TM) i9-11980HK @ 2.60GHz

Took 81.99151563644409 seconds to run 1000000 stochastic simulations on 1 core
Platform: Windows-10-10.0.22000-SP0
python_version: 3.9.5.final.0 (64 bit)
Processor: 11th Gen Intel(R) Core(TM) i9-11980HK @ 2.60GHz

Took 81.62831592559814 seconds to run 1000000 stochastic simulations on 1 core
Platform: Windows-10-10.0.22000-SP0
python_version: 3.9.5.final.0 (64 bit)
Processor: 11th Gen Intel(R) Core(TM) i9-11980HK @ 2.60GHz

llvm 12
--------

Took 79.52541327476501 seconds to run 1000000 stochastic simulations on 1 core
Platform: Windows-10-10.0.22000-SP0
python_version: 3.9.5.final.0 (64 bit)
Processor: 11th Gen Intel(R) Core(TM) i9-11980HK @ 2.60GHz

Took 80.61383438110352 seconds to run 1000000 stochastic simulations on 1 core
Platform: Windows-10-10.0.22000-SP0
python_version: 3.9.5.final.0 (64 bit)
Processor: 11th Gen Intel(R) Core(TM) i9-11980HK @ 2.60GHz

Took 77.75305724143982 seconds to run 1000000 stochastic simulations on 1 core
Platform: Windows-10-10.0.22000-SP0
python_version: 3.9.5.final.0 (64 bit)
Processor: 11th Gen Intel(R) Core(TM) i9-11980HK @ 2.60GHz

```