### PR TITLE
Fix the sequential times vs. start/end/points bug.

### DIFF
--- a/source/rrRoadRunnerOptions.cpp
+++ b/source/rrRoadRunnerOptions.cpp
@@ -60,6 +60,18 @@ namespace rr {
     {
     }
 
+    void SimulateOptions::reset()
+    {
+        reset_model = false;
+        structured_result = Config::getBool(Config::SIMULATEOPTIONS_STRUCTURED_RESULT);
+        copy_result = Config::getBool(Config::SIMULATEOPTIONS_COPY_RESULT);
+        steps = Config::getInt(Config::SIMULATEOPTIONS_STEPS);
+        start = 0;
+        duration = Config::getDouble(Config::SIMULATEOPTIONS_DURATION);
+        times.clear();
+        hstep = 0;
+    }
+
     void SimulateOptions::loadSBMLSettings(const std::string &fname) {
         if (!fname.size()) {
             rrLog(Logger::LOG_ERROR) << "Empty file name for setings file";

--- a/source/rrRoadRunnerOptions.h
+++ b/source/rrRoadRunnerOptions.h
@@ -344,6 +344,11 @@ namespace rr
 
 		virtual double getNext(size_t step);
 
+		/**
+		* Reset all values to defaults. 
+		*/
+		virtual void reset();
+
     private:
 
 		double hstep; //Used if we have a duration and number of steps, but not 'times'.

--- a/wrappers/Python/roadrunner/roadrunner.i
+++ b/wrappers/Python/roadrunner/roadrunner.i
@@ -1454,6 +1454,7 @@ namespace std { class ostream{}; }
             o = self.__simulateOptions
             originalSteps = o.steps
             originalVSS = True;
+            o.reset()
 
             if self.getIntegrator().hasValue('variable_step_size'):
                 originalVSS = self.getIntegrator().getValue('variable_step_size')
@@ -1471,6 +1472,9 @@ namespace std { class ostream{}; }
 
             if points is not None:
                 o.steps = points - 1
+            elif steps is not None:
+                o.steps = steps
+
 
             if selections is not None:
                 self.timeCourseSelections = selections
@@ -1484,9 +1488,6 @@ namespace std { class ostream{}; }
                 o.output_file = output_file
             else:
                 o.output_file = ""
-
-            if steps is not None:
-                o.steps = steps
 
             result = self._simulate(o)
 


### PR DESCRIPTION
The python version of the simulate functions starts with the built-in 'opt' object, which persists from simulation to simulation.  This probably has always been a problem, but it was exacerbated by the new 'times' option, which is incompatible with the 'start/end/points' options.  So, add a new 'reset' function to the Options object, and use it when calling 'simulate'.