### PR TITLE
Fix https://github.com/sys-bio/roadrunner/issues/905

### DIFF
--- a/source/SBMLValidator.cpp
+++ b/source/SBMLValidator.cpp
@@ -168,9 +168,13 @@ std::string fixMissingStoichAndMath(const std::string sbml) {
         if (!m) {
             if (doc->getNumErrors(libsbml::LIBSBML_SEV_ERROR) > 0)
             {
-                const libsbml::SBMLError* err = doc->getError(0); //DEBUG should be doc->getErrorWithSeverity(0, libsbml::LIBSBML_SEV_ERROR); but won't work yet due to libsbml bug.  See https://github.com/sbmlteam/libsbml/pull/169
-                string errmsg = err->getMessage();
-                throw std::runtime_error("SBML document unable to be read.  Error from libsbml:\n" + doc->getErrorWithSeverity(0, libsbml::LIBSBML_SEV_ERROR)->getMessage());
+                const libsbml::SBMLError* err = doc->getErrorWithSeverity(0, libsbml::LIBSBML_SEV_ERROR); //Will only work on XML errors after https://github.com/sbmlteam/libsbml/pull/169
+                string errmsg = "  The XML content is incorrect.";
+                if (err)
+                {
+                    errmsg = "  Error from libsbml:\n" + err->getMessage();
+                }
+                throw std::runtime_error("SBML document unable to be read." + errmsg);
             }
             //Otherwise, the document is fine, it just has no model:
             std::string result = writeSBMLToStdString(doc);

--- a/test/sbml_features/CMakeLists.txt
+++ b/test/sbml_features/CMakeLists.txt
@@ -2,6 +2,7 @@ add_test_executable(
         test_sbml_features test_targets
         ${SharedTestFiles}
         boolean_delay.cpp
+        invalid_sbml.cpp
 )
 
 # make test_targets list global to all tests

--- a/test/sbml_features/invalid_sbml.cpp
+++ b/test/sbml_features/invalid_sbml.cpp
@@ -1,0 +1,27 @@
+#include "gtest/gtest.h"
+#include "rrRoadRunner.h"
+#include "rrException.h"
+#include "rrUtils.h"
+#include "rrTestSuiteModelSimulation.h"
+#include "sbml/SBMLTypes.h"
+#include "sbml/SBMLReader.h"
+#include "../test_util.h"
+#include <filesystem>
+#include "RoadRunnerTest.h"
+
+using namespace testing;
+using namespace rr;
+using namespace std;
+using std::filesystem::path;
+
+class SBMLFeatures : public RoadRunnerTest {
+public:
+    path SBMLFeaturesDir = rrTestModelsDir_ / "SBMLFeatures";
+    SBMLFeatures() = default;
+};
+
+TEST_F(SBMLFeatures, InvalidSBML_badXML)
+{
+    EXPECT_THROW(RoadRunner rri("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n  <model metaid=\"x\" id=\"x\">\n    <listOfCompartments>\n      <compartment sboTerm=\"SBO:0000410\" id=\"default_compartment\" spatialDimensions=\"3\" size=\"1\" constant=\"true\"/>\n    </listOfCompartments>\n  </model>\n</sbml>\n2.0.5"), std::runtime_error);
+}
+


### PR DESCRIPTION
Correctly pass error message from libsbml

The problem here turned out to be in part a bug in libsbml that would return NULL instead of the error in question if the error was an XML error and not an SBML Error.  I worked with the libsbml team to fix this, but in the meantime, this changed code should work both with the current SBML and the fixed version (the fixed version will have more information, though).