### PR TITLE
Fix for #779:  remove warnings.

### DIFF
--- a/source/llvm/CodeGenBase.h
+++ b/source/llvm/CodeGenBase.h
@@ -13,7 +13,23 @@
 #include "LLVMException.h"
 #include "rrLogger.h"
 #include <Poco/Logger.h>
+
+#ifdef _MSC_VER
+#pragma warning(disable: 4146)
+#pragma warning(disable: 4141)
+#pragma warning(disable: 4267)
+#pragma warning(disable: 4624)
+#endif
+
 #include "llvm/IR/Mangler.h"
+
+#ifdef _MSC_VER
+#pragma warning(default: 4146)
+#pragma warning(default: 4141)
+#pragma warning(default: 4267)
+#pragma warning(default: 4624)
+#endif
+
 
 using rr::Logger;
 using rr::getLogger;

--- a/source/llvm/Jit.cpp
+++ b/source/llvm/Jit.cpp
@@ -8,11 +8,26 @@
 #include "Jit.h"
 #include "ModelResources.h"
 #include "rrRoadRunnerOptions.h"
-#include "llvm/Support/TargetRegistry.h"
-#include "llvm/Support/Host.h"
 #include "SBMLModelObjectCache.h"
 #include "rrRoadRunnerOptions.h"
 #include "SBMLSupportFunctions.h"
+
+#ifdef _MSC_VER
+#pragma warning(disable: 4146)
+#pragma warning(disable: 4141)
+#pragma warning(disable: 4267)
+#pragma warning(disable: 4624)
+#endif
+
+#include "llvm/Support/TargetRegistry.h"
+#include "llvm/Support/Host.h"
+
+#ifdef _MSC_VER
+#pragma warning(default: 4146)
+#pragma warning(default: 4141)
+#pragma warning(default: 4267)
+#pragma warning(default: 4624)
+#endif
 
 using namespace rr;
 

--- a/source/llvm/Jit.h
+++ b/source/llvm/Jit.h
@@ -7,16 +7,31 @@
 
 #define NOMINMAX
 
-#include <llvm/Analysis/TargetLibraryInfo.h>
 #include <rrSparse.h>
-#include "llvm/IR/IRBuilder.h"
 #include "LLVMException.h"
+#include "rrSparse.h"
+#include <unordered_map>
+
+#ifdef _MSC_VER
+#pragma warning(disable: 4146)
+#pragma warning(disable: 4141)
+#pragma warning(disable: 4267)
+#pragma warning(disable: 4624)
+#endif
+
+#include <llvm/Analysis/TargetLibraryInfo.h>
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/ExecutionEngine/ObjectCache.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Object/ObjectFile.h"
-#include "llvm/ExecutionEngine/ObjectCache.h"
-#include "rrSparse.h"
 #include "llvm/IR/Mangler.h"
-#include <unordered_map>
+
+#ifdef _MSC_VER
+#pragma warning(default: 4146)
+#pragma warning(default: 4141)
+#pragma warning(default: 4267)
+#pragma warning(default: 4624)
+#endif
 
 namespace rr {
     class ExecutableModel;

--- a/source/llvm/LLJit.cpp
+++ b/source/llvm/LLJit.cpp
@@ -6,18 +6,33 @@
 #include "LLJit.h"
 #include "rrConfig.h"
 #include "rrLogger.h"
-#include "llvm/IR/Function.h"
 #include "SBMLSupportFunctions.h"
-#include "llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h"
 #include "ModelDataIRBuilder.h"
-#include "llvm/Target/TargetMachine.h"
-#include "llvm/IRReader/IRReader.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "SBMLModelObjectCache.h"
 #include "rrRoadRunnerOptions.h"
 #include "rrSparse.h"
 #include <thread>
+
+#ifdef _MSC_VER
+#pragma warning(disable: 4146)
+#pragma warning(disable: 4141)
+#pragma warning(disable: 4267)
+#pragma warning(disable: 4624)
+#endif
+
+#include "llvm/IR/Function.h"
+#include "llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
+
+#ifdef _MSC_VER
+#pragma warning(default: 4146)
+#pragma warning(default: 4141)
+#pragma warning(default: 4267)
+#pragma warning(default: 4624)
+#endif
 
 #if LIBSBML_HAS_PACKAGE_DISTRIB
 

--- a/source/llvm/LLJit.h
+++ b/source/llvm/LLJit.h
@@ -7,12 +7,26 @@
 
 #define NOMINMAX
 
+#include "SBMLModelObjectCache.h"
+
+#ifdef _MSC_VER
+#pragma warning(disable: 4146)
+#pragma warning(disable: 4141)
+#pragma warning(disable: 4267)
+#pragma warning(disable: 4624)
+#endif
+
 #include <llvm/IRReader/IRReader.h>
 #include "llvm/Jit.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/Support/SourceMgr.h"
-#include "SBMLModelObjectCache.h"
 
+#ifdef _MSC_VER
+#pragma warning(default: 4146)
+#pragma warning(default: 4141)
+#pragma warning(default: 4267)
+#pragma warning(default: 4624)
+#endif
 
 using namespace rr;
 

--- a/source/llvm/LLVMIncludes.h
+++ b/source/llvm/LLVMIncludes.h
@@ -24,6 +24,10 @@
 
 #ifdef _MSC_VER
 #pragma warning( push )
+#pragma warning(disable: 4146)
+#pragma warning(disable: 4141)
+#pragma warning(disable: 4267)
+#pragma warning(disable: 4624)
 #pragma warning( disable : 4355 )
 #pragma warning( disable : 4244 )
 #endif
@@ -95,6 +99,13 @@
 
 #ifdef _MSC_VER
 #pragma warning( pop )
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(default: 4146)
+#pragma warning(default: 4141)
+#pragma warning(default: 4267)
+#pragma warning(default: 4624)
 #endif
 
 #pragma pop_macro("min")

--- a/source/llvm/LLVMModelGenerator.cpp
+++ b/source/llvm/LLVMModelGenerator.cpp
@@ -15,6 +15,7 @@
 #include "LLVMExecutableModel.h"
 #include "ModelGeneratorContext.h"
 #include "LLVMIncludes.h"
+#include "JitFactory.h"
 #include "ModelResources.h"
 #include "Random.h"
 #include <rrLogger.h>
@@ -28,12 +29,9 @@
 #pragma warning(disable: 4624)
 #endif
 
-
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/LLVMExecutableModel.h"
-
 #include "llvm/MCJit.h"
-#include "JitFactory.h"
 
 #if LLVM_VERSION_MAJOR >= 13
 

--- a/source/llvm/MCJit.cpp
+++ b/source/llvm/MCJit.cpp
@@ -2,16 +2,31 @@
 // Created by Ciaran on 25/10/2021.
 //
 
-#include <llvm/ExecutionEngine/SectionMemoryManager.h>
-#include "llvm/Support/DynamicLibrary.h"
 #include "MCJit.h"
 #include "ModelDataIRBuilder.h"
 #include "SBMLSupportFunctions.h"
 #include "rrRoadRunnerOptions.h"
 #include "rrLogger.h"
 #include "ModelResources.h"
+
+#ifdef _MSC_VER
+#pragma warning(disable: 4146)
+#pragma warning(disable: 4141)
+#pragma warning(disable: 4267)
+#pragma warning(disable: 4624)
+#endif
+
+#include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#include "llvm/Support/DynamicLibrary.h"
 #include "llvm/IR/AssemblyAnnotationWriter.h"
 #include "llvm/IR/Mangler.h"
+
+#ifdef _MSC_VER
+#pragma warning(default: 4146)
+#pragma warning(default: 4141)
+#pragma warning(default: 4267)
+#pragma warning(default: 4624)
+#endif
 
 #ifdef LIBSBML_HAS_PACKAGE_DISTRIB
 

--- a/source/llvm/MCJit.h
+++ b/source/llvm/MCJit.h
@@ -7,8 +7,23 @@
 
 #include <rrRoadRunnerOptions.h>
 #include "Jit.h"
+
+#ifdef _MSC_VER
+#pragma warning(disable: 4146)
+#pragma warning(disable: 4141)
+#pragma warning(disable: 4267)
+#pragma warning(disable: 4624)
+#endif
+
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
 #include "llvm/IR/LegacyPassManager.h"
+
+#ifdef _MSC_VER
+#pragma warning(default: 4146)
+#pragma warning(default: 4141)
+#pragma warning(default: 4267)
+#pragma warning(default: 4624)
+#endif
 
 
 using namespace llvm;

--- a/source/llvm/ModelGeneratorContext.cpp
+++ b/source/llvm/ModelGeneratorContext.cpp
@@ -121,7 +121,7 @@ namespace rrllvm {
         try {
 
             if (options & LoadSBMLOptions::CONSERVED_MOIETIES) {
-                if ((rr::Config::getBool(rr::Config::ROADRUNNER_DISABLE_WARNINGS) &
+                if ((rr::Config::getBool(rr::Config::ROADRUNNER_DISABLE_WARNINGS) &&
                      rr::Config::ROADRUNNER_DISABLE_WARNINGS_CONSERVED_MOIETY) == 0) {
                     rrLog(Logger::LOG_NOTICE) << "performing conserved moiety conversion";
                 }

--- a/source/llvm/ModelGeneratorContext.h
+++ b/source/llvm/ModelGeneratorContext.h
@@ -26,6 +26,7 @@
 #pragma warning(disable: 4141)
 #pragma warning(disable: 4267)
 #pragma warning(disable: 4624)
+#pragma warning(disable: 4244)
 #endif
 
 #include "llvm/IR/LegacyPassManager.h"
@@ -36,6 +37,7 @@
 #pragma warning(default: 4141)
 #pragma warning(default: 4267)
 #pragma warning(default: 4624)
+#pragma warning(default: 4244)
 #endif
 
 namespace libsbml {

--- a/source/llvm/ModelResources.cpp
+++ b/source/llvm/ModelResources.cpp
@@ -14,7 +14,6 @@
 #include "rrRoadRunnerOptions.h"
 #include "MCJit.h"
 #include "LLJit.h"
-#include "llvm/SBMLSupportFunctions.h"
 #include "rrRoadRunnerOptions.h"
 
 #include <memory>
@@ -30,6 +29,7 @@
 #pragma warning(disable: 4624)
 #endif
 
+#include "llvm/SBMLSupportFunctions.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Support/Error.h"

--- a/source/llvm/ModelResources.h
+++ b/source/llvm/ModelResources.h
@@ -10,7 +10,21 @@
 #define CACHEDMODEL_H_
 
 #include "LLVMExecutableModel.h"
+#ifdef _MSC_VER
+#pragma warning(disable: 4146)
+#pragma warning(disable: 4141)
+#pragma warning(disable: 4267)
+#pragma warning(disable: 4624)
+#endif
+
 #include "llvm/Jit.h"
+
+#ifdef _MSC_VER
+#pragma warning(default: 4146)
+#pragma warning(default: 4141)
+#pragma warning(default: 4267)
+#pragma warning(default: 4624)
+#endif
 
 namespace rr {
     class ExecutableModel;

--- a/source/llvm/SBMLModelObjectCache.h
+++ b/source/llvm/SBMLModelObjectCache.h
@@ -8,9 +8,23 @@
 #define NOMINMAX
 
 #include <memory>
+#ifdef _MSC_VER
+#pragma warning(disable: 4146)
+#pragma warning(disable: 4141)
+#pragma warning(disable: 4267)
+#pragma warning(disable: 4624)
+#endif
+
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ExecutionEngine/ObjectCache.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
+
+#ifdef _MSC_VER
+#pragma warning(default: 4146)
+#pragma warning(default: 4141)
+#pragma warning(default: 4267)
+#pragma warning(default: 4624)
+#endif
 
 
 namespace rrllvm {

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -4,73 +4,58 @@
 
 #include "rrOSSpecifics.h"
 
-#include <iostream>
-#include <list>
-#include "rrRoadRunner.h"
-#include "rrException.h"
+#include "ApproxSteadyStateDecorator.h"
 #include "ExecutableModelFactory.h"
-#include "rrCompiler.h"
-#include "rrLogger.h"
-#include "rrUtils.h"
-#include "rrExecutableModel.h"
-#include "rr-libstruct/lsLA.h"
-#include "rr-libstruct/lsLibla.h"
-#include "rrConstants.h"
-#include "rrVersionInfo.h"
+#include "ForwardSensitivitySolver.h"
 #include "Integrator.h"
-#include "SteadyStateSolver.h"
-#include "rrSBMLReader.h"
-#include "rrConfig.h"
+#include "IntegratorFactory.h"
+#include "PresimulationDecorator.h"
+#include "PresimulationProgramDecorator.h"
 #include "SBMLValidator.h"
-#include "sbml/ListOf.h"
-#include "sbml/Model.h"
-#include "sbml/math/FormulaParser.h"
-#include "sbml/common/operationReturnValues.h"
 #include "SVD.h"
 #include "SensitivitySolver.h"
-#include "ForwardSensitivitySolver.h"
 #include "SensitivitySolverFactory.h"
+#include "SteadyStateSolver.h"
 #include "SteadyStateSolverFactory.h"
-#include "IntegratorFactory.h"
+#include "rr-libstruct/lsLA.h"
+#include "rr-libstruct/lsLibla.h"
+#include "rrCompiler.h"
+#include "rrConfig.h"
+#include "rrConstants.h"
+#include "rrException.h"
+#include "rrExecutableModel.h"
+#include "rrLogger.h"
+#include "rrRoadRunner.h"
+#include "rrSBMLReader.h"
+#include "rrUtils.h"
+#include "rrVersionInfo.h"
+#include "sbml/ListOf.h"
+#include "sbml/Model.h"
+#include "sbml/common/operationReturnValues.h"
+#include "sbml/math/FormulaParser.h"
 
-
-#ifdef _MSC_VER
-#pragma warning(disable: 4146)
-#pragma warning(disable: 4141)
-#pragma warning(disable: 4267)
-#pragma warning(disable: 4624)
-#endif
-
+//Have to include these last because of something to do with min and max in Random.h
+#include <rr-libstruct/lsLibStructural.h>
+#include <sbml/UnitKind.h>
+#include <sbml/conversion/SBMLLevelVersionConverter.h>
+#include <sbml/conversion/SBMLLocalParameterConverter.h>
+#include <Poco/File.h>
+#include <assert.h>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <iostream>
+#include <list>
+#include <list>
+#include <math.h>
+#include <memory>
+#include <thread>
+#include <thread_pool.hpp>
+#include <utility>
+//Shouldn't need the warning-disabling #pragmas here, since these are all links to *our* llvm, not the offical LLVM source.
 #include "llvm/LLVMExecutableModel.h"
 #include "llvm/ModelResources.h"
 #include "llvm/IR/IRBuilder.h"
-#include "PresimulationDecorator.h"
-#include "ApproxSteadyStateDecorator.h"
-#include "PresimulationProgramDecorator.h"
-
-#ifdef _MSC_VER
-#pragma warning(default: 4146)
-#pragma warning(default: 4141)
-#pragma warning(default: 4267)
-#pragma warning(default: 4624)
-#endif
-
-#include <sbml/conversion/SBMLLocalParameterConverter.h>
-#include <sbml/conversion/SBMLLevelVersionConverter.h>
-#include <sbml/UnitKind.h>
-#include <thread>
-#include <thread_pool.hpp>
-
-#include <iostream>
-#include <math.h>
-#include <assert.h>
-#include <rr-libstruct/lsLibStructural.h>
-#include <Poco/File.h>
-#include <list>
-#include <cstdlib>
-#include <fstream>
-#include <memory>
-#include <utility>
 
 
 #ifdef _MSC_VER


### PR DESCRIPTION
LLVM will emit a *lot* of warnings if you let it.  We wrap llvm includes in #pragmas that disable the warning messages they give.  With the LLVM revamp, some new files evaded the old #pragmas, so this puts them back in.

Also fixed a warning that was a real problem, since it had been obscured by all the llvm warnings (an '&' instead of an '&&')