### PR TITLE
Connect the 'saveState' version to rr's version.

### DIFF
--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -497,7 +497,9 @@ namespace rr {
     }
 
     RoadRunner::RoadRunner(unsigned int level, unsigned int version)
-            : impl(new RoadRunnerImpl("", NULL)) {
+        : impl(new RoadRunnerImpl("", NULL))
+        , dataVersionNumber(RR_VERSION_MAJOR * 10 + RR_VERSION_MINOR) 
+    {
 
         llvm::InitializeNativeTarget();
         llvm::InitializeNativeTargetAsmPrinter();
@@ -531,7 +533,8 @@ namespace rr {
 
 
     RoadRunner::RoadRunner(const std::string& uriOrSBML, const Dictionary* options) 
-        : impl(new RoadRunnerImpl(uriOrSBML, options)) 
+        : impl(new RoadRunnerImpl(uriOrSBML, options))
+        , dataVersionNumber(RR_VERSION_MAJOR * 10 + RR_VERSION_MINOR)
     {
         /**
          * The main program should call this function to
@@ -580,8 +583,10 @@ namespace rr {
 
 
     RoadRunner::RoadRunner(const std::string &_compiler, const std::string &_tempDir,
-                           const std::string &supportCodeDir) :
-            impl(new RoadRunnerImpl(_compiler, _tempDir, supportCodeDir)) {
+                           const std::string &supportCodeDir) 
+        : impl(new RoadRunnerImpl(_compiler, _tempDir, supportCodeDir))
+        , dataVersionNumber(RR_VERSION_MAJOR * 10 + RR_VERSION_MINOR)
+    {
         llvm::InitializeNativeTarget();
         llvm::InitializeNativeTargetAsmPrinter();
         llvm::InitializeNativeTargetAsmParser();
@@ -613,7 +618,9 @@ namespace rr {
     }
 
     RoadRunner::RoadRunner(const RoadRunner &rr)
-            : impl(new RoadRunnerImpl(*rr.impl)) {
+        : impl(new RoadRunnerImpl(*rr.impl))
+        , dataVersionNumber(RR_VERSION_MAJOR * 10 + RR_VERSION_MINOR)
+    {
         //Set up integrators.
         // We loop through all the integrators in the source, setting the current one to
         //  each in turn, and setting the values of that current one based on the one in

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -1830,7 +1830,7 @@ namespace rr {
         void loadSelectionVector(std::istream &, std::vector<SelectionRecord> &);
 
         const int fileMagicNumber = 0xAD6F52;
-        const int dataVersionNumber = RR_VERSION_MAJOR*10 + RR_VERSION_MINOR;
+        const int dataVersionNumber;
     };
 
 }

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -1830,7 +1830,7 @@ namespace rr {
         void loadSelectionVector(std::istream &, std::vector<SelectionRecord> &);
 
         const int fileMagicNumber = 0xAD6F52;
-        const int dataVersionNumber = 1;
+        const int dataVersionNumber = RR_VERSION_MAJOR*10 + RR_VERSION_MINOR;
     };
 
 }


### PR DESCRIPTION
It's possible that this might be simultaneously too small a change and too large a change:  if the version number changes without the saveState data changing, we needlessly refuse to load files that would have loaded.  Conversely, if a 'patch' version change changes the saveState data, we might not catch it.

I think this is a reasonable compromise, as it's difficult to remember to change the dataVersionNumber otherwise--it's been stuck on '1' ever since it was introduced, which has included a few saveState changes.  But if we need to change it to major+minor+patch, that'd also be OK by me.