### PR TITLE
When calculating ucc, don't fail if we try to set something already set.

### DIFF
--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -139,14 +139,14 @@ int LLVMExecutableModel::getValues(double (*funcPtr)(LLVMModelData*, size_t),
 }
 
 int LLVMExecutableModel::setValues(bool (*funcPtr)(LLVMModelData*, int, double),
-        GetNameFuncPtr getNameFuncPtr, size_t len, const int *indx, const double *values)
+    GetNameFuncPtr getNameFuncPtr, size_t len, const int* indx, const double* values, bool strict)
 {
     for (size_t i = 0; i < len; ++i)
     {
         size_t j = indx ? indx[i] : i;
         bool result =  funcPtr(modelData, static_cast<int>(j), values[i]);
 
-        if (!result)
+        if (!result && strict)
         {
             std::stringstream s;
             std::string id = (this->*getNameFuncPtr)(j);
@@ -1759,7 +1759,13 @@ int LLVMExecutableModel::getFloatingSpeciesConcentrationRates(size_t len,
 }
 
 int LLVMExecutableModel::setBoundarySpeciesAmounts(size_t len, const int* indx,
-        const double* values)
+    const double* values)
+{
+    return setBoundarySpeciesAmounts(len, indx, values, true);
+}
+
+int LLVMExecutableModel::setBoundarySpeciesAmounts(size_t len, const int* indx,
+    const double* values, bool strict)
 {
     bool result = false;
     if (setBoundarySpeciesAmountPtr)
@@ -1768,7 +1774,7 @@ int LLVMExecutableModel::setBoundarySpeciesAmounts(size_t len, const int* indx,
         {
             int j = indx ? indx[i] : i;
             result = setBoundarySpeciesAmountPtr(modelData, j, values[i]);
-            if (!result)
+            if (!result && strict)
             {
                 std::stringstream s;
                 std::string id = symbols->getBoundarySpeciesId(j);
@@ -1897,8 +1903,14 @@ int LLVMExecutableModel::getFloatingSpeciesAmounts(size_t len, const int* indx,
     return getValues(getFloatingSpeciesAmountPtr, len, indx, values);
 }
 
-int LLVMExecutableModel::setFloatingSpeciesAmounts(size_t len, int const *indx,
-        const double *values)
+int LLVMExecutableModel::setFloatingSpeciesAmounts(size_t len, int const* indx,
+    const double* values)
+{
+    return setFloatingSpeciesAmounts(len, indx, values, true);
+}
+
+int LLVMExecutableModel::setFloatingSpeciesAmounts(size_t len, int const* indx,
+    const double* values, bool strict)
 {
     for (int i = 0; i < len; ++i)
     {
@@ -1929,24 +1941,24 @@ int LLVMExecutableModel::setFloatingSpeciesAmounts(size_t len, int const *indx,
                         << ", setting CM to " << newCmVal
                         << ", was " << currCmVal;
 
-                setGlobalParameterValues(1, &gpIndex, &newCmVal);
+                setGlobalParameterValues(1, &gpIndex, &newCmVal, strict);
             }
-            else
+            else if (strict)
             {
-            std::stringstream s;
-            std::string id = symbols->getFloatingSpeciesId(j);
-            s << "Could not set value for NON conserved moiety floating species " << id;
+                std::stringstream s;
+                std::string id = symbols->getFloatingSpeciesId(j);
+                s << "Could not set value for NON conserved moiety floating species " << id;
 
-            if (symbols->hasAssignmentRule(id))
-            {
-                s << ", it is defined by an assignment rule, can not be set independently.";
-            }
-            else if (symbols->hasRateRule(id))
-            {
-                s << ", it is defined by a rate rule and can not be set independently.";
-            }
+                if (symbols->hasAssignmentRule(id))
+                {
+                    s << ", it is defined by an assignment rule, can not be set independently.";
+                }
+                else if (symbols->hasRateRule(id))
+                {
+                    s << ", it is defined by a rate rule and can not be set independently.";
+                }
 
-            throw_llvm_exception(s.str());
+                throw_llvm_exception(s.str());
             }
         }
     }
@@ -2045,13 +2057,19 @@ int LLVMExecutableModel::getGlobalParameterValues(size_t len, const int* indx,
 }
 
 int LLVMExecutableModel::setGlobalParameterValues(size_t len, const int* indx,
-        const double* values)
+    const double* values)
+{
+    return setGlobalParameterValues(len, indx, values, true);
+}
+
+int LLVMExecutableModel::setGlobalParameterValues(size_t len, const int* indx,
+    const double* values, bool strict)
 {
     int result = -1;
     if (setGlobalParameterPtr)
     {
         result = setValues(setGlobalParameterPtr,
-                &LLVMExecutableModel::getGlobalParameterId, len, indx, values);
+                &LLVMExecutableModel::getGlobalParameterId, len, indx, values, strict);
 
         for (int i = 0; i < len; ++i)
         {
@@ -2231,13 +2249,19 @@ int LLVMExecutableModel::getRateRuleRates(size_t len,
 
 
 int LLVMExecutableModel::setCompartmentVolumes(size_t len, const int* indx,
-        const double* values)
+    const double* values)
+{
+    return setCompartmentVolumes(len, indx, values, true);
+}
+
+int LLVMExecutableModel::setCompartmentVolumes(size_t len, const int* indx,
+    const double* values, bool strict)
 {
     int result = -1;
     if (setCompartmentVolumePtr)
     {
         result = setValues(setCompartmentVolumePtr,
-                &LLVMExecutableModel::getCompartmentId, len, indx, values);
+                &LLVMExecutableModel::getCompartmentId, len, indx, values, strict);
     }
     return result;
 }

--- a/source/llvm/LLVMExecutableModel.h
+++ b/source/llvm/LLVMExecutableModel.h
@@ -139,6 +139,9 @@ public:
     virtual int setGlobalParameterValues(size_t len, int const *indx,
             const double *values);
 
+    virtual int setGlobalParameterValues(size_t len, int const* indx,
+        const double* values, bool strict);
+
     virtual int getNumReactions();
 
     virtual int getReactionRates(size_t len, int const *indx,
@@ -267,6 +270,9 @@ public:
     virtual int setFloatingSpeciesAmounts(size_t len, int const *indx,
             const double *values);
 
+    virtual int setFloatingSpeciesAmounts(size_t len, int const* indx,
+        const double* values, bool strict);
+
     /**
      * get the boundary species amounts
      *
@@ -312,6 +318,9 @@ public:
      virtual int setBoundarySpeciesAmounts(size_t len, int const *indx,
              double const *values);
 
+     virtual int setBoundarySpeciesAmounts(size_t len, int const* indx,
+         double const* values, bool strict);
+
 
     virtual int getGlobalParameterIndex(const std::string&);
     virtual std::string getGlobalParameterId(size_t);
@@ -330,8 +339,11 @@ public:
             const double *values);
 
 
-    virtual int setCompartmentVolumes(size_t len, int const *indx,
-            const double *values);
+    virtual int setCompartmentVolumes(size_t len, int const* indx,
+        const double* values);
+
+    virtual int setCompartmentVolumes(size_t len, int const* indx,
+        const double* values, bool strict);
 
 
     virtual double getStoichiometry(int speciesIndex, int reactionIndex);
@@ -696,7 +708,7 @@ private:
      * set the model struct values from the given array.
      */
     int setValues(bool (*funcPtr)(LLVMModelData*, int, double), GetNameFuncPtr, size_t len,
-            const int *indx, const double *values);
+            const int *indx, const double *values, bool strict=true);
 
     static LLVMExecutableModel* dummy();
 

--- a/source/rrExecutableModel.h
+++ b/source/rrExecutableModel.h
@@ -185,6 +185,9 @@ namespace rr {
         virtual int setFloatingSpeciesAmounts(size_t len, int const *indx,
                                               const double *values) = 0;
 
+        virtual int setFloatingSpeciesAmounts(size_t len, int const* indx,
+            const double* values, bool strict) = 0;
+
         virtual int getFloatingSpeciesAmountRates(size_t len, int const *indx,
                                                   double *values) = 0;
 
@@ -319,6 +322,9 @@ namespace rr {
         virtual int setBoundarySpeciesAmounts(size_t len, int const* indx,
             double const* values) = 0;
 
+        virtual int setBoundarySpeciesAmounts(size_t len, int const* indx,
+            double const* values, bool strict) = 0;
+
         /**
          * Set the initial concentrations of the boundary species.
          *
@@ -398,6 +404,9 @@ namespace rr {
         virtual int setGlobalParameterValues(size_t len, int const *indx,
                                              const double *values) = 0;
 
+        virtual int setGlobalParameterValues(size_t len, int const* indx,
+            const double* values, bool strict) = 0;
+
         /**
         * Set the initial value of the global parameter.
         *
@@ -447,6 +456,9 @@ namespace rr {
 
         virtual int setCompartmentVolumes(size_t len, int const *indx,
                                           const double *values) = 0;
+
+        virtual int setCompartmentVolumes(size_t len, int const* indx,
+            const double* values, bool strict) = 0;
 
         /**
          * Set the initial volumes of the compartments.

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -3783,10 +3783,10 @@ namespace rr {
                 double f2 = -(8 * fd + fi2);
 
                 // What ever happens, make sure we restore the original state
-                impl->model->setFloatingSpeciesAmounts(nfloat, 0, floats);
-                impl->model->setBoundarySpeciesAmounts(nboundary, 0, boundaries);
-                impl->model->setCompartmentVolumes(ncomp, 0, comps);
-                impl->model->setGlobalParameterValues(nparam, 0, params);
+                impl->model->setFloatingSpeciesAmounts(nfloat, 0, floats, false);
+                impl->model->setBoundarySpeciesAmounts(nboundary, 0, boundaries, false);
+                impl->model->setCompartmentVolumes(ncomp, 0, comps, false);
+                impl->model->setGlobalParameterValues(nparam, 0, params, false);
                 //loadStateS(orig_state);
 
                 return 1 / (12 * hstep) * (f1 + f2);

--- a/test/mockups/MockExecutableModel.h
+++ b/test/mockups/MockExecutableModel.h
@@ -24,6 +24,7 @@ public:
     MOCK_METHOD(int, getNumIndFloatingSpecies, (), (override));
     MOCK_METHOD(int, getFloatingSpeciesAmounts, (size_t len, int const *indx, double *values), (override));
     MOCK_METHOD(int, setFloatingSpeciesAmounts, (size_t len, int const *indx, const double *values), (override));
+    MOCK_METHOD(int, setFloatingSpeciesAmounts, (size_t len, int const* indx, const double* values, bool strict), (override));
     MOCK_METHOD(int, getFloatingSpeciesAmountRates, (size_t len, int const *indx, double *values), (override));
     MOCK_METHOD(int, getFloatingSpeciesConcentrationRates, (size_t len, int const *indx, double *values), (override));
     MOCK_METHOD(int, getFloatingSpeciesConcentrations, (size_t len, int const *indx, double *values), (override));
@@ -39,6 +40,7 @@ public:
     MOCK_METHOD(int, getBoundarySpeciesConcentrations,     (size_t len, int const *indx, double *values),        (override));
     MOCK_METHOD(int, setBoundarySpeciesConcentrations,     (size_t len, int const *indx, double const *values), (override));
     MOCK_METHOD(int, setBoundarySpeciesAmounts, (size_t len, int const* indx, double const* values), (override));
+    MOCK_METHOD(int, setBoundarySpeciesAmounts, (size_t len, int const* indx, double const* values, bool strict), (override));
     MOCK_METHOD(int, setBoundarySpeciesInitConcentrations, (size_t len, int const* indx, double const* values), (override));
     MOCK_METHOD(int, getBoundarySpeciesInitConcentrations, (size_t len, int const* indx, double* values), (override));
     MOCK_METHOD(int, setBoundarySpeciesInitAmounts, (size_t len, int const* indx, double const* values), (override));
@@ -48,6 +50,7 @@ public:
     MOCK_METHOD(std::string, getGlobalParameterId, (size_t index), (override));
     MOCK_METHOD(int, getGlobalParameterValues, (size_t len, int const *indx, double *values), (override));
     MOCK_METHOD(int, setGlobalParameterValues, (size_t len, int const *indx, const double *values), (override));
+    MOCK_METHOD(int, setGlobalParameterValues, (size_t len, int const* indx, const double* values, bool strict), (override));
     MOCK_METHOD(int, setGlobalParameterInitValues, (size_t len, int const *indx, double const *values), (override));
     MOCK_METHOD(int, getGlobalParameterInitValues, (size_t len, int const *indx, double *values), (override));
     MOCK_METHOD(int, getNumCompartments, (), (override));
@@ -57,6 +60,7 @@ public:
     MOCK_METHOD(std::string, getCompartmentId, (size_t index), (override));
     MOCK_METHOD(int, getCompartmentVolumes, (size_t len, int const *indx, double *values), (override));
     MOCK_METHOD(int, setCompartmentVolumes, (size_t len, int const *indx, const double *values), (override));
+    MOCK_METHOD(int, setCompartmentVolumes, (size_t len, int const* indx, const double* values, bool strict), (override));
     MOCK_METHOD(int, setCompartmentInitVolumes, (size_t len, int const *indx, double const *values), (override));
     MOCK_METHOD(int, getCompartmentInitVolumes, (size_t len, int const *indx, double *values), (override));
     MOCK_METHOD(void, getIds, (int types, std::list<std::string> & ids), (override));

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -21,6 +21,14 @@ public:
 };
 
 
+TEST_F(ModelAnalysisTests, checkUCCForSet) {
+    RoadRunner rr((modelAnalysisModelsDir / "BIOMD0000000021.xml").string());
+    //Behind the scenes, we get and then set various values to calculate ucc, and 
+    // have to ensure that we don't worry about setting something that's already set.
+    double val = rr.getValue("ucc(P0_to_P1, V_mT)");
+    EXPECT_NEAR(val, 7.78235, 0.001);
+}
+
 TEST_F(ModelAnalysisTests, getConcentrationRateSimple) {
     RoadRunner rr((modelAnalysisModelsDir / "threestep.xml").string());
     double S1_conc_rate = rr.getValue("[S1]'");
@@ -1374,5 +1382,3 @@ TEST_F(ModelAnalysisTests, ResetAfterControlCalc) {
 
     EXPECT_EQ(pre, post);
 }
-
-

--- a/test/models/ModelAnalysis/BIOMD0000000021.xml
+++ b/test/models/ModelAnalysis/BIOMD0000000021.xml
@@ -1,0 +1,1274 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<sbml xmlns="http://www.sbml.org/sbml/level2" level="2" metaid="metaid_0000001" version="1">
+  <model id="Leloup1999_CircClock_periodic" name="Leloup1999_CircClock" metaid="metaid_0000002">
+    <notes>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+        <p>This model originates from BioModels Database: A Database of Annotated Published Models. It is copyright (c) 2005-2009 The BioModels Team.<br/>For more information see the <a href="http://www.ebi.ac.uk/biomodels/legal.html" target="_blank">terms of use</a>.<br/>To cite BioModels Database, please use <a href="http://www.pubmedcentral.nih.gov/articlerender.fcgi?tool=pubmed&amp;pubmedid=16381960" target="_blank">Le Novère N., Bornstein B., Broicher A., Courtot M., Donizelli M., Dharuri H., Li L., Sauro H., Schilstra M., Shapiro B., Snoep J.L., Hucka M. (2006) BioModels Database: A Free, Centralized Database of Curated, Published, Quantitative Kinetic Models of Biochemical and Cellular Systems Nucleic Acids Res., 34: D689-D691.</a>
+      </p>
+    </body>
+  </notes>
+    <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000002">
+	<dc:creator>
+	<rdf:Bag>
+	<rdf:li rdf:parseType="Resource">
+	<vCard:N rdf:parseType="Resource">
+	<vCard:Family>Le Novère</vCard:Family>
+	<vCard:Given>Nicolas</vCard:Given>
+	</vCard:N>
+	<vCard:EMAIL>lenov@ebi.ac.uk</vCard:EMAIL>
+	<vCard:ORG rdf:parseType="Resource">
+	<vCard:Orgname>EMBL-EBI</vCard:Orgname>
+	</vCard:ORG>
+	</rdf:li>
+	<rdf:li rdf:parseType="Resource">
+	<vCard:N rdf:parseType="Resource">
+	<vCard:Family>Shapiro</vCard:Family>
+	<vCard:Given>Bruce</vCard:Given>
+	</vCard:N>
+	<vCard:EMAIL>bshapiro@jpl.nasa.gov</vCard:EMAIL>
+	<vCard:ORG rdf:parseType="Resource">
+	<vCard:Orgname>NASA Jet Propulsion Laboratory</vCard:Orgname>
+	</vCard:ORG>
+	</rdf:li>
+	</rdf:Bag>
+	</dc:creator>
+	<dcterms:created rdf:parseType="Resource">
+	<dcterms:W3CDTF>2005-06-29T10:27:52Z</dcterms:W3CDTF>
+	</dcterms:created>
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2015-02-25T13:16:43Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqmodel:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/biomodels.db/MODEL6617834203"/>
+	</rdf:Bag>
+	</bqmodel:is>
+	<bqmodel:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/biomodels.db/BIOMD0000000021"/>
+	</rdf:Bag>
+	</bqmodel:is>
+	<bqmodel:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/pubmed/10366496"/>
+	</rdf:Bag>
+	</bqmodel:isDescribedBy>
+	<bqmodel:isDerivedFrom>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/biomodels.db/BIOMD0000000171"/>
+	</rdf:Bag>
+	</bqmodel:isDerivedFrom>
+	<bqbiol:hasTaxon>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/taxonomy/7227"/>
+	</rdf:Bag>
+	</bqbiol:hasTaxon>
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/kegg.pathway/dme04710"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0042752"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+      <listOfUnitDefinitions>
+      <unitDefinition id="substance" name="nanomole (default)" metaid="metaid_0000003">
+        <listOfUnits>
+          <unit scale="-9" metaid="be6ed642-357c-44e8-b5eb-60592d20150d" kind="mole"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="time" name="hour (default)" metaid="metaid_0000005">
+        <listOfUnits>
+          <unit metaid="_82138a11-f6dd-4f59-b4c0-7370deb90814" multiplier="3600" kind="second"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment id="Cell" name="cytoplasm" metaid="metaid_0000012" size="1">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000012">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0005737"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </compartment>
+      <compartment id="compartment_0000002" name="nucleus" metaid="metaid_0000049" outside="Cell" size="1">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000049">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0005634"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </compartment>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="P0" initialConcentration="0" name="PER Protein (unphosphorylated)" metaid="metaid_0000013" compartment="Cell">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000013">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P07663"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species id="T0" initialConcentration="0" name="TIM Protein (unphosphorylated)" metaid="metaid_0000014" compartment="Cell">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000014">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P49021"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species id="P1" initialConcentration="0" name="PER Protein (mono-phosphorylated)" metaid="metaid_0000015" compartment="Cell">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000015">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P07663"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species id="T1" initialConcentration="0" name="TIM Protein (mono-phosphorylated)" metaid="metaid_0000016" compartment="Cell">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000016">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P49021"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species id="P2" initialConcentration="0" name="PER Protein (bi-phosphorylated)" metaid="metaid_0000017" compartment="Cell">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000017">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P07663"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species id="T2" initialConcentration="0" name="TIM Protein (bi-phosphorylated)" metaid="metaid_0000018" compartment="Cell">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000018">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P49021"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species id="CC" initialConcentration="0" name="Cytosolic PER-TIM Complex" metaid="metaid_0000019" compartment="Cell">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000019">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P49021"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P07663"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species id="Cn" initialConcentration="0" name="Nuclear PER-TIM Complex" metaid="metaid_0000020" compartment="compartment_0000002">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000020">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P49021"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P07663"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species id="Mp" initialConcentration="0" name="PER mRNA" metaid="metaid_0000021" compartment="Cell">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000021">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:33699"/>
+	<rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00046"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species id="Mt" initialConcentration="0" name="TIM mRNA" metaid="metaid_0000022" compartment="Cell">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000022">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:33699"/>
+	<rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00046"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+            </species>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="Pt" constant="false" name="Total Per" metaid="metaid_0000008"/>
+      <parameter id="Tt" constant="false" name="Total Tim" metaid="metaid_0000009"/>
+      <parameter id="V_mT" metaid="metaid_0000010" value="0.7">
+        <notes>
+        <body xmlns="http://www.w3.org/1999/xhtml">
+          <p>V_mT=.7 (physiological oscillations); 0.28 (chaos); .4 or .99 (biorhythmicity example)</p>
+        </body>
+      </notes>
+      </parameter>
+      <parameter id="V_dT" metaid="metaid_0000011" value="2">
+        <notes>
+        <body xmlns="http://www.w3.org/1999/xhtml">
+          <p>V_dT=2 (physiological oscillations); 4.8 (chaos); 3.8 or 2 (biorhythmicity example)</p>
+        </body>
+      </notes>
+      </parameter>
+    </listOfParameters>
+    <listOfRules>
+      <assignmentRule metaid="metaid_0000023" variable="Pt">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <plus/>
+            <ci> CC </ci>
+            <ci> Cn </ci>
+            <ci> P0 </ci>
+            <ci> P1 </ci>
+            <ci> P2 </ci>
+          </apply>
+        </math>
+            </assignmentRule>
+      <assignmentRule metaid="metaid_0000024" variable="Tt">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <plus/>
+            <ci> CC </ci>
+            <ci> Cn </ci>
+            <ci> T0 </ci>
+            <ci> T1 </ci>
+            <ci> T2 </ci>
+          </apply>
+        </math>
+            </assignmentRule>
+    </listOfRules>
+    <listOfReactions>
+      <reaction id="P0_to_P1" name="First Phosphorylation of PER" metaid="metaid_0000025" reversible="false">
+        <notes>
+        <body xmlns="http://www.w3.org/1999/xhtml">
+          <p>This phosphorylation is triggered by the protein product of the gene <em>double-time</em> (DBT, <a href="http://www.uniprot.org/entry/O76324">DCO_DROME</a>). Not explicitely represented in the model.</p>
+        </body>
+      </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000025">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.11.1"/>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006468"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="P0" metaid="eb7323b4-c644-4067-9c3e-bb4a81c1c1ef"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="P1" metaid="_1762bf51-7790-410e-818a-d71779a0a6c0"/>
+        </listOfProducts>
+        <kineticLaw metaid="ac180c81-5336-4f1a-b790-6b06b0191fb1">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> V_1P </ci>
+                <ci> P0 </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> K1_P </ci>
+                <ci> P0 </ci>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="K1_P" metaid="_727239" value="2"/>
+            <parameter id="V_1P" metaid="_727241" value="8"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="T0_to_T1" name="First Phosphorylation of TIM" metaid="metaid_0000026" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000026">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.11.1"/>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006468"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="T0" metaid="_3f373a66-baa5-41cc-9e21-c470153254fc"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="T1" metaid="d19b9930-b416-46c2-a25a-fc7940ee82ef"/>
+        </listOfProducts>
+        <kineticLaw metaid="_88e2474a-a46c-4c74-b8b7-85bbdce5fd9e">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> V_1T </ci>
+                <ci> T0 </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> K_1T </ci>
+                <ci> T0 </ci>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="K_1T" metaid="_727243" value="2"/>
+            <parameter id="V_1T" metaid="_727245" value="8"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="P1_to_P0" name="Dephosphorylation of PER (1st P)" metaid="metaid_0000027" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000027">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/3.1.3.16"/>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006470"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="P1" metaid="_4effb747-e348-4b51-bb81-3637dbada2a5"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="P0" metaid="_99d36cf1-3873-43ea-88e3-8e1145c2038a"/>
+        </listOfProducts>
+        <kineticLaw metaid="_2f892d79-9043-433e-94d3-f7a0c789eedf">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> V_2P </ci>
+                <ci> P1 </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> K_2P </ci>
+                <ci> P1 </ci>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="K_2P" metaid="_727247" value="2"/>
+            <parameter id="V_2P" metaid="_727249" value="1"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="T1_to_T0" name="Dephosphorylation of TIM (1st P)" metaid="metaid_0000028" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000028">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/3.1.3.16"/>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006470"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="T1" metaid="_4e846094-8b8c-4d61-8210-7a0c781d8057"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="T0" metaid="_70a72dd5-fcf5-4305-b29b-bc5881e219f3"/>
+        </listOfProducts>
+        <kineticLaw metaid="_5024104c-d32b-4d5e-b8bf-bc391f8d3933">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> V_2T </ci>
+                <ci> T1 </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> K_2T </ci>
+                <ci> T1 </ci>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="K_2T" metaid="_727251" value="2"/>
+            <parameter id="V_2T" metaid="_727253" value="1"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="P1_to_P2" name="Second Phosphorylation of PER" metaid="metaid_0000029" reversible="false">
+        <notes>
+        <body xmlns="http://www.w3.org/1999/xhtml">
+          <p>This phosphorylation is triggered by the protein product of the gene <em>double-time</em> (DBT, <a href="http://www.uniprot.org/entry/O76324">DCO_DROME</a>). Not explicitely represented in the model.</p>
+        </body>
+      </notes>
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000029">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.11.1"/>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006468"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="P1" metaid="_0bc6c8c0-47bd-4d4e-82c3-c62ad60d34c3"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="P2" metaid="f64833fa-1d3a-4e6f-8614-55cec2941585"/>
+        </listOfProducts>
+        <kineticLaw metaid="_54163e56-0fb4-4502-928b-b7f622cf09d1">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> V_3P </ci>
+                <ci> P1 </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> K_3P </ci>
+                <ci> P1 </ci>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="K_3P" metaid="_727255" value="2"/>
+            <parameter id="V_3P" metaid="_727257" value="8"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="T1_to_T2" name="Second Phosphorylation of TIM" metaid="metaid_0000030" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000030">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.11.1"/>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006468"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="T1" metaid="_6278ec2c-54b8-4077-aa3a-c15726c81775"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="T2" metaid="a6c73c32-8b91-4090-bbfc-bd436282a97e"/>
+        </listOfProducts>
+        <kineticLaw metaid="_752dffc9-4a5e-40a1-8b7b-ddbac8dd040f">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> V_3T </ci>
+                <ci> T1 </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> K_3T </ci>
+                <ci> T1 </ci>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="K_3T" metaid="_727259" value="2"/>
+            <parameter id="V_3T" metaid="_727261" value="8"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="P2_to_P1" name="Dephosphorylation of PER (2nd P)" metaid="metaid_0000031" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000031">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/3.1.3.16"/>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006470"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="P2" metaid="_0e390c99-d2d4-4e32-a39b-90217e3813ea"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="P1" metaid="a2b77f9c-4528-4bd5-8237-23854f4bfd28"/>
+        </listOfProducts>
+        <kineticLaw metaid="_72ffae63-65fa-4853-a931-4fdd55761104">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> V_4P </ci>
+                <ci> P2 </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> K_4P </ci>
+                <ci> P2 </ci>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="K_4P" metaid="_727263" value="2"/>
+            <parameter id="V_4P" metaid="_727265" value="1"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="T2_to_T1" name="Dephosphorylation of TIM (2nd P)" metaid="metaid_0000032" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000032">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/3.1.3.16"/>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006470"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="T2" metaid="_7e42605d-88c8-4b54-b62a-dcc393f3022e"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="T1" metaid="f8b9fb1f-58e1-4161-93d2-34e0439d70de"/>
+        </listOfProducts>
+        <kineticLaw metaid="_962193bc-72bc-4cfc-977c-f6aef4d75fe9">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> V_4T </ci>
+                <ci> T2 </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> K_4T </ci>
+                <ci> T2 </ci>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="K_4T" metaid="_727267" value="2"/>
+            <parameter id="V_4T" metaid="_727269" value="1"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="P0_degradation" name="PER degradation" metaid="metaid_0000033" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000033">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="P0" metaid="_1f91e609-52e0-464a-b5fb-3456c21f02b8"/>
+        </listOfReactants>
+        <kineticLaw metaid="_12a9636a-242e-4fbe-911d-209386c34ecc">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <ci> k_d </ci>
+              <ci> P0 </ci>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k_d" metaid="_727271" value="0.01"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="T0_degradation" name="TIM degradation" metaid="metaid_0000034" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000034">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="T0" metaid="_66fc0702-facc-4857-afbb-b23706dd0f83"/>
+        </listOfReactants>
+        <kineticLaw metaid="_19088145-b75a-44d9-b2f0-5d4789d75f59">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <ci> k_d </ci>
+              <ci> T0 </ci>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k_d" metaid="_727272" value="0.01"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="P1_degradation" name="PER-1 degradation" metaid="metaid_0000035" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000035">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="P1" metaid="_824ddd9b-9fd6-4159-a7f1-eeb8e03aa59b"/>
+        </listOfReactants>
+        <kineticLaw metaid="_707a63ac-0df2-4c7e-b451-ae9ed4adf238">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <ci> k_d </ci>
+              <ci> P1 </ci>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k_d" metaid="_727273" value="0.01"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="T1_degradation" name="TIM-1 degradation" metaid="metaid_0000036" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000036">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="T1" metaid="_4d420e93-4b35-49ca-b607-a03122a6b924"/>
+        </listOfReactants>
+        <kineticLaw metaid="ac4f8c01-1269-48c6-827e-0bd4286169c5">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <ci> k_d </ci>
+              <ci> T1 </ci>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k_d" metaid="_727275" value="0.01"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="P2_degradation" name="PER-2 degradation" metaid="metaid_0000037" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000037">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="P2" metaid="_5a10e740-a44c-453c-bca9-2c9e5bbd82db"/>
+        </listOfReactants>
+        <kineticLaw metaid="b0dfc84a-b8f9-424e-8a4a-475730920e89">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <plus/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> k_d </ci>
+                <ci> P2 </ci>
+              </apply>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Cell </ci>
+                  <ci> V_dP </ci>
+                  <ci> P2 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> K_dP </ci>
+                  <ci> P2 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k_d" metaid="_727276" value="0.01"/>
+            <parameter id="V_dP" metaid="_727277" value="2"/>
+            <parameter id="K_dP" metaid="_727279" value="0.2"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="T2_degradation" name="TIM-2 degradation" metaid="metaid_0000038" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000038">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="T2" metaid="d1d4c269-0efc-4622-a591-5783c74c0cba"/>
+        </listOfReactants>
+        <kineticLaw metaid="_59168c32-a607-4a6a-bde3-44f8ddacf569">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <plus/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> k_d </ci>
+                <ci> T2 </ci>
+              </apply>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Cell </ci>
+                  <ci> V_dT </ci>
+                  <ci> T2 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> K_dT </ci>
+                  <ci> T2 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k_d" metaid="_727281" value="0.01"/>
+            <parameter id="K_dT" metaid="_727283" value="0.2"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="PT_complex_formation" name="PER-TIM complex formation" metaid="metaid_0000039">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000039">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006461"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="P2" metaid="ded8e8ea-76d3-4598-be99-01fc1236245b"/>
+          <speciesReference species="T2" metaid="_83066b32-4bab-4ae1-9a0b-1332d27f0271"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="CC" metaid="d7db0c02-f36b-4cd6-b720-da7e44766a87"/>
+        </listOfProducts>
+        <kineticLaw metaid="fcce4871-d2a6-4c87-8c15-169d5e45ded7">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <minus/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> k3 </ci>
+                <ci> P2 </ci>
+                <ci> T2 </ci>
+              </apply>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> k4 </ci>
+                <ci> CC </ci>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k3" metaid="_727285" value="1.2"/>
+            <parameter id="k4" metaid="_727287" value="0.6"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="PT_complex_nucleation" name="PER-TIM complex nucleation" metaid="metaid_0000040">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000040">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006606"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="CC" metaid="_6116b0ca-972d-4527-9ca5-c5e00347d329"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="Cn" metaid="_5efdcf22-a5f4-496d-a0a2-189a10eb2d09"/>
+        </listOfProducts>
+        <kineticLaw metaid="d429e613-b9d2-4797-a9dd-b7afa8ef8b5c">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <minus/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> k1 </ci>
+                <ci> CC </ci>
+              </apply>
+              <apply>
+                <times/>
+                <ci> compartment_0000002 </ci>
+                <ci> k2 </ci>
+                <ci> Cn </ci>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k1" metaid="_727289" value="0.6"/>
+            <parameter id="k2" metaid="_727291" value="0.2"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="PT_complex_degradation" name="PER-TIM complex degradation (cytosol)" metaid="metaid_0000041" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000041">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="CC" metaid="_55382236-b33b-4c25-9f0d-8aed74a35bb8"/>
+        </listOfReactants>
+        <kineticLaw metaid="_6c547fe1-0939-4662-8f5d-52ab552911ef">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <ci> k_dC </ci>
+              <ci> CC </ci>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k_dC" metaid="_727293" value="0.01"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="PTnucl_complex_degradation" name="PER-TIM complex degradation (nuclear)" metaid="metaid_0000042" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000042">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="Cn" metaid="_1dd7e968-0174-46e2-949c-5a96bd73ed43"/>
+        </listOfReactants>
+        <kineticLaw metaid="_223c61da-a933-4e64-baca-bb126664f4fb">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_0000002 </ci>
+              <ci> k_dN </ci>
+              <ci> Cn </ci>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k_dN" metaid="_727294" value="0.01"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="Mp_production" name="PER mRNA production" metaid="metaid_0000043" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000043">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0009299"/>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006355"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfProducts>
+          <speciesReference species="Mp" metaid="_16d7e551-8f7e-445e-baf9-8ee5f6dec135"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference species="Cn" metaid="_4ea46937-e153-4a09-b182-5a12470ce929"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_8e9f3b0a-ccd1-4c2e-91e9-d9d6c043ddaf">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> v_sP </ci>
+                <apply>
+                  <power/>
+                  <ci> K_IP </ci>
+                  <ci> n </ci>
+                </apply>
+              </apply>
+              <apply>
+                <plus/>
+                <apply>
+                  <power/>
+                  <ci> K_IP </ci>
+                  <ci> n </ci>
+                </apply>
+                <apply>
+                  <power/>
+                  <ci> Cn </ci>
+                  <ci> n </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="v_sP" metaid="_727295" value="1"/>
+            <parameter id="K_IP" metaid="_727296" value="1"/>
+            <parameter id="n" metaid="_727297" value="4"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="Mt_production" name="TIM mRNA production" metaid="metaid_0000044" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000044">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0009299"/>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006355"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfProducts>
+          <speciesReference species="Mt" metaid="_59cfd0a3-f740-48f0-bc21-84a9531ee76e"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference species="Cn" metaid="_394e38bf-5ca0-44ac-bd30-9dd93d8b9e66"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_496d05d5-4d8f-4649-b49a-0f536c725788">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> V_sT </ci>
+                <apply>
+                  <power/>
+                  <ci> K_IT </ci>
+                  <ci> n </ci>
+                </apply>
+              </apply>
+              <apply>
+                <plus/>
+                <apply>
+                  <power/>
+                  <ci> K_IT </ci>
+                  <ci> n </ci>
+                </apply>
+                <apply>
+                  <power/>
+                  <ci> Cn </ci>
+                  <ci> n </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="V_sT" metaid="_727298" value="1"/>
+            <parameter id="K_IT" metaid="_727299" value="1"/>
+            <parameter id="n" metaid="_727301" value="4"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="P0_production" name="PER production" metaid="metaid_0000045" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000045">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006412"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfProducts>
+          <speciesReference species="P0" metaid="_0de26dae-ab04-4c5c-87bf-70ecefeed722"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference species="Mp" metaid="_388a860b-d473-4e86-b77a-d6eea61491d6"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_9d2b5391-5c31-48ed-a3de-d7a7dfc27530">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <ci> k_sP </ci>
+              <ci> Mp </ci>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k_sP" metaid="_727303" value="0.9"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="T0_production" name="TIM production" metaid="metaid_0000046" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000046">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006412"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfProducts>
+          <speciesReference species="T0" metaid="ab7414cc-b437-490f-a887-b79059791830"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference species="Mt" metaid="d0250058-2489-42b2-979b-7cb88eaf25cb"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_1415ce64-f593-472e-876d-23d65beea702">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <ci> k_sT </ci>
+              <ci> Mt </ci>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k_sT" metaid="_727304" value="0.9"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="Mp_degradation" name="PER mRNA degradation" metaid="metaid_0000047" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000047">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006402"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="Mp" metaid="ae123f65-a6d7-4c06-8910-55f6d462e235"/>
+        </listOfReactants>
+        <kineticLaw metaid="a3912b6b-2cd8-458a-a427-f898d78f8608">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <plus/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> k_d </ci>
+                <ci> Mp </ci>
+              </apply>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Cell </ci>
+                  <ci> V_mP </ci>
+                  <ci> Mp </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> K_mP </ci>
+                  <ci> Mp </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k_d" metaid="_727305" value="0.01"/>
+            <parameter id="V_mP" metaid="_727306" value="0.7"/>
+            <parameter id="K_mP" metaid="_727307" value="0.2"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="Mt_degradation" name="TIM mRNA degradation" metaid="metaid_0000048" reversible="false">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+	<rdf:Description rdf:about="#metaid_0000048">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0006402"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	</rdf:RDF>
+	</annotation>
+              <listOfReactants>
+          <speciesReference species="Mt" metaid="b9e4c100-7f9e-4648-a130-991ac43bdba8"/>
+        </listOfReactants>
+        <kineticLaw metaid="de3a20f2-9096-44a7-938c-3bb7db3d429d">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <plus/>
+              <apply>
+                <times/>
+                <ci> Cell </ci>
+                <ci> k_d </ci>
+                <ci> Mt </ci>
+              </apply>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Cell </ci>
+                  <ci> V_mT </ci>
+                  <ci> Mt </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> K_mT </ci>
+                  <ci> Mt </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                  <listOfParameters>
+            <parameter id="k_d" metaid="_727308" value="0.01"/>
+            <parameter id="K_mT" metaid="_727309" value="0.2"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>


### PR DESCRIPTION
To calculate ucc's, we use the current model state as a sort of scratch pad for calculations, and then have to reset everything again after we're done.  However, some of those set values might already be set due to assignment rules.  So I had to implement a whole 'strict' system for the setters so that they could continue even when asked to do something dumb, because figuring things out manually would be even more work and rigamarole.