### PR TITLE
Properly raise AttributeError with __getattr__

### DIFF
--- a/test/model_editing/model_editing.cpp
+++ b/test/model_editing/model_editing.cpp
@@ -1082,6 +1082,24 @@ TEST_F(ModelEditingTests, REMOVE_PARAM_RECURSE_2) {
     }));
 }
 
+TEST_F(ModelEditingTests, REMOVE_ELEMENT_ASNT_RULE) {
+    RoadRunner rri((rrTestDir_ / path("models/ModelEditingTests/assignment_rule_species.xml")).string());
+    rri.removeSpecies("S1");
+    vector<string> arids = rri.getAssignmentRuleIds();
+    EXPECT_EQ(arids.size(), 0);
+    const ls::DoubleMatrix* results = rri.simulate();
+    EXPECT_EQ(results->numCols(), 2);
+}
+
+TEST_F(ModelEditingTests, REMOVE_ELEMENT_RATE_RULE) {
+    RoadRunner rri((rrTestDir_ / path("models/ModelEditingTests/assignment_rule_species.xml")).string());
+    rri.removeSpecies("S2");
+    vector<string> rrids = rri.getRateRuleIds();
+    EXPECT_EQ(rrids.size(), 0);
+    const ls::DoubleMatrix* results = rri.simulate();
+    EXPECT_EQ(results->numCols(), 2);
+}
+
 TEST_F(ModelEditingTests, FROM_SCRATCH_1) {
     ASSERT_TRUE(RunTestModelFromScratch([](RoadRunner *rri) {
         rri->addCompartment("compartment", 1);

--- a/test/models/ModelEditingTests/assignment_rule_species.xml
+++ b/test/models/ModelEditingTests/assignment_rule_species.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.13.0 with libSBML version 5.19.1. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="S1" compartment="default_compartment" initialConcentration="3" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S2" compartment="default_compartment" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfRules>
+      <assignmentRule variable="S1">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <cn type="integer"> 3 </cn>
+        </math>
+      </assignmentRule>
+      <rateRule variable="S2">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <cn type="integer"> 1 </cn>
+        </math>
+      </rateRule>
+    </listOfRules>
+  </model>
+</sbml>

--- a/wrappers/Python/roadrunner/roadrunner.i
+++ b/wrappers/Python/roadrunner/roadrunner.i
@@ -2700,8 +2700,10 @@ namespace std { class ostream{}; }
         def __getattr__(self, name):
             if name in self.getSettings():
                 return Solver.getValue(self, name)
-            else:
+            elif name in self.__dict__:
                 return self.__dict__[name]
+            else:
+                raise AttributeError(name)
 
         def __setattr__(self, name, value):
             if(name != 'this' and name in self.getSettings()):
@@ -2783,8 +2785,10 @@ namespace std { class ostream{}; }
         def __getattr__(self, name):
             if(name in self.getSettings()):
                 return Solver.getValue(self, name)
-            else:
+            elif name in self.__dict__:
                 return self.__dict__[name]
+            else:
+                raise AttributeError(name)
 
         def __setattr__(self, name, value):
             if(name != 'this' and name in self.getSettings()):
@@ -2813,8 +2817,10 @@ namespace std { class ostream{}; }
         def __getattr__(self, name):
             if(name in self.getSettings()):
                 return Solver.getValue(self, name)
-            else:
+            elif name in self.__dict__:
                 return self.__dict__[name]
+            else:
+                raise AttributeError(name)
 
         def __setattr__(self, name, value):
             if(name != 'this' and name in self.getSettings()):


### PR DESCRIPTION
Addresses #901:  hasattr was failing because __getattr__ wasn't raising an AttributeError on failure.

Not sure if this ever worked, despite the report.  Other objects in roadrunner had correct __getattr__functions that properly failed, but 3 of the 4 defined here did not.  Affected the Solver, the SteadyStateSolver, and the Integrator.  (The RoadRunner object was fine.)