### PR TITLE
This replaces getElementBySId where possible with faster lookups.

### DIFF
--- a/source/conservation/ConservedMoietyConverter.cpp
+++ b/source/conservation/ConservedMoietyConverter.cpp
@@ -16,6 +16,7 @@
 #include "rrSBMLReader.h"
 #include "rrLogger.h"
 #include "rrConfig.h"
+#include "rrRoadRunner.h"
 
 #include <sbml/math/ASTNode.h>
 #include <sbml/AlgebraicRule.h>
@@ -741,10 +742,8 @@ static void conservedMoietyCheck(const SBMLDocument *doc)
     {
         const Rule *rule = rules->get(i);
 
-        const SBase *element = const_cast<Model*>(model)->getElementBySId(
-                rule->getVariable());
+        const Species *species = model->getSpecies(rule->getVariable());
 
-        const Species *species = dynamic_cast<const Species*>(element);
         if(species && !species->getBoundaryCondition() && model->getNumReactions() > 0)
         {
             std::string msg = "Cannot perform moiety conversion when floating "
@@ -754,8 +753,10 @@ static void conservedMoietyCheck(const SBMLDocument *doc)
             conservedMoietyException(msg);
         }
 
+        ListOfReactions* lor = const_cast<ListOfReactions*>(model->getListOfReactions());
+
         const SpeciesReference *ref =
-                dynamic_cast<const SpeciesReference*>(element);
+                dynamic_cast<const SpeciesReference*>(lor->getElementBySId(rule->getVariable()));
         if(ref)
         {
             std::string msg = "Cannot perform moiety conversion with non-constant "
@@ -812,10 +813,8 @@ static void conservedMoietyCheck(const SBMLDocument *doc)
             if (!ass->isSetMath()) {
                 continue;
             }
-            const SBase *element = const_cast<Model*>(model)->getElementBySId(
-                    ass->getVariable());
 
-            const Species *species = dynamic_cast<const Species*>(element);
+            const Species* species = model->getSpecies(ass->getVariable());
             if(species && !species->getBoundaryCondition())
             {
                 std::string msg = "Cannot perform moiety conversion when floating "
@@ -824,6 +823,8 @@ static void conservedMoietyCheck(const SBMLDocument *doc)
                 conservedMoietyException(msg);
             }
 
+            libsbml::ListOfReactions* lor = const_cast<libsbml::ListOfReactions*>(model->getListOfReactions());
+            const SBase* element = lor->getElementBySId(ass->getVariable());
             const SpeciesReference *ref =
                     dynamic_cast<const SpeciesReference*>(element);
             if(ref)

--- a/source/llvm/EvalRateRuleRatesCodeGen.cpp
+++ b/source/llvm/EvalRateRuleRatesCodeGen.cpp
@@ -63,10 +63,9 @@ Value* EvalRateRuleRatesCodeGen::codeGen()
             // check if this rate rule applies to species, we only deal with
             // amounts and rates of change of amounts, so need to convert
             // accordingly
-            const SBase* sbase = const_cast<Model*>(model)->getElementBySId(rateRule->getVariable());
-            if (sbase && sbase->getTypeCode() == SBML_SPECIES)
+            const Species* species = const_cast<Model*>(model)->getSpecies(rateRule->getVariable());
+            if (species)
             {
-                const Species* species = static_cast<const Species*>(sbase);
                 if (!species->getHasOnlySubstanceUnits())
                 {
                     // product rule, need to check if we have a rate rule for the

--- a/source/llvm/EvalVolatileStoichCodeGen.cpp
+++ b/source/llvm/EvalVolatileStoichCodeGen.cpp
@@ -196,18 +196,26 @@ namespace rrllvm {
             }
             return true;
         } else if (ast->isName()) {
-            const SBase *element = const_cast<Model *>(model)->getElementBySId(
+            const Species* species = model->getSpecies(ast->getName());
+            if (species) {
+                return species->getConstant();
+            }
+            
+            const Parameter* param = model->getParameter(ast->getName());
+            if (param) {
+                return param->getConstant();
+            }
+
+            const Compartment* comp = model->getCompartment(ast->getName());
+            if (comp) {
+                return comp->getConstant();
+            }
+
+            const ListOfReactions* lor = model->getListOfReactions();
+            const SBase *element = const_cast<ListOfReactions *>(lor)->getElementBySId(
                     ast->getName());
-
             bool result;
-
-            if (isSetConstant<Parameter>(element, result)) {
-                return result;
-            } else if (isSetConstant<Compartment>(element, result)) {
-                return result;
-            } else if (isSetConstant<Species>(element, result)) {
-                return result;
-            } else if (isSetConstant<SpeciesReference>(element, result)) {
+            if (isSetConstant<SpeciesReference>(element, result)) {
                 return result;
             } else {
                 return false;

--- a/source/llvm/LLVMModelSymbols.cpp
+++ b/source/llvm/LLVMModelSymbols.cpp
@@ -11,6 +11,7 @@
 #include "rrLogger.h"
 #include "rrStringUtils.h"
 #include "rrException.h"
+#include "rrRoadRunner.h"
 
 #include "conservation/ConservationExtension.h"
 
@@ -128,7 +129,7 @@ bool LLVMModelSymbols::visit(const libsbml::Species& x)
 bool LLVMModelSymbols::visit(const libsbml::AssignmentRule& x)
 {
     rrLog(Logger::LOG_TRACE) << "processing AssignmentRule, id: " << x.getId();
-    SBase *element = const_cast<Model*>(model)->getElementBySId(x.getVariable());
+    const SBase* element = rr::RoadRunner::getElementWithMathematicalMeaning(model, x.getId());
 
     if (element)
     {
@@ -147,7 +148,7 @@ bool LLVMModelSymbols::visit(const libsbml::AssignmentRule& x)
 bool LLVMModelSymbols::visit(const libsbml::InitialAssignment& x)
 {
     rrLog(Logger::LOG_TRACE) << "processing InitialAssignment, id: " +  x.getId();
-    SBase *element = const_cast<Model*>(model)->getElementBySId(x.getSymbol());
+    const SBase* element = rr::RoadRunner::getElementWithMathematicalMeaning(model, x.getId());
     processElement(initialValues, element, x.getMath());
     processElement(initialAssignmentRules, element, x.getMath());
     return true;
@@ -156,7 +157,7 @@ bool LLVMModelSymbols::visit(const libsbml::InitialAssignment& x)
 bool LLVMModelSymbols::visit(const libsbml::RateRule& rule)
 {
     rrLog(Logger::LOG_TRACE) << "processing RateRule, id: " +  rule.getId();
-    SBase *element = const_cast<Model*>(model)->getElementBySId(rule.getVariable());
+    const SBase* element = rr::RoadRunner::getElementWithMathematicalMeaning(model, rule.getVariable());
     processElement(rateRules, element, rule.getMath());
     return true;
 }

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1022,6 +1022,22 @@ namespace rr {
         return impl->loadOpt.getItem("tempDir");
     }
 
+    const libsbml::SBase* RoadRunner::getElementWithMathematicalMeaning(const libsbml::Model* model, const std::string& id)
+    {
+        const libsbml::SBase* element = model->getSpecies(id);
+        if (!element) {
+            element = model->getParameter(id);
+            if (!element) {
+                element = model->getCompartment(id);
+                if (!element) {
+                    libsbml::ListOfReactions* lor = const_cast<libsbml::ListOfReactions*>(model->getListOfReactions());
+                    element = lor->getElementBySId(id);
+                }
+            }
+        }
+        return element;
+    }
+
     size_t RoadRunner::createDefaultTimeCourseSelectionList() {
         std::vector<std::string> selections;
         std::vector<std::string> oFloating = getFloatingSpeciesIds();
@@ -6086,7 +6102,7 @@ namespace rr {
     }
 
     void checkAddRule(const std::string &vid, libsbml::Model *sbmlModel) {
-        libsbml::SBase *sbase = sbmlModel->getElementBySId(vid);
+        libsbml::SBase *sbase = const_cast<libsbml::SBase*>(RoadRunner::getElementWithMathematicalMeaning(sbmlModel, vid));
         if (sbase == NULL) {
             throw std::invalid_argument(
                     "Unable to add rule because no variable with ID " + vid + " was found in the model.");

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -1707,6 +1707,14 @@ namespace rr {
          */
         std::string getTempDir();
 
+        /**
+         * @internal
+         *
+         * Search for the element with the given ID, but only among SBML elements that have mathematical meaning:  Species, Parameters, Compartments, and SpeciesReferences (in that order).
+         */
+        static const libsbml::SBase* getElementWithMathematicalMeaning(const libsbml::Model* model, const std::string& id);
+
+
 #endif // #ifndef SWIG
 
     private:

--- a/test/mockups/MockSBase.h
+++ b/test/mockups/MockSBase.h
@@ -33,8 +33,8 @@ public:
     MOCK_METHOD(void, replaceSIDWithFunction, (const std::string& id, const ASTNode* function), (override));
     MOCK_METHOD(void, divideAssignmentsToSIdByFunction, (const std::string& id, const ASTNode* function), (override));
     MOCK_METHOD(void, multiplyAssignmentsToSIdByFunction, (const std::string& id, const ASTNode* function), (override));
-    MOCK_METHOD(SBase*, getElementFromPluginsBySId, (std::string id), (override));
-    MOCK_METHOD(SBase*, getElementFromPluginsByMetaId, (std::string metaid), (override));
+    MOCK_METHOD(SBase*, getElementFromPluginsBySId, (const std::string& id), (override));
+    MOCK_METHOD(SBase*, getElementFromPluginsByMetaId, (const std::string& metaid), (override));
     MOCK_METHOD(bool, hasNonstandardIdentifierBeginningWith, (const std::string& prefix), (override));
     MOCK_METHOD(int, prependStringToAllIdentifiers, (const std::string& prefix), (override));
     MOCK_METHOD(int, transformIdentifiers, (IdentifierTransformer * idTransformer), (override));


### PR DESCRIPTION
If we're actually looking for a species, just call 'getSpecies'; if we're looking for anything with mathematical meaning, use the new 'getElementWithMathematicalMeaning' static function in the roadrunner class.  (I tried putting this in rrUtils, but that seems to be formulated for a slightly different interface, so I put it in RoadRunner instead.  If there's a better place for it, I'm happy to put it there instead.  I suppose one place might be libsbml itself, with the advantage that it could deal with plugins with mathematical meaning better, though there aren't a lot of them.)

Also, MockSBase needed updating, as some functions changed their signatures in the latest libsbml.

It would still be nice if we kept a hash of IDs somewhere, and it would mean we could check uniqueness a little faster elsewhere (where we still use getElementBySId), but that's a bigger project.