### PR TITLE
Connect the 'saveState' version to rr's version.

### DIFF
--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -497,7 +497,9 @@ namespace rr {
     }
 
     RoadRunner::RoadRunner(unsigned int level, unsigned int version)
-            : impl(new RoadRunnerImpl("", NULL)) {
+        : impl(new RoadRunnerImpl("", NULL))
+        , dataVersionNumber(RR_VERSION_MAJOR * 10 + RR_VERSION_MINOR)
+    {
 
         initLLVM();
 
@@ -527,7 +529,9 @@ namespace rr {
 
 
     RoadRunner::RoadRunner(const std::string &uriOrSBML, const Dictionary *options)
-            : impl(new RoadRunnerImpl(uriOrSBML, options)) {
+        : impl(new RoadRunnerImpl(uriOrSBML, options))
+        , dataVersionNumber(RR_VERSION_MAJOR * 10 + RR_VERSION_MINOR)
+    {
         initLLVM();
 
         /**
@@ -555,8 +559,10 @@ namespace rr {
 
 
     RoadRunner::RoadRunner(const std::string &_compiler, const std::string &_tempDir,
-                           const std::string &supportCodeDir) :
-            impl(new RoadRunnerImpl(_compiler, _tempDir, supportCodeDir)) {
+                           const std::string &supportCodeDir) 
+        : impl(new RoadRunnerImpl(_compiler, _tempDir, supportCodeDir)) 
+        , dataVersionNumber(RR_VERSION_MAJOR * 10 + RR_VERSION_MINOR)
+    {
         initLLVM();
         // must be run to register solvers
         registerSolvers();
@@ -584,7 +590,9 @@ namespace rr {
     }
 
     RoadRunner::RoadRunner(const RoadRunner &rr)
-            : impl(new RoadRunnerImpl(*rr.impl)) {
+        : impl(new RoadRunnerImpl(*rr.impl))
+        , dataVersionNumber(RR_VERSION_MAJOR * 10 + RR_VERSION_MINOR)
+    {
         //Set up integrators.
         // We loop through all the integrators in the source, setting the current one to
         //  each in turn, and setting the values of that current one based on the one in

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -1841,7 +1841,7 @@ namespace rr {
         void loadSelectionVector(std::istream &, std::vector<SelectionRecord> &);
 
         const int fileMagicNumber = 0xAD6F52;
-        const int dataVersionNumber = 1;
+        const int dataVersionNumber;
     };
 
 }


### PR DESCRIPTION
Recreates old branch that no longer merges.

It's possible that this might be simultaneously too small a change and too large a change:  if the version number changes without the saveState data changing, we needlessly refuse to load files that would have loaded.  Conversely, if a 'patch' version change changes the saveState data, we might not catch it.

I think this is a reasonable compromise, as it's difficult to remember to change the dataVersionNumber otherwise--it's been stuck on '1' ever since it was introduced, which has included a few saveState changes.  But if we need to change it to major+minor+patch, that'd also be OK by me.