### PR TITLE
Allow a wider variety of selections.

### DIFF
--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -1222,7 +1222,7 @@ double LLVMExecutableModel::getValue(const std::string& id)
         getFloatingSpeciesAmountRates(1, &index, &result);
         break;
     case SelectionRecord::GLOBAL_PARAMETER_RATE:
-        getRateRueRates(1, &index, &result);
+        getRateRuleRates(1, &index, &result);
         break;
     case SelectionRecord::INITIAL_FLOATING_AMOUNT:
         getFloatingSpeciesInitAmounts(1, &index, &result);
@@ -1998,7 +1998,7 @@ int LLVMExecutableModel::getFloatingSpeciesAmountRates(size_t len,
 }
 
 
-int LLVMExecutableModel::getRateRueRates(size_t len,
+int LLVMExecutableModel::getRateRuleRates(size_t len,
         int const *indx, double *values)
 {
     uint dydtSize = modelData->numRateRules;

--- a/source/llvm/LLVMExecutableModel.h
+++ b/source/llvm/LLVMExecutableModel.h
@@ -565,7 +565,7 @@ public:
      * calculate rate rule values.
      * TODO redo this function, not very effecient.
      */
-    int getRateRueRates(size_t len, int const *indx, double *values);
+    virtual int getRateRuleRates(size_t len, int const *indx, double *values);
 
 
     /**

--- a/source/rrExecutableModel.cpp
+++ b/source/rrExecutableModel.cpp
@@ -135,4 +135,9 @@ namespace rr
         mIntegrationStartTime = time;
     }
 
+    int ExecutableModel::getRateRuleRates(size_t len, int const* indx, double* values)
+    {
+        return -1;
+    }
+
 } // namespace rr

--- a/source/rrExecutableModel.h
+++ b/source/rrExecutableModel.h
@@ -570,10 +570,10 @@ namespace rr {
         /**
          * get the std::vector of reaction rates.
          *
-         * @param len: the length of the suplied buffer, must be >= reaction rates size.
+         * @param len: the length of the supplied buffer, must be >= reaction rates size.
          * @param indx: pointer to index array. If NULL, then it is ignored and the
-         * reaction rates are copied directly into the suplied buffer.
-         * @param values: pointer to user suplied buffer where rates will be stored.
+         * reaction rates are copied directly into the supplied buffer.
+         * @param values: pointer to user supplied buffer where rates will be stored.
          */
         virtual int getReactionRates(size_t len, int const *indx,
                                      double *values) = 0;
@@ -586,6 +586,17 @@ namespace rr {
          * rate rules we have.
          */
         virtual void getRateRuleValues(double *rateRuleValues) = 0;
+
+        /**
+         * get the 'rates' i.e. the what the rate rule integrates to, and
+         * store it in the given array.
+         *
+         * @param len: the length of the supplied buffer, must be >= reaction rates size.
+         * @param indx: pointer to index array. If NULL, then it is ignored and the
+         * rates are copied directly into the supplied buffer.
+         * @param values: pointer to user supplied buffer where rates will be stored.
+         */
+        virtual int getRateRuleRates(size_t len, int const* indx, double* values);
 
         /**
          * get the id of an element of the state std::vector.

--- a/source/rrNLEQ1Interface.cpp
+++ b/source/rrNLEQ1Interface.cpp
@@ -18,7 +18,7 @@ namespace rr
 
 // NLEQ is an ancient Fortran77 routine that assumes that there is only
 // one program which has a hard coded function in it.
-// So, there is no concept of a user suplied data block, have to store
+// So, there is no concept of a user supplied data block, have to store
 // the model in this static location -- only a single thread at a time
 // may use the nleq steady state.
 static ExecutableModel* callbackModel = NULL;

--- a/source/rrNLEQ2Interface.cpp
+++ b/source/rrNLEQ2Interface.cpp
@@ -18,7 +18,7 @@ namespace rr
 
 // NLEQ is an ancient Fortran77 routine that assumes that there is only
 // one program which has a hard coded function in it.
-// So, there is no concept of a user suplied data block, have to store
+// So, there is no concept of a user supplied data block, have to store
 // the model in this static location -- only a single thread at a time
 // may use the nleq steady state.
 static ExecutableModel* callbackModel = NULL;

--- a/source/rrSelectionRecord.cpp
+++ b/source/rrSelectionRecord.cpp
@@ -134,6 +134,24 @@ static bool is_concentration(const std::string& str, std::string& p1)
     }
 }
 
+static const Poco::RegularExpression is_concentration_rate_re("^\\s*\\[\\s*(\\w*)\\s*\\]\\'\\s*$", RegularExpression::RE_CASELESS);
+static bool is_concentration_rate(const std::string& str, std::string& p1)
+{
+    std::vector<std::string> matches;
+
+    int nmatch = is_concentration_rate_re.split(str, matches);
+
+    if (nmatch == 2)
+    {
+        p1 = matches[1];
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
 static const Poco::RegularExpression is_symbol_re("^\\s*(\\w*)\\s*$", RegularExpression::RE_CASELESS);
 static bool is_symbol(const std::string& str, std::string& p1)
 {
@@ -261,7 +279,7 @@ std::ostream& operator<<(std::ostream& stream, const SelectionRecord& rec)
     stream << "A Selection Record --" << std::endl;
     stream << "Index: " << rec.index << std::endl;
     stream << "p1: " << rec.p1 << std::endl;
-    stream << "p2: " << rec.p1 << std::endl;
+    stream << "p2: " << rec.p2 << std::endl;
     stream << "SelectionType: " << rec.selectionType << std::endl;
     return stream;
 }
@@ -332,6 +350,10 @@ rr::SelectionRecord::SelectionRecord(const std::string str) :
     {
         selectionType = UNKNOWN_CONCENTRATION;
     }
+    else if (is_concentration_rate(str, p1))
+    {
+        selectionType = FLOATING_CONCENTRATION_RATE;
+    }
     else if(is_amount_rate(str, p1))
     {
         selectionType = FLOATING_AMOUNT_RATE;
@@ -382,8 +404,12 @@ std::string rr::SelectionRecord::to_string() const
     case UNKNOWN_CONCENTRATION:
         result = "[" + p1 + "]";
         break;
+    case FLOATING_CONCENTRATION_RATE:
+        result = "[" + p1 + "]'";
+        break;
     case FLOATING_AMOUNT_RATE:
     case GLOBAL_PARAMETER_RATE:
+    case COMPARTMENT_RATE:
         result = p1 + "'";
         break;
     case COMPARTMENT:
@@ -416,9 +442,15 @@ std::string rr::SelectionRecord::to_string() const
         result = "eigenImag(" + p1 + ")";
         break;
     case INITIAL_AMOUNT:
+    case INITIAL_FLOATING_AMOUNT:
+    case INITIAL_BOUNDARY_AMOUNT:
+    case INITIAL_GLOBAL_PARAMETER:
+    case INITIAL_COMPARTMENT:
         result = "init(" + p1 + ")";
         break;
     case INITIAL_CONCENTRATION:
+    case INITIAL_FLOATING_CONCENTRATION:
+    case INITIAL_BOUNDARY_CONCENTRATION:
         result = "init([" + p1 + "])";
         break;
     case STOICHIOMETRY:
@@ -426,9 +458,6 @@ std::string rr::SelectionRecord::to_string() const
         break;
     case UNKNOWN:
         result = "UNKNOWN";
-        break;
-    case INITIAL_GLOBAL_PARAMETER:
-        result = "init(" + p1 + ")";
         break;
     default:
         result = "ERROR";

--- a/source/rrSelectionRecord.h
+++ b/source/rrSelectionRecord.h
@@ -254,6 +254,11 @@ public:
         REACTION_RATE =                     REACTION | RATE | DEPENDENT,
 
         /**
+         * SelectionType for compartment rate, always current
+         */
+        COMPARTMENT_RATE =                  COMPARTMENT | RATE | DEPENDENT,
+
+        /**
          * SelectionType for initial species amounts.
          */
         INITIAL_AMOUNT =                    INITIAL | AMOUNT | INDEPENDENT | DEPENDENT,

--- a/source/testing/CXXBrusselatorExecutableModel.h
+++ b/source/testing/CXXBrusselatorExecutableModel.h
@@ -438,10 +438,10 @@ public:
     /**
      * get the std::vector of reaction rates.
      *
-     * @param len: the length of the suplied buffer, must be >= reaction rates size.
+     * @param len: the length of the supplied buffer, must be >= reaction rates size.
      * @param indx: pointer to index array. If NULL, then it is ignored and the
-     * reaction rates are copied directly into the suplied buffer.
-     * @param values: pointer to user suplied buffer where rates will be stored.
+     * reaction rates are copied directly into the supplied buffer.
+     * @param values: pointer to user supplied buffer where rates will be stored.
      */
     virtual int getReactionRates(size_t len, int const *indx,
                 double *values) override;

--- a/source/testing/CXXEnzymeExecutableModel.h
+++ b/source/testing/CXXEnzymeExecutableModel.h
@@ -457,10 +457,10 @@ public:
     /**
      * get the std::vector of reaction rates.
      *
-     * @param len: the length of the suplied buffer, must be >= reaction rates size.
+     * @param len: the length of the supplied buffer, must be >= reaction rates size.
      * @param indx: pointer to index array. If NULL, then it is ignored and the
-     * reaction rates are copied directly into the suplied buffer.
-     * @param values: pointer to user suplied buffer where rates will be stored.
+     * reaction rates are copied directly into the supplied buffer.
+     * @param values: pointer to user supplied buffer where rates will be stored.
      */
     virtual int getReactionRates(size_t len, int const *indx,
                 double *values) override;

--- a/source/testing/CXXExecutableModel.h
+++ b/source/testing/CXXExecutableModel.h
@@ -431,10 +431,10 @@ public:
     /**
      * get the std::vector of reaction rates.
      *
-     * @param len: the length of the suplied buffer, must be >= reaction rates size.
+     * @param len: the length of the supplied buffer, must be >= reaction rates size.
      * @param indx: pointer to index array. If NULL, then it is ignored and the
-     * reaction rates are copied directly into the suplied buffer.
-     * @param values: pointer to user suplied buffer where rates will be stored.
+     * reaction rates are copied directly into the supplied buffer.
+     * @param values: pointer to user supplied buffer where rates will be stored.
      */
     virtual int getReactionRates(size_t len, int const *indx,
                 double *values);

--- a/source/testing/CXXPiecewiseExecutableModel.h
+++ b/source/testing/CXXPiecewiseExecutableModel.h
@@ -439,10 +439,10 @@ public:
     /**
      * get the std::vector of reaction rates.
      *
-     * @param len: the length of the suplied buffer, must be >= reaction rates size.
+     * @param len: the length of the supplied buffer, must be >= reaction rates size.
      * @param indx: pointer to index array. If NULL, then it is ignored and the
-     * reaction rates are copied directly into the suplied buffer.
-     * @param values: pointer to user suplied buffer where rates will be stored.
+     * reaction rates are copied directly into the supplied buffer.
+     * @param values: pointer to user supplied buffer where rates will be stored.
      */
     virtual int getReactionRates(size_t len, int const *indx,
                 double *values) override;

--- a/test/cxx_api_tests/SelectionRecordTests.cpp
+++ b/test/cxx_api_tests/SelectionRecordTests.cpp
@@ -6,6 +6,7 @@
 #include "rrSelectionRecord.h"
 #include "rrRoadRunner.h"
 #include "TestModelFactory.h"
+#include "RoadRunnerTest.h"
 
 using namespace rr;
 using namespace testing;
@@ -15,7 +16,7 @@ using namespace testing;
  *
  */
 
-class SelectionRecordTests: public ::testing::Test {
+class SelectionRecordTests: public RoadRunnerTest {
 public:
     SelectionRecordTests() {
         //std::cout << TestModelFactory("SimpleFlux")->str() << std::endl;
@@ -27,248 +28,211 @@ TEST_F(SelectionRecordTests, TIME) {
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
     SelectionRecord record = rr.createSelection("time");
-    ASSERT_EQ(record.selectionType, SelectionRecord::TIME);
-    ASSERT_EQ(record.index, -1);
+    EXPECT_EQ(record.selectionType, SelectionRecord::TIME);
+    EXPECT_EQ(record.index, -1);
+    EXPECT_EQ(record.p1, "");
+    EXPECT_EQ(record.p2, "");
     delete testModel;
 }
 
-TEST_F(SelectionRecordTests, CONCENTRATION) {}
-
-TEST_F(SelectionRecordTests, AMOUNT) {}
-
-TEST_F(SelectionRecordTests, RATE) {
+TEST_F(SelectionRecordTests, REACTION_RATE) {
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
     SelectionRecord record = rr.createSelection("_J1");
-    ASSERT_EQ(record.selectionType, SelectionRecord::REACTION_RATE);
-    std::cout << record << std::endl;
+    EXPECT_EQ(record.selectionType, SelectionRecord::REACTION_RATE);
+    EXPECT_EQ(record.index, 1);
+    EXPECT_EQ(record.p1, "_J1");
+    EXPECT_EQ(record.p2, "");
     delete testModel;
 }
 
-TEST_F(SelectionRecordTests, BOUNDARY) {
+TEST_F(SelectionRecordTests, BOUNDARY_CONCENTRATION) {
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
     rr.setBoundary("S1", true, true);
     SelectionRecord record = rr.createSelection("[S1]");
-    ASSERT_EQ(record.selectionType, SelectionRecord::BOUNDARY_CONCENTRATION);
-    std::cout << record << std::endl;
+    EXPECT_EQ(record.selectionType, SelectionRecord::BOUNDARY_CONCENTRATION);
+    EXPECT_STREQ(record.to_string().c_str(), "[S1]");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "S1");
+    EXPECT_EQ(record.p2, "");
+    delete testModel;
+}
+
+TEST_F(SelectionRecordTests, BOUNDARY_AMOUNT) {
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    rr.setBoundary("S1", true, true);
+    SelectionRecord record = rr.createSelection("S1");
+    EXPECT_EQ(record.selectionType, SelectionRecord::BOUNDARY_AMOUNT);
+    EXPECT_STREQ(record.to_string().c_str(), "S1");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "S1");
+    EXPECT_EQ(record.p2, "");
     delete testModel;
 }
 
 TEST_F(SelectionRecordTests, UNKNOWN) {
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
-    ASSERT_THROW(
+    EXPECT_THROW(
         SelectionRecord record = rr.createSelection("random");,
         Exception
     );
     delete testModel;
 }
 
-//TEST_F(SelectionRecordTests, FLOATING){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::FLOATING);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::FLOATING);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, _COMPARTMENT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::_COMPARTMENT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::_COMPARTMENT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, _GLOBAL_PARAMETER){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::_GLOBAL_PARAMETER);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::_GLOBAL_PARAMETER);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, REACTION){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::REACTION);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::REACTION);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, INITIAL){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::INITIAL);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::INITIAL);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, CURRENT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::CURRENT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::CURRENT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, UNSCALED){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::UNSCALED);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::UNSCALED);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, ELASTICITY){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::ELASTICITY);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::ELASTICITY);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, CONTROL){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::CONTROL);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::CONTROL);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, EIGENVALUE_REAL){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::EIGENVALUE_REAL);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::EIGENVALUE_REAL);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, ELEMENT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::ELEMENT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::ELEMENT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, STOICHIOMETRY){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::STOICHIOMETRY);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::STOICHIOMETRY);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, UNKNOWN){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::UNKNOWN);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::UNKNOWN);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, DEPENDENT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::DEPENDENT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::DEPENDENT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, INDEPENDENT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::INDEPENDENT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::INDEPENDENT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, CONSERVED_MOIETY){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::CONSERVED_MOIETY);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::CONSERVED_MOIETY);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, STATE_VECTOR){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::STATE_VECTOR);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::STATE_VECTOR);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, EVENT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::EVENT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::EVENT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, EIGENVALUE_IMAG){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::EIGENVALUE_IMAG);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::EIGENVALUE_IMAG);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, ALL){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::ALL);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::ALL);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, EIGENVALUE_COMPLEX){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::EIGENVALUE_COMPLEX);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::EIGENVALUE_COMPLEX);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, UNKNOWN_CONCENTRATION){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::UNKNOWN_CONCENTRATION);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::UNKNOWN_CONCENTRATION);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
+TEST_F(SelectionRecordTests, FLOATING_AMOUNT){
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    SelectionRecord record = rr.createSelection("S2");
+    EXPECT_EQ(record.selectionType, SelectionRecord::FLOATING_AMOUNT);
+    EXPECT_STREQ(record.to_string().c_str(), "S2");
+    EXPECT_EQ(record.index, 1);
+    EXPECT_EQ(record.p1, "S2");
+    EXPECT_EQ(record.p2, "");
+    delete testModel;
+}
+
+TEST_F(SelectionRecordTests, FLOATING_CONCENTRATION) {
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    SelectionRecord record = rr.createSelection("[S2]");
+    EXPECT_EQ(record.selectionType, SelectionRecord::FLOATING_CONCENTRATION);
+    EXPECT_STREQ(record.to_string().c_str(), "[S2]");
+    EXPECT_EQ(record.index, 1);
+    EXPECT_EQ(record.p1, "S2");
+    EXPECT_EQ(record.p2, "");
+    delete testModel;
+}
+
+TEST_F(SelectionRecordTests, INITIAL_FLOATING_AMOUNT){
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    SelectionRecord record = rr.createSelection("init(S2)");
+    EXPECT_EQ(record.selectionType, SelectionRecord::INITIAL_FLOATING_AMOUNT);
+    EXPECT_STREQ(record.to_string().c_str(), "init(S2)");
+    EXPECT_EQ(record.index, 1);
+    EXPECT_EQ(record.p1, "S2");
+    EXPECT_EQ(record.p2, "");
+    delete testModel;
+}
+
+TEST_F(SelectionRecordTests, INITIAL_FLOATING_CONCENTRATION) {
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    SelectionRecord record = rr.createSelection("init([S2])");
+    EXPECT_EQ(record.selectionType, SelectionRecord::INITIAL_FLOATING_CONCENTRATION);
+    EXPECT_STREQ(record.to_string().c_str(), "init([S2])");
+    EXPECT_EQ(record.index, 1);
+    EXPECT_EQ(record.p1, "S2");
+    EXPECT_EQ(record.p2, "");
+    delete testModel;
+}
+
+TEST_F(SelectionRecordTests, INITIAL_BOUNDARY_AMOUNT) {
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    rr.setBoundary("S1", true, true);
+    SelectionRecord record = rr.createSelection("init(S1)");
+    EXPECT_EQ(record.selectionType, SelectionRecord::INITIAL_BOUNDARY_AMOUNT);
+    EXPECT_STREQ(record.to_string().c_str(), "init(S1)");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "S1");
+    EXPECT_EQ(record.p2, "");
+    delete testModel;
+}
+
+TEST_F(SelectionRecordTests, INITIAL_BOUNDARY_CONCENTRATION) {
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    rr.setBoundary("S1", true, true);
+    SelectionRecord record = rr.createSelection("init([S1])");
+    EXPECT_EQ(record.selectionType, SelectionRecord::INITIAL_BOUNDARY_CONCENTRATION);
+    EXPECT_STREQ(record.to_string().c_str(), "init([S1])");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "S1");
+    EXPECT_EQ(record.p2, "");
+    delete testModel;
+}
+
+TEST_F(SelectionRecordTests, EIGENVALUE_COMPLEX){
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    SelectionRecord record = rr.createSelection("eigen(S1)");
+    EXPECT_EQ(record.selectionType, SelectionRecord::EIGENVALUE_COMPLEX);
+    EXPECT_STREQ(record.to_string().c_str(), "eigen(S1)");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "S1");
+    EXPECT_EQ(record.p2, "");
+    delete testModel;
+}
+
+TEST_F(SelectionRecordTests, EIGENVALUE_REAL) {
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    SelectionRecord record = rr.createSelection("eigenReal(S1)");
+    EXPECT_EQ(record.selectionType, SelectionRecord::EIGENVALUE_REAL);
+    EXPECT_STREQ(record.to_string().c_str(), "eigenReal(S1)");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "S1");
+    EXPECT_EQ(record.p2, "");
+    delete testModel;
+}
+
+TEST_F(SelectionRecordTests, EIGENVALUE_IMAG) {
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    SelectionRecord record = rr.createSelection("eigenImag(S1)");
+    EXPECT_EQ(record.selectionType, SelectionRecord::EIGENVALUE_IMAG);
+    EXPECT_STREQ(record.to_string().c_str(), "eigenImag(S1)");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "S1");
+    EXPECT_EQ(record.p2, "");
+    delete testModel;
+}
+
+TEST_F(SelectionRecordTests, STOICHIOMETRY){
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    SelectionRecord record = rr.createSelection("stoich(S1, _J1)");
+    EXPECT_EQ(record.selectionType, SelectionRecord::STOICHIOMETRY);
+    EXPECT_STREQ(record.to_string().c_str(), "stoich(S1, _J1)");
+    EXPECT_EQ(record.index, -1);
+    EXPECT_EQ(record.p1, "S1");
+    EXPECT_EQ(record.p2, "_J1");
+    delete testModel;
+}
+
+TEST_F(SelectionRecordTests, CONSERVED_MOIETY){
+    RoadRunner rr((rrTestModelsDir_ / "ModelAnalysis" / "conserved_cycle.xml").string());
+    rr.setConservedMoietyAnalysis(true);
+    SelectionRecord record = rr.createSelection("_CSUM0");
+    //Conserved moieties come through as global parameters, and not conserved moieties.
+    EXPECT_EQ(record.selectionType, SelectionRecord::GLOBAL_PARAMETER);
+    EXPECT_STREQ(record.to_string().c_str(), "_CSUM0");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "_CSUM0");
+    EXPECT_EQ(record.p2, "");
+}
+
+TEST_F(SelectionRecordTests, EVENT){
+    RoadRunner rr((rrTestModelsDir_ / "ModelAnalysis" / "event.xml").string());
+    EXPECT_THROW(
+        SelectionRecord record = rr.createSelection("_E0"),
+        Exception
+    );
+}
 
 TEST_F(SelectionRecordTests, COMPARTMENT) {
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
     SelectionRecord record = rr.createSelection("default_compartment");
-    ASSERT_EQ(record.selectionType, SelectionRecord::COMPARTMENT);
-    std::cout << record << std::endl;
+    EXPECT_EQ(record.selectionType, SelectionRecord::COMPARTMENT);
+    EXPECT_STREQ(record.to_string().c_str(), "default_compartment");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "default_compartment");
+    EXPECT_EQ(record.p2, "");
     delete testModel;
 }
 
@@ -276,313 +240,131 @@ TEST_F(SelectionRecordTests, GLOBAL_PARAMETER) {
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
     SelectionRecord record = rr.createSelection("kf");
-    ASSERT_EQ(record.selectionType, SelectionRecord::GLOBAL_PARAMETER);
-    std::cout << record << std::endl;
+    EXPECT_EQ(record.selectionType, SelectionRecord::GLOBAL_PARAMETER);
+    EXPECT_STREQ(record.to_string().c_str(), "kf");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "kf");
+    EXPECT_EQ(record.p2, "");
     delete testModel;
 }
 
-TEST_F(SelectionRecordTests, FLOATING_AMOUNT) {
+TEST_F(SelectionRecordTests, FLOATING_AMOUNT_RATE){
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
-    SelectionRecord record = rr.createSelection("S2");
-    ASSERT_EQ(record.selectionType, SelectionRecord::FLOATING_AMOUNT);
-    ASSERT_STREQ(record.to_string().c_str(), "S2");
-    ASSERT_EQ(record.index, 1);
+    SelectionRecord record = rr.createSelection("S1'");
+    EXPECT_EQ(record.selectionType, SelectionRecord::FLOATING_AMOUNT_RATE);
+    EXPECT_STREQ(record.to_string().c_str(), "S1'");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "S1");
+    EXPECT_EQ(record.p2, "");
     delete testModel;
 }
-//
-//TEST_F(SelectionRecordTests, INDEPENDENT_FLOATING_AMOUNT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::INDEPENDENT_FLOATING_AMOUNT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::INDEPENDENT_FLOATING_AMOUNT);
-//    delete testModel;
-//    std::cout << record << std::endl;
-//}
-//
-//TEST_F(SelectionRecordTests, DEPENDENT_FLOATING_AMOUNT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::DEPENDENT_FLOATING_AMOUNT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::DEPENDENT_FLOATING_AMOUNT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-TEST_F(SelectionRecordTests, BOUNDARY_AMOUNT) {
+
+TEST_F(SelectionRecordTests, FLOATING_CONCENTRATION_RATE){
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
-    rr.setBoundary("S1", true, true);
-    SelectionRecord record = rr.createSelection("S1");
-    ASSERT_EQ(record.selectionType, SelectionRecord::BOUNDARY_AMOUNT);
-    std::cout << record << std::endl;
+    SelectionRecord record = rr.createSelection("[S1]'");
+    EXPECT_EQ(record.selectionType, SelectionRecord::FLOATING_CONCENTRATION_RATE);
+    EXPECT_STREQ(record.to_string().c_str(), "[S1]'");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "S1");
+    EXPECT_EQ(record.p2, "");
     delete testModel;
 }
-//
-//TEST_F(SelectionRecordTests, BOUNDARY_CONCENTRATION){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::BOUNDARY_CONCENTRATION);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::BOUNDARY_CONCENTRATION);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-TEST_F(SelectionRecordTests, FLOATING_CONCENTRATION) {
+
+TEST_F(SelectionRecordTests, GLOBAL_PARAMETER_RATE){
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
-    SelectionRecord record = rr.createSelection("[S1]");
-    std::cout << record << std::endl;
-    ASSERT_EQ(record.selectionType, SelectionRecord::FLOATING_CONCENTRATION);
-    ASSERT_STREQ(record.to_string().c_str(), "[S1]");
-    ASSERT_EQ(record.index, 0);
+    SelectionRecord record = rr.createSelection("kf'");
+    EXPECT_EQ(record.selectionType, SelectionRecord::GLOBAL_PARAMETER_RATE);
+    EXPECT_STREQ(record.to_string().c_str(), "kf'");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "kf");
+    EXPECT_EQ(record.p2, "");
     delete testModel;
 }
 
-//TEST_F(SelectionRecordTests, FLOATING_AMOUNT_RATE){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::FLOATING_AMOUNT_RATE);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::FLOATING_AMOUNT_RATE);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-
-//TEST_F(SelectionRecordTests, FLOATING_CONCENTRATION_RATE){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::FLOATING_CONCENTRATION_RATE);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::FLOATING_CONCENTRATION_RATE);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, GLOBAL_PARAMETER_RATE){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::GLOBAL_PARAMETER_RATE);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::GLOBAL_PARAMETER_RATE);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-TEST_F(SelectionRecordTests, REACTION_RATE) {
+TEST_F(SelectionRecordTests, COMPARTMENT_RATE) {
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
-    SelectionRecord record = rr.createSelection("_J1");
-    ASSERT_EQ(record.selectionType, SelectionRecord::REACTION_RATE);
-    std::cout << record << std::endl;
+    SelectionRecord record = rr.createSelection("default_compartment'");
+    EXPECT_EQ(record.selectionType, SelectionRecord::COMPARTMENT_RATE);
+    EXPECT_STREQ(record.to_string().c_str(), "default_compartment'");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "default_compartment");
+    EXPECT_EQ(record.p2, "");
     delete testModel;
 }
-//
-//TEST_F(SelectionRecordTests, INITIAL_AMOUNT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::INITIAL_AMOUNT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::INITIAL_AMOUNT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, INITIAL_FLOATING_AMOUNT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::INITIAL_FLOATING_AMOUNT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::INITIAL_FLOATING_AMOUNT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, INITIAL_CONCENTRATION){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::INITIAL_CONCENTRATION);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::INITIAL_CONCENTRATION);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, INITIAL_FLOATING_CONCENTRATION){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::INITIAL_FLOATING_CONCENTRATION);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::INITIAL_FLOATING_CONCENTRATION);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, INITIAL_COMPARTMENT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::INITIAL_COMPARTMENT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::INITIAL_COMPARTMENT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, INITIAL_GLOBAL_PARAMETER){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::INITIAL_GLOBAL_PARAMETER);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::INITIAL_GLOBAL_PARAMETER);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, DEPENDENT_INITIAL_GLOBAL_PARAMETER){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::DEPENDENT_INITIAL_GLOBAL_PARAMETER);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::DEPENDENT_INITIAL_GLOBAL_PARAMETER);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, UNSCALED_ELASTICITY){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::UNSCALED_ELASTICITY);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::UNSCALED_ELASTICITY);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, UNSCALED_CONTROL){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::UNSCALED_CONTROL);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::UNSCALED_CONTROL);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, UNKNOWN_ELEMENT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::UNKNOWN_ELEMENT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::UNKNOWN_ELEMENT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, ALL_INDEPENDENT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::ALL_INDEPENDENT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::ALL_INDEPENDENT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, ALL_DEPENDENT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::ALL_DEPENDENT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::ALL_DEPENDENT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, ALL_INDEPENDENT_AMOUNT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::ALL_INDEPENDENT_AMOUNT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::ALL_INDEPENDENT_AMOUNT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, ALL_DEPENDENT_AMOUNT){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::ALL_DEPENDENT_AMOUNT);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::ALL_DEPENDENT_AMOUNT);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, ALL_INDEPENDENT_CONCENTRATION){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::ALL_INDEPENDENT_CONCENTRATION);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::ALL_INDEPENDENT_CONCENTRATION);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, ALL_DEPENDENT_CONCENTRATION){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::ALL_DEPENDENT_CONCENTRATION);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::ALL_DEPENDENT_CONCENTRATION);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, MODEL_STATE){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::MODEL_STATE);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::MODEL_STATE);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
-//
-//TEST_F(SelectionRecordTests, SBML_INITIALIZE){
-//    TestModel* testModel = TestModelFactory("SimpleFlux");
-//    RoadRunner rr(testModel->str());
-//    SelectionRecord record = rr.createSelection( SelectionRecord::SBML_INITIALIZE);
-//    ASSERT_EQ(record.selectionType,         SelectionRecord::SBML_INITIALIZE);
-//    std::cout << record << std::endl;
-//    delete testModel;
-//}
 
+TEST_F(SelectionRecordTests, INITIAL_COMPARTMENT){
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    SelectionRecord record = rr.createSelection("init(default_compartment)");
+    EXPECT_EQ(record.selectionType, SelectionRecord::INITIAL_COMPARTMENT);
+    EXPECT_STREQ(record.to_string().c_str(), "init(default_compartment)");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "default_compartment");
+    EXPECT_EQ(record.p2, "");
+    delete testModel;
+}
 
-TEST_F(SelectionRecordTests, unscaled_elasticity) {
+TEST_F(SelectionRecordTests, INITIAL_GLOBAL_PARAMETER){
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    RoadRunner rr(testModel->str());
+    SelectionRecord record = rr.createSelection("init(kf)");
+    EXPECT_EQ(record.selectionType, SelectionRecord::INITIAL_GLOBAL_PARAMETER);
+    EXPECT_STREQ(record.to_string().c_str(), "init(kf)");
+    EXPECT_EQ(record.index, 0);
+    EXPECT_EQ(record.p1, "kf");
+    EXPECT_EQ(record.p2, "");
+    delete testModel;
+}
+
+TEST_F(SelectionRecordTests, UNSCALED_ELASTICITY) {
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
     SelectionRecord record = rr.createSelection("uec(_J1, S2)");
-    ASSERT_STREQ(record.to_string().c_str(), "uec(_J1, S2)");
-    ASSERT_EQ(record.selectionType, SelectionRecord::UNSCALED_ELASTICITY);
-    ASSERT_EQ(record.index, -1);
-    ASSERT_EQ(record.p1, "_J1");
-    ASSERT_EQ(record.p2, "S2");
+    EXPECT_STREQ(record.to_string().c_str(), "uec(_J1, S2)");
+    EXPECT_EQ(record.selectionType, SelectionRecord::UNSCALED_ELASTICITY);
+    EXPECT_EQ(record.index, -1);
+    EXPECT_EQ(record.p1, "_J1");
+    EXPECT_EQ(record.p2, "S2");
     delete testModel;
 }
 
-TEST_F(SelectionRecordTests, scaled_elasticity) {
+TEST_F(SelectionRecordTests, ELASTICITY) {
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
     SelectionRecord record = rr.createSelection("ec(_J1, S2)");
-    ASSERT_STREQ(record.to_string().c_str(), "ec(_J1, S2)");
-    ASSERT_EQ(record.selectionType, SelectionRecord::ELASTICITY);
-    ASSERT_EQ(record.index, -1);
-    ASSERT_EQ(record.p1, "_J1");
-    ASSERT_EQ(record.p2, "S2");
+    EXPECT_STREQ(record.to_string().c_str(), "ec(_J1, S2)");
+    EXPECT_EQ(record.selectionType, SelectionRecord::ELASTICITY);
+    EXPECT_EQ(record.index, -1);
+    EXPECT_EQ(record.p1, "_J1");
+    EXPECT_EQ(record.p2, "S2");
     delete testModel;
 }
 
-TEST_F(SelectionRecordTests, unscaled_control) {
+TEST_F(SelectionRecordTests, UNSCALED_CONTROL) {
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
     SelectionRecord record = rr.createSelection("ucc(_J1, kf)");
-    ASSERT_STREQ(record.to_string().c_str(), "ucc(_J1, kf)");
-    ASSERT_EQ(record.selectionType, SelectionRecord::UNSCALED_CONTROL);
-    ASSERT_EQ(record.index, -1);
-    ASSERT_EQ(record.p1, "_J1");
-    ASSERT_EQ(record.p2, "kf");
+    EXPECT_STREQ(record.to_string().c_str(), "ucc(_J1, kf)");
+    EXPECT_EQ(record.selectionType, SelectionRecord::UNSCALED_CONTROL);
+    EXPECT_EQ(record.index, -1);
+    EXPECT_EQ(record.p1, "_J1");
+    EXPECT_EQ(record.p2, "kf");
     delete testModel;
 }
 
-TEST_F(SelectionRecordTests, scaled_control) {
+TEST_F(SelectionRecordTests, CONTROL) {
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());
     SelectionRecord record = rr.createSelection("cc(_J1, kf)");
-    ASSERT_STREQ(record.to_string().c_str(), "cc(_J1, kf)");
-    ASSERT_EQ(record.selectionType, SelectionRecord::CONTROL);
-    ASSERT_EQ(record.index, -1);
-    ASSERT_EQ(record.p1, "_J1");
-    ASSERT_EQ(record.p2, "kf");
+    EXPECT_STREQ(record.to_string().c_str(), "cc(_J1, kf)");
+    EXPECT_EQ(record.selectionType, SelectionRecord::CONTROL);
+    EXPECT_EQ(record.index, -1);
+    EXPECT_EQ(record.p1, "_J1");
+    EXPECT_EQ(record.p2, "kf");
     delete testModel;
 }
 

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -21,6 +21,36 @@ public:
 };
 
 
+TEST_F(ModelAnalysisTests, getConcentrationRateSimple) {
+    RoadRunner rr((modelAnalysisModelsDir / "threestep.xml").string());
+    double S1_conc_rate = rr.getValue("[S1]'");
+    double S1_rate = rr.getValue("S1'");
+    EXPECT_NEAR(S1_conc_rate, -1.3, 0.001);
+    EXPECT_NEAR(S1_rate, -1.3, 0.001);
+}
+
+TEST_F(ModelAnalysisTests, getConcentrationRateComplex) {
+    RoadRunner rr((modelAnalysisModelsDir / "threestep_varC.xml").string());
+    double S1_rate = rr.getValue("S1'");
+    double S1_conc = rr.getValue("[S1]");
+    double comp = rr.getValue("C");
+    double comp_rate = rr.getValue("C'");
+    double S1_conc_rate = rr.getValue("[S1]'");
+    EXPECT_NEAR(S1_rate, -1.3, 0.001);
+    EXPECT_NEAR(S1_conc, 10, 0.001);
+    EXPECT_NEAR(comp, 2, 0.001);
+    EXPECT_NEAR(comp_rate, 2, 0.001);
+    EXPECT_NEAR(S1_conc_rate, (S1_rate - (S1_conc * comp_rate))/comp, 0.001);
+}
+
+TEST_F(ModelAnalysisTests, getConcentrationRateFail) {
+    RoadRunner rr((modelAnalysisModelsDir / "threestep.xml").string());
+    rr.addAssignmentRule("C", "3");
+    EXPECT_THROW(
+        double S1_conc_rate = rr.getValue("[S1]'"), 
+        std::invalid_argument);
+}
+
 TEST_F(ModelAnalysisTests, SameJacobians1) {
     RoadRunner rr((modelAnalysisModelsDir / "apap_liver_core_9.xml").string());
 

--- a/test/models/ModelAnalysis/threestep_varC.xml
+++ b/test/models/ModelAnalysis/threestep_varC.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.3. -->
+<!-- Created by libAntimony version v2.13.0 with libSBML version 5.19.1. -->
 <sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
   <model metaid="__main" id="__main">
     <listOfCompartments>
-      <compartment sboTerm="SBO:0000410" id="C" spatialDimensions="3" size="1" constant="true"/>
+      <compartment id="C" spatialDimensions="3" size="2" constant="false"/>
     </listOfCompartments>
     <listOfSpecies>
       <species id="S1" compartment="C" initialConcentration="10" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
@@ -11,6 +11,13 @@
       <species id="S3" compartment="C" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
       <species id="S4" compartment="C" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
+    <listOfRules>
+      <rateRule variable="C">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <cn type="integer"> 2 </cn>
+        </math>
+      </rateRule>
+    </listOfRules>
     <listOfReactions>
       <reaction id="J1" reversible="true">
         <listOfReactants>


### PR DESCRIPTION
Roadrunner defines an almost dizzying array of selection record types, but hasn't handled all of them.  This adds the ability to handle more types, and adds tests for them.

Of particular note, this adds the ability to handle the FLOATING_CONCENTRATION_RATE type, even when the species amount and the compartment volume are both changing (denoted by the string "[S1]'".  Other changes include:

* The ability to get rate rule values the same way you get other values in models.
* 'suplied' -> 'supplied'
* The addition of the COMPARTMENT_RATE record type.
* Lots more selection record tests.