### PR TITLE
Fix the rate labels when getting *all* the rates.

### DIFF
--- a/source/llvm/EvalRateRuleRatesCodeGen.cpp
+++ b/source/llvm/EvalRateRuleRatesCodeGen.cpp
@@ -77,21 +77,21 @@ Value* EvalRateRuleRatesCodeGen::codeGen()
                         rrLog(Logger::LOG_DEBUG) << "species " << species->getId()
                                 << " is a concentration with time dependent volume, "
                                 "converting conc rate to amt rate using product rule";
-                        ASTNode *dcdt = new ASTNode(*rateRule->getMath());
-                        ASTNode *v = new ASTNode(AST_NAME);
-                        v->setName(species->getCompartment().c_str());
-
-                        ASTNode *dvdt = new ASTNode(*compRateRule->getMath());
+                        ASTNode *dcdt = new ASTNode(*compRateRule->getMath());
                         ASTNode *c = new ASTNode(AST_NAME);
-                        c->setName(species->getId().c_str());
+                        c->setName(species->getCompartment().c_str());
+
+                        ASTNode *dvdt = new ASTNode(*rateRule->getMath());
+                        ASTNode *v = new ASTNode(AST_NAME);
+                        v->setName(species->getId().c_str());
 
                         ASTNode *l = new ASTNode(AST_TIMES);
+                        l->addChild(v);
                         l->addChild(dcdt);
-                        l->addChild(c);
 
                         ASTNode *r = new ASTNode(AST_TIMES);
+                        r->addChild(c);
                         r->addChild(dvdt);
-                        r->addChild(v);
 
                         ASTNode *plus = nodes.create(AST_PLUS);
                         plus->addChild(l);

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -1166,6 +1166,12 @@ void LLVMExecutableModel::getIds(int types, std::list<std::string> &ids)
             {
                 ids.push_back(rid + "'");
             }
+            if (symbols->getFloatingSpeciesIndex(rid, false) >= 0 &&
+                (checkExact(SelectionRecord::FLOATING_AMOUNT_RATE, types) ||
+                    SelectionRecord::RATE == types))
+            {
+                ids.push_back(rid + "'");
+            }
             if (symbols->getCompartmentIndex(rid) >= 0 &&
                 (checkExact(SelectionRecord::COMPARTMENT_RATE, types) ||
                     SelectionRecord::RATE == types))
@@ -1184,7 +1190,8 @@ void LLVMExecutableModel::getIds(int types, std::list<std::string> &ids)
     if (checkExact(SelectionRecord::FLOATING_AMOUNT_RATE, types)) {
         for (size_t i = 0; i < getNumFloatingSpecies(); ++i) {
             string sid = this->getFloatingSpeciesId(i);
-            if (!symbols->hasAssignmentRule(sid))
+            if (!symbols->hasAssignmentRule(sid) &&
+                !symbols->hasRateRule(sid))
             {
                 ids.push_back(sid + "'");
             }

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -1154,6 +1154,33 @@ void LLVMExecutableModel::getIds(int types, std::list<std::string> &ids)
         }
     }
 
+    //Do the rate rules first because that's the way they're ordered in the 
+    // underlying data model.
+    if (checkExact(SelectionRecord::RATE, types)) {
+
+        for (size_t i = 0; i < symbols->getRateRuleSize(); ++i) {
+            string rid = symbols->getRateRuleId(i);
+            if (symbols->getBoundarySpeciesIndex(rid) >= 0 &&
+                (checkExact(SelectionRecord::BOUNDARY_AMOUNT_RATE, types) ||
+                    SelectionRecord::RATE == types))
+            {
+                ids.push_back(rid + "'");
+            }
+            if (symbols->getCompartmentIndex(rid) >= 0 &&
+                (checkExact(SelectionRecord::COMPARTMENT_RATE, types) ||
+                    SelectionRecord::RATE == types))
+            {
+                ids.push_back(rid + "'");
+            }
+            if (symbols->getGlobalParameterIndex(rid) >= 0 &&
+                (checkExact(SelectionRecord::GLOBAL_PARAMETER_RATE, types) ||
+                    SelectionRecord::RATE == types))
+            {
+                ids.push_back(rid + "'");
+            }
+        }
+    }
+
     if (checkExact(SelectionRecord::FLOATING_AMOUNT_RATE, types)) {
         for (size_t i = 0; i < getNumFloatingSpecies(); ++i) {
             string sid = this->getFloatingSpeciesId(i);
@@ -1180,28 +1207,6 @@ void LLVMExecutableModel::getIds(int types, std::list<std::string> &ids)
             if (!symbols->hasAssignmentRule(sid))
             {
                 ids.push_back("[" + sid + "]'");
-            }
-        }
-    }
-
-    if (checkExact(SelectionRecord::RATE, types)) {
-
-        for (size_t i = 0; i < symbols->getRateRuleSize(); ++i) {
-            string rid = symbols->getRateRuleId(i);
-            if (symbols->getBoundarySpeciesIndex(rid) >= 0 &&
-                checkExact(SelectionRecord::BOUNDARY_AMOUNT_RATE, types))
-            {
-                ids.push_back(rid + "'");
-            }
-            if (symbols->getCompartmentIndex(rid) >= 0 &&
-                checkExact(SelectionRecord::COMPARTMENT_RATE, types))
-            {
-                ids.push_back(rid + "'");
-            }
-            if (symbols->getGlobalParameterIndex(rid) >= 0 &&
-                checkExact(SelectionRecord::GLOBAL_PARAMETER_RATE, types))
-            {
-                ids.push_back(rid + "'");
             }
         }
     }

--- a/source/llvm/LLVMModelDataSymbols.cpp
+++ b/source/llvm/LLVMModelDataSymbols.cpp
@@ -526,7 +526,7 @@ std::string LLVMModelDataSymbols::getCompartmentId(size_t indx) const
 
     std::stringstream errSS;
     errSS << "Attempted to access compartment id at index " << indx << ", but ";
-    auto size = boundarySpeciesMap.size();
+    auto size = compartmentsMap.size();
     if (size == 0) {
         errSS << "there are no compartments in the model.";
     }
@@ -1568,7 +1568,7 @@ void LLVMModelDataSymbols::initEvents(const libsbml::Model* model)
                 attr = attr | EventInitialValue;
             }
 
-            // older versions seem to default to persisent
+            // older versions default to persisent
             const SBMLDocument *doc = model->getSBMLDocument();
             if (doc->getLevel() < 3 ||
                     (trigger->isSetPersistent() && trigger->getPersistent()))

--- a/source/llvm/LLVMModelGenerator.cpp
+++ b/source/llvm/LLVMModelGenerator.cpp
@@ -280,7 +280,8 @@ namespace rrllvm {
     }
 
     ExecutableModel*
-        LLVMModelGenerator::regenerateModel(rr::ExecutableModel* oldModel, libsbml::SBMLDocument* doc, uint options) {
+        LLVMModelGenerator::regenerateModel(rr::ExecutableModel* oldModel, libsbml::SBMLDocument* doc, uint options) 
+    {
         SharedModelResourcesPtr modelResources = std::make_shared<ModelResources>();
 
         char* docSBML = doc->toSBML();

--- a/source/llvm/ModelResources.cpp
+++ b/source/llvm/ModelResources.cpp
@@ -139,7 +139,7 @@ namespace rrllvm {
                 llvm::object::ObjectFile::createObjectFile(
                         llvm::MemoryBufferRef(moduleStr, sbmlMD5));
         if (!objFile) {
-            std::string err = "Failed to load object data";
+            std::string err = "Failed to load object data.";
             rrLogErr << err;
             llvm::logAllUnhandledErrors(objFile.takeError(), llvm::errs(), err);
         }

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -4898,7 +4898,20 @@ namespace rr {
         }
 
         std::vector<std::string> ret(rate_list.begin(), rate_list.end());
-        ret.insert(ret.end(), ind_spec_list.begin(), ind_spec_list.end());
+        for (auto isl = ind_spec_list.begin(); isl != ind_spec_list.end(); isl++)
+        {
+            bool found = false;
+            for (auto rr = rate_list.begin(); rr != rate_list.end(); rr++)
+            {
+                if (*rr == *isl) {
+                    found = true;
+                }
+            }
+            if (!found)
+            {
+                ret.push_back(*isl);
+            }
+        }
         return ret;
     }
 

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -4890,13 +4890,16 @@ namespace rr {
     }
 
     std::vector<std::string> RoadRunner::getRateOfChangeIds() {
-        std::list<std::string> list;
+        std::list<std::string> rate_list, ind_spec_list;
 
         if (impl->model) {
-            impl->model->getIds(SelectionRecord::FLOATING_AMOUNT_RATE, list);
+            impl->model->getIds(SelectionRecord::RATE, rate_list);
+            impl->model->getIds(SelectionRecord::FLOATING_AMOUNT_RATE, ind_spec_list);
         }
 
-        return std::vector<std::string>(list.begin(), list.end());
+        std::vector<std::string> ret(rate_list.begin(), rate_list.end());
+        ret.insert(ret.end(), ind_spec_list.begin(), ind_spec_list.end());
+        return ret;
     }
 
     std::vector<std::string> RoadRunner::getCompartmentIds() {

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -2461,7 +2461,7 @@ namespace rr {
         delete[] vals;
         delete[] ssv;
 
-        v.setColNames(getFloatingSpeciesIds());
+        v.setColNames(getRateOfChangeIds());
 
         return v;
     }

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -27,6 +27,7 @@ TEST_F(ModelAnalysisTests, checkGetRatesOfChangeIds) {
     RoadRunner rr((modelAnalysisModelsDir / "ratesOfChange.xml").string());
     vector<double> out = rr.getRatesOfChange();
     vector<string> outids = rr.getRateOfChangeIds();
+    ASSERT_EQ(out.size(), outids.size());
     EXPECT_NEAR(out[0], 0.7, 0.0001);
     EXPECT_NEAR(out[1], 3.0, 0.0001);
     EXPECT_NEAR(out[2], 0.5, 0.0001);
@@ -39,7 +40,10 @@ TEST_F(ModelAnalysisTests, checkGetRatesOfChangeIds) {
     EXPECT_STREQ(outids[3].c_str(), "S1'");
     EXPECT_STREQ(outids[4].c_str(), "S2'");
     EXPECT_STREQ(outids[5].c_str(), "S5'");
-    ASSERT_EQ(out.size(), outids.size());
+
+    ls::DoubleMatrix out2m = rr.getRatesOfChangeNamedArray();
+    vector<string> cols = out2m.getColNames();
+    EXPECT_EQ(cols, outids);
 }
 
 

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -47,6 +47,34 @@ TEST_F(ModelAnalysisTests, checkGetRatesOfChangeIds) {
 }
 
 
+TEST_F(ModelAnalysisTests, checkGetRatesOfChangeIdsNonBoundarySpeciesRate) {
+    //A species can be 'boundary=false' and still have a rate rule if it
+    // never shows up in a reaction.  This makes it 'floating', which makes
+    // things more awkward for situations like this.
+    RoadRunner rr((modelAnalysisModelsDir / "ratesOfChange.xml").string());
+    rr.setBoundary("S3", false);
+    vector<double> out = rr.getRatesOfChange();
+    vector<string> outids = rr.getRateOfChangeIds();
+    ASSERT_EQ(out.size(), outids.size());
+    EXPECT_NEAR(out[0], 0.7, 0.0001);
+    EXPECT_NEAR(out[1], 3.0, 0.0001);
+    EXPECT_NEAR(out[2], 0.5, 0.0001);
+    EXPECT_NEAR(out[3], -.3, 0.0001);
+    EXPECT_NEAR(out[4], 0.3, 0.0001);
+    EXPECT_NEAR(out[5], 0.0, 0.0001);
+    EXPECT_STREQ(outids[0].c_str(), "S3'");
+    EXPECT_STREQ(outids[1].c_str(), "C'");
+    EXPECT_STREQ(outids[2].c_str(), "k1'");
+    EXPECT_STREQ(outids[3].c_str(), "S1'");
+    EXPECT_STREQ(outids[4].c_str(), "S2'");
+    EXPECT_STREQ(outids[5].c_str(), "S5'");
+
+    ls::DoubleMatrix out2m = rr.getRatesOfChangeNamedArray();
+    vector<string> cols = out2m.getColNames();
+    EXPECT_EQ(cols, outids);
+}
+
+
 TEST_F(ModelAnalysisTests, checkGetFullStoichimetryMatrixWarningMsg) {
     //If a model has a lot of reactions but only a few species, it would sometimes
     // get too small of a scratch space to use in lapack.  The only way to tell

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -21,6 +21,28 @@ public:
 };
 
 
+TEST_F(ModelAnalysisTests, checkGetRatesOfChangeIds) {
+    //If a model has non-species with rates of change, 'getRatesOfChange' works fine,
+    // but the labels for those rates were wrong. This tests that they were fixed.
+    RoadRunner rr((modelAnalysisModelsDir / "ratesOfChange.xml").string());
+    vector<double> out = rr.getRatesOfChange();
+    vector<string> outids = rr.getRateOfChangeIds();
+    EXPECT_NEAR(out[0], 0.7, 0.0001);
+    EXPECT_NEAR(out[1], 3.0, 0.0001);
+    EXPECT_NEAR(out[2], 0.5, 0.0001);
+    EXPECT_NEAR(out[3], -.3, 0.0001);
+    EXPECT_NEAR(out[4], 0.3, 0.0001);
+    EXPECT_NEAR(out[5], 0.0, 0.0001);
+    EXPECT_STREQ(outids[0].c_str(), "S3'");
+    EXPECT_STREQ(outids[1].c_str(), "C'");
+    EXPECT_STREQ(outids[2].c_str(), "k1'");
+    EXPECT_STREQ(outids[3].c_str(), "S1'");
+    EXPECT_STREQ(outids[4].c_str(), "S2'");
+    EXPECT_STREQ(outids[5].c_str(), "S5'");
+    ASSERT_EQ(out.size(), outids.size());
+}
+
+
 TEST_F(ModelAnalysisTests, checkGetFullStoichimetryMatrixWarningMsg) {
     //If a model has a lot of reactions but only a few species, it would sometimes
     // get too small of a scratch space to use in lapack.  The only way to tell

--- a/test/models/ModelAnalysis/ratesOfChange.xml
+++ b/test/models/ModelAnalysis/ratesOfChange.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.13.0 with libSBML version 5.19.2. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment id="C" spatialDimensions="3" size="1" constant="false"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="S1" compartment="C" initialAmount="1" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S2" compartment="C" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S3" compartment="C" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S4" compartment="C" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S5" compartment="C" initialAmount="3" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="k1" value="0.3" constant="false"/>
+    </listOfParameters>
+    <listOfRules>
+      <assignmentRule variable="S4">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <plus/>
+            <apply>
+              <times/>
+              <cn type="integer"> 2 </cn>
+              <ci> S1 </ci>
+            </apply>
+            <ci> S2 </ci>
+          </apply>
+        </math>
+      </assignmentRule>
+      <rateRule variable="S3">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <cn> 0.7 </cn>
+        </math>
+      </rateRule>
+      <rateRule variable="C">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <cn type="integer"> 3 </cn>
+        </math>
+      </rateRule>
+      <rateRule variable="k1">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <cn> 0.5 </cn>
+        </math>
+      </rateRule>
+    </listOfRules>
+    <listOfReactions>
+      <reaction id="_J0" reversible="true" fast="false">
+        <listOfReactants>
+          <speciesReference species="S1" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="S2" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> k1 </ci>
+              <ci> S1 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/models/SBMLFeatures/BIOMD0000000447_url.xml
+++ b/test/models/SBMLFeatures/BIOMD0000000447_url.xml
@@ -1,0 +1,1731 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" metaid="b81d53e0_4f0d_468e_89d7_29849de133ac" version="4">
+  <model id="MODEL1303130000" metaid="COPASI1" name="Venkatraman2012 - Interplay between PLS and TSP1 in TGF-β1 activation">
+    <notes>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+        <div class="dc:title">Venkatraman2012 - Interplay between PLS and TSP1 in TGF-β1 activation</div>
+            <div class="dc:description">      <p>The interplay between PLS (Plasmin) and TSP1 (Thrombospondin-1) in TGF-β1 (Transforming growth factor-β1)is shown using mathematical modelling and        <em>in vitro</em>
+            experimentents.        </p>
+                </div>
+            <div class="dc:bibliographicCitation">      <p>This model is described in the article:</p>
+                <div class="bibo:title">        <a href="http://identifiers.org/pubmed/23009856" title="Access to this publication">Plasmin triggers a switch-like decrease in thrombospondin-dependent activation of TGF-β1.</a>
+                    </div>
+                <div class="bibo:authorList">Venkatraman L, Chia SM, Narmada BC, White JK, Bhowmick SS, Forbes Dewey C Jr, So PT, Tucker-Kellogg L, Yu H.</div>
+                <div class="bibo:Journal">Biophys J. 2012 Sep 5;103(5):1060-8.</div>
+                <p>Abstract:</p>
+                <div class="bibo:abstract">        <p>Transforming growth factor-β1 (TGF-β1) is a potent regulator of extracellular matrix production, wound healing, differentiation, and immune response, and is implicated in the progression of fibrotic diseases and cancer. Extracellular activation of TGF-β1 from its latent form provides spatiotemporal control over TGF-β1 signaling, but the current understanding of TGF-β1 activation does not emphasize cross talk between activators. Plasmin (PLS) and thrombospondin-1 (TSP1) have been studied individually as activators of TGF-β1, and in this work we used a systems-level approach with mathematical modeling and in vitro experiments to study the interplay between PLS and TSP1 in TGF-β1 activation. Simulations and steady-state analysis predicted a switch-like bistable transition between two levels of active TGF-β1, with an inverse correlation between PLS and TSP1. In particular, the model predicted that increasing PLS breaks a TSP1-TGF-β1 positive feedback loop and causes an unexpected net decrease in TGF-β1 activation. To test these predictions in vitro, we treated rat hepatocytes and hepatic stellate cells with PLS, which caused proteolytic cleavage of TSP1 and decreased activation of TGF-β1. The TGF-β1 activation levels showed a cooperative dose response, and a test of hysteresis in the cocultured cells validated that TGF-β1 activation is bistable. We conclude that switch-like behavior arises from natural competition between two distinct modes of TGF-β1 activation: a TSP1-mediated mode of high activation and a PLS-mediated mode of low activation. This switch suggests an explanation for the unexpected effects of the plasminogen activation system on TGF-β1 in fibrotic diseases in vivo, as well as novel prognostic and therapeutic approaches for diseases with TGF-β dysregulation.</p>
+                    </div>
+                </div>
+            <div class="dc:publisher">      <p>This model is hosted on        <a href="http://www.ebi.ac.uk/biomodels/">BioModels Database</a>
+            and identified
+by:        <a href="http://identifiers.org/biomodels.db/MODEL1303130000">MODEL1303130000</a>
+            .        </p>
+                <p>To cite BioModels Database, please use:        <a href="http://identifiers.org/pubmed/20587024" title="Latest BioModels Database publication">BioModels Database: An enhanced, curated and annotated resource
+for published quantitative kinetic models</a>
+            .        </p>
+                </div>
+            <div class="dc:license">      <p>To the extent possible under law, all copyright and related or
+neighbouring rights to this encoded model have been dedicated to the public
+domain worldwide. Please refer to        <a href="http://creativecommons.org/publicdomain/zero/1.0/" title="Access to: CC0 1.0 Universal (CC0 1.0), Public Domain Dedication">CC0 Public Domain
+Dedication</a>
+            for more information.        </p>
+                </div>
+            </body>
+      
+    </notes>
+    <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+        <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">
+          <rdf:Description rdf:about="#COPASI1">
+            <dcterms:bibliographicCitation>
+              <rdf:Description>
+                <CopasiMT:isDescribedBy rdf:resource="http://identifiers.org/pubmed/23009856"/>
+              </rdf:Description>
+            </dcterms:bibliographicCitation>
+            <dcterms:created>
+              <rdf:Description>
+                <dcterms:W3CDTF>2012-11-10T11:27:58Z</dcterms:W3CDTF>
+              </rdf:Description>
+            </dcterms:created>
+            <dcterms:creator>
+              <rdf:Description>
+                <vCard:N>
+                  <rdf:Description>
+                    <vCard:Family>Venkatraman</vCard:Family>
+                    <vCard:Given>Lakshmi</vCard:Given>
+                  </rdf:Description>
+                </vCard:N>
+              </rdf:Description>
+            </dcterms:creator>
+            <dcterms:creator>
+              <rdf:Description>
+                <vCard:N>
+                  <rdf:Description>
+                    <vCard:Family>Chia</vCard:Family>
+                    <vCard:Given>Ser-Mien</vCard:Given>
+                  </rdf:Description>
+                </vCard:N>
+              </rdf:Description>
+            </dcterms:creator>
+            <dcterms:creator>
+              <rdf:Description>
+                <vCard:N>
+                  <rdf:Description>
+                    <vCard:Family>Narmada</vCard:Family>
+                    <vCard:Given>Balakrishnan Chakrapani</vCard:Given>
+                  </rdf:Description>
+                </vCard:N>
+              </rdf:Description>
+            </dcterms:creator>
+            <dcterms:creator>
+              <rdf:Description>
+                <vCard:N>
+                  <rdf:Description>
+                    <vCard:Family>White</vCard:Family>
+                    <vCard:Given>Jacob</vCard:Given>
+                  </rdf:Description>
+                </vCard:N>
+              </rdf:Description>
+            </dcterms:creator>
+            <dcterms:creator>
+              <rdf:Description>
+                <vCard:N>
+                  <rdf:Description>
+                    <vCard:Family>Bhowmick</vCard:Family>
+                    <vCard:Given>Sourav</vCard:Given>
+                  </rdf:Description>
+                </vCard:N>
+              </rdf:Description>
+            </dcterms:creator>
+            <dcterms:creator>
+              <rdf:Description>
+                <vCard:N>
+                  <rdf:Description>
+                    <vCard:Family>Dewey</vCard:Family>
+                    <vCard:Given>Forbes</vCard:Given>
+                  </rdf:Description>
+                </vCard:N>
+              </rdf:Description>
+            </dcterms:creator>
+            <dcterms:creator>
+              <rdf:Description>
+                <vCard:N>
+                  <rdf:Description>
+                    <vCard:Family>So</vCard:Family>
+                    <vCard:Given>Peter</vCard:Given>
+                  </rdf:Description>
+                </vCard:N>
+              </rdf:Description>
+            </dcterms:creator>
+            <dcterms:creator>
+              <rdf:Description>
+                <vCard:N>
+                  <rdf:Description>
+                    <vCard:Family>Tucker-Kellogg</vCard:Family>
+                    <vCard:Given>Lisa</vCard:Given>
+                  </rdf:Description>
+                </vCard:N>
+              </rdf:Description>
+            </dcterms:creator>
+            <dcterms:creator>
+              <rdf:Description>
+                <vCard:N>
+                  <rdf:Description>
+                    <vCard:Family>Yu</vCard:Family>
+                    <vCard:Given>Hanry</vCard:Given>
+                  </rdf:Description>
+                </vCard:N>
+              </rdf:Description>
+            </dcterms:creator>
+          </rdf:Description>
+        </rdf:RDF>
+      </COPASI>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+        <rdf:Description rdf:about="#COPASI1">
+	<dc:creator>
+	<rdf:Bag>
+	<rdf:li rdf:parseType="Resource">
+	<vCard:N rdf:parseType="Resource">
+	<vCard:Family>Chelliah</vCard:Family>
+	<vCard:Given>Vijayalakshmi</vCard:Given>
+	</vCard:N>
+	<vCard:EMAIL>viji@ebi.ac.uk</vCard:EMAIL>
+	<vCard:ORG rdf:parseType="Resource">
+	<vCard:Orgname>EMBL-EBI</vCard:Orgname>
+	</vCard:ORG>
+	</rdf:li>
+	<rdf:li rdf:parseType="Resource">
+	<vCard:N rdf:parseType="Resource">
+	<vCard:Family>Li</vCard:Family>
+	<vCard:Given>Huipeng</vCard:Given>
+	</vCard:N>
+	<vCard:EMAIL>lihuipengsmacsb@gmail.com</vCard:EMAIL>
+	<vCard:ORG rdf:parseType="Resource">
+	<vCard:Orgname>Singapore MIT Alliance, Computational and Systems Biology</vCard:Orgname>
+	</vCard:ORG>
+	</rdf:li>
+	</rdf:Bag>
+	</dc:creator>
+	<dcterms:created rdf:parseType="Resource">
+	<dcterms:W3CDTF>2013-03-26T13:34:09Z</dcterms:W3CDTF>
+	</dcterms:created>
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2014-04-07T02:42:37Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqmodel:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/biomodels.db/MODEL1303130000"/>
+	</rdf:Bag>
+	</bqmodel:is>
+	<bqmodel:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/biomodels.db/BIOMD0000000447"/>
+	</rdf:Bag>
+	</bqmodel:is>
+	<bqmodel:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/pubmed/23009856"/>
+	</rdf:Bag>
+	</bqmodel:isDescribedBy>
+	<bqmodel:isDerivedFrom>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/biomodels.db/MODEL1303130001"/>
+	</rdf:Bag>
+	</bqmodel:isDerivedFrom>
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0036363"/>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0070053"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	<bqbiol:hasTaxon>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/taxonomy/10117"/>
+	</rdf:Bag>
+	</bqbiol:hasTaxon>
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/mamo/MAMO_0000046"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+      <listOfFunctionDefinitions>
+      <functionDefinition id="function_1" metaid="_5e0f8175_7c46_445e_ac00_88e8b7b1c992" name="Constant flux (irreversible)">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <lambda>
+            <bvar>
+              <ci> v </ci>
+            </bvar>
+            <ci> v </ci>
+          </lambda>
+        </math>
+            </functionDefinition>
+    </listOfFunctionDefinitions>
+    <listOfUnitDefinitions>
+      <unitDefinition id="substance" metaid="_51ddbc1c_c48c_4e78_b89c_0cce0993e441" name="substance">
+        <listOfUnits>
+          <unit kind="mole" metaid="de5c374f_b7ab_4437_8592_32078816d010" scale="-6"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment id="compartment_1" metaid="_9f70fd74_e2b5_449e_a9fa_71e2569b863f" name="compartment" sboTerm="SBO:0000290" size="1">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_9f70fd74_e2b5_449e_a9fa_71e2569b863f">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/go/GO:0005623"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </compartment>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species compartment="compartment_1" id="species_1" initialConcentration="0.003" metaid="COPASI2" name="PLG">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI2">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:12:32Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#COPASI2">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q01177"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species compartment="compartment_1" id="species_2" initialConcentration="0" metaid="_86f16bf7_5e25_4834_8042_4daab7b3f07f" name="PLS">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_86f16bf7_5e25_4834_8042_4daab7b3f07f">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/3.4.21.7"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species compartment="compartment_1" id="species_3" initialConcentration="0.001" metaid="COPASI3" name="scUPA">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI3">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:12:33Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#COPASI3">
+              <bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P29598"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/pato/PATO:0002355"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species compartment="compartment_1" id="species_4" initialConcentration="0" metaid="cce6912a_e6d8_4aea_853b_8f61cfc19b03" name="tcUPA">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#cce6912a_e6d8_4aea_853b_8f61cfc19b03">
+              <bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P29598"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/pato/PATO:0002354"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species compartment="compartment_1" id="species_5" initialConcentration="0.001" metaid="COPASI4" name="LTGFb1">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI4">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:12:30Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#COPASI4">
+              <bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P17246"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/pato/PATO:0002355"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species compartment="compartment_1" id="species_6" initialConcentration="0" metaid="COPASI5" name="TGFb1">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI5">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:12:34Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#COPASI5">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P17246"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species compartment="compartment_1" id="species_7" initialConcentration="0" metaid="COPASI6" name="TSP1">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI6">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:12:34Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#COPASI6">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q71SA3"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species compartment="compartment_1" id="species_8" initialConcentration="0" metaid="COPASI7" name="PAI1">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI7">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:12:31Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#COPASI7">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P20961"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species compartment="compartment_1" id="species_9" initialConcentration="0" metaid="e5d41f55_cbd8_4120_875a_e9ccb17978c6" name="TSP1:PLS">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#e5d41f55_cbd8_4120_875a_e9ccb17978c6">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/3.4.21.7"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q71SA3"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species compartment="compartment_1" id="species_10" initialConcentration="0.005" metaid="COPASI8" name="A2M">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI8">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:12:28Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#COPASI8">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P06238"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species compartment="compartment_1" id="species_11" initialConcentration="0" metaid="COPASI9" name="A2M:PLS">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI9">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:12:29Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#COPASI9">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/3.4.21.7"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P06238"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species compartment="compartment_1" id="species_12" initialConcentration="0" metaid="COPASI10" name="PAI1:tcUPA">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI10">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:12:31Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#COPASI10">
+              <bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P20961"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P29598"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/pato/PATO:0002354"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+      <species compartment="compartment_1" id="species_13" initialConcentration="0" metaid="_31f84bf3_77d5_44e9_b0c9_82130e6df4c7" name="PAI1:scUPA">
+        <annotation>
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_31f84bf3_77d5_44e9_b0c9_82130e6df4c7">
+              <bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P29598"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P20961"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/pato/PATO:0002355"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+	</rdf:RDF>
+	</annotation>
+            </species>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="parameter_1" metaid="e91a6d02_4d96_44ba_84cd_1a31a7abf6eb" name="keff1" value="0.035"/>
+      <parameter id="parameter_2" metaid="ffe16b91_7f2f_45d3_ac17_163588cfe96e" name="keff2" value="0.35"/>
+      <parameter id="parameter_3" metaid="_37e7d832_ea19_43ec_8582_12f21bbe3b12" name="keff3" value="1.4"/>
+      <parameter id="parameter_4" metaid="ca897413_06b4_482e_9639_2b63f433b052" name="k1" value="0.035"/>
+      <parameter id="parameter_5" metaid="_724c7a09_17d5_4067_a853_b90424dae5f6" name="k2" value="24.5"/>
+      <parameter id="parameter_6" metaid="_50941eb8_5c69_40b1_95c3_36bc234937f3" name="kothers" value="0.005"/>
+      <parameter id="parameter_7" metaid="_268d8e4c_5321_4c9e_a09c_c7a6779fc12a" name="kp1" value="0.35"/>
+      <parameter id="parameter_8" metaid="d1a0a681_155b_4c90_a69c_a5c31f359fc6" name="kp2" value="1.05"/>
+      <parameter id="parameter_9" metaid="COPASI11" name="k3" value="17.5">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI11">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-20T10:45:27Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+            </parameter>
+      <parameter id="parameter_10" metaid="_7eb0cf16_7092_4595_a583_0818565d076c" name="k_3" value="0.0245"/>
+      <parameter id="parameter_11" metaid="_6f696279_b35c_4ecd_9194_4ae276eceac2" name="k4" value="0.35"/>
+      <parameter id="parameter_12" metaid="_8ca9e164_6efa_4581_8061_4d3ebd6ad0ed" name="k5" value="24.5"/>
+      <parameter id="parameter_13" metaid="_86020e68_afd9_43ca_be38_7b38720478c9" name="k_5" value="0.0105"/>
+      <parameter id="parameter_14" metaid="_3b4a9125_3300_4db4_9125_8393e6652c71" name="k6" value="0.035"/>
+      <parameter id="parameter_15" metaid="_39b2013e_d66c_4c87_8415_e8f909c85bc0" name="k_6" value="0.0035"/>
+      <parameter id="parameter_16" metaid="_56dc76ba_d3e1_4d89_b31f_2aa8f7a417eb" name="k7" value="0.07"/>
+      <parameter id="parameter_17" metaid="_43717b00_7ab5_48bf_b345_ff0fc59d663b" name="k_7" value="0.0035"/>
+      <parameter id="parameter_18" metaid="c8d93546_c77c_4b13_8977_998f187e7c6e" name="k8" value="24.5"/>
+      <parameter id="parameter_19" metaid="COPASI12" name="k9" value="0.21">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI12">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-20T10:47:55Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+            </parameter>
+      <parameter id="parameter_20" metaid="_2b6b23e1_75a8_45d6_ab54_f8e4d53aa3ec" name="u_edeg" value="0.0525"/>
+      <parameter id="parameter_21" metaid="ebc6e47f_0dbd_4fff_ad69_1766379b7b7f" name="u_pdeg" value="0.0175"/>
+      <parameter id="parameter_22" metaid="dfbc20da_6d50_499f_a794_23555403bc83" name="alpha1" value="0.0035"/>
+      <parameter id="parameter_23" metaid="f1575b4b_2d70_4eef_a975_92e5379d60b8" name="alpha2" value="0.035"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction id="reaction_1" metaid="COPASI13" name="reaction_1" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI13">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:59:29Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="e7b30801_96ec_4b39_917e_5e87cbe94e80" species="species_3"/>
+          <speciesReference metaid="_48b96972_fed8_44a1_a474_5b701b834993" species="species_1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_825f41ba_ed30_49b4_ac1d_9f94cc1341ed" species="species_2"/>
+          <speciesReference metaid="_2430dc3d_ccd5_42eb_83fd_1f9f7289bcbd" species="species_3"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_8044193b_616b_406b_b8d7_c5ae25a090ef" species="species_3"/>
+          <modifierSpeciesReference metaid="c6063960_795d_4c87_a37f_d6739e69fc71" species="species_1"/>
+        </listOfModifiers>
+        <kineticLaw metaid="c1eb14d5_9636_4618_8c75_44f789d94e34">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_1 </ci>
+              <ci> species_3 </ci>
+              <ci> species_1 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_2" metaid="COPASI14" name="reaction_2" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI14">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:20:03Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_64ce7d96_34a4_49fb_8bbd_8b0858ae1c70" species="species_2"/>
+          <speciesReference metaid="debf19ad_5d2d_4554_bf82_ec18a70089f9" species="species_3"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_51737c2c_2fcd_4959_bbd1_773fc76b2fac" species="species_4"/>
+          <speciesReference metaid="e3f00b5a_8362_40e4_bb86_22425b1ea36d" species="species_2"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="ba61b3fc_6994_407e_911a_4525ec2f8202" species="species_2"/>
+          <modifierSpeciesReference metaid="_856015b6_7790_48bd_9eb3_b340dfa53a83" species="species_3"/>
+        </listOfModifiers>
+        <kineticLaw metaid="b437e193_420b_4bd0_9c08_536ab759016f">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_2 </ci>
+              <ci> species_2 </ci>
+              <ci> species_3 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_3" metaid="COPASI15" name="reaction_3" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI15">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T11:45:03Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_22a76541_3273_42e6_93a8_97b75050696b" species="species_4"/>
+          <speciesReference metaid="d4e03b2f_190b_4263_a10a_25b9f53a147d" species="species_1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_3e5f602e_dca6_423a_8f3f_0e4d886b3821" species="species_2"/>
+          <speciesReference metaid="_8b79f12d_e8a7_487b_b27f_57669b4fbd19" species="species_4"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_61239c03_ead1_4671_b03c_ba5cf21b5ce9" species="species_4"/>
+          <modifierSpeciesReference metaid="_7e734d73_536c_4f9f_9c20_d8ab6122e272" species="species_1"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_3056f116_5515_4121_9fe0_9830eb5eda78">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_3 </ci>
+              <ci> species_4 </ci>
+              <ci> species_1 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_4" metaid="COPASI16" name="reaction_4" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI16">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:20:43Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="c234fd6b_0050_444f_9fbb_23eecf11019a" species="species_2"/>
+          <speciesReference metaid="_9c87f47b_6838_4ef6_9d0a_f1222f008046" species="species_5"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="dcc83352_2504_4af8_94b1_b93a4162003a" species="species_6"/>
+          <speciesReference metaid="f07ce333_49c6_4702_b0a1_ef63b2a62867" species="species_2"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="afb58bb5_2e2a_40a6_9025_564fb20f9c82" species="species_2"/>
+          <modifierSpeciesReference metaid="df808007_5737_4dbf_9ced_0a5c2042f6f7" species="species_5"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_211125c3_8d09_4f9b_b756_033ee8dc3704">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_4 </ci>
+              <ci> species_2 </ci>
+              <ci> species_5 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_5" metaid="COPASI17" name="reaction_5" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI17">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:20:52Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_8c7616c3_8588_4ebe_ba5f_8dc5b2eacca5" species="species_7"/>
+          <speciesReference metaid="_6bbfe58d_f849_4273_a3d7_c6134a099ba8" species="species_5"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="ee084ecb_6dba_49b0_8ada_c22a35097ac7" species="species_6"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="cdbd00bb_8902_4c38_a4c2_a419c709aed1" species="species_7"/>
+          <modifierSpeciesReference metaid="c57180ff_7e0e_4dc8_87d5_b615fb140109" species="species_5"/>
+        </listOfModifiers>
+        <kineticLaw metaid="ce2ff081_0ad9_4a2b_9e86_f9604a954d30">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_5 </ci>
+              <ci> species_7 </ci>
+              <ci> species_5 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_6" metaid="COPASI18" name="reaction_6" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI18">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:21:19Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="bc99a80b_0f6e_489f_ba14_2fdcc81d1354" species="species_5"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_89e71fd1_07b5_4bad_8312_b833dc6682e4" species="species_6"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_8532adf2_a986_46c0_ba1b_39910517e975" species="species_5"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_0ef0fdfe_d007_4a66_a6a3_3c756dd973e2">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_6 </ci>
+              <ci> species_5 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_7" metaid="COPASI19" name="reaction_7" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI19">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:21:33Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_34cd1d9d_af81_4b0b_b22f_af84a1e75979" species="species_6"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_8cd1ae4c_3b86_4ca4_aeb2_fb0a987fe5a8" species="species_6"/>
+          <speciesReference metaid="_1fa593b2_28de_488e_a83c_6e867dda77d9" species="species_7"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="bea2dd28_10e0_4032_872f_cbd8ae780445" species="species_6"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_03e8a968_c434_49bc_83bc_717d56b7f407">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_7 </ci>
+              <ci> species_6 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_8" metaid="COPASI20" name="reaction_8" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI20">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:21:42Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_0c36def4_6370_4e3c_80eb_6193ead21cff" species="species_6"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_4c8c3311_c20b_4aff_bfc4_30cee09a36f7" species="species_6"/>
+          <speciesReference metaid="b1b6b14e_082c_4c60_8706_1285c7b0f343" species="species_8"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_57cf5971_38ff_49e7_b309_55d974c0d0af" species="species_6"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_3bfa4d66_f9c2_441c_b9d2_2875807df1cf">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_8 </ci>
+              <ci> species_6 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_9" metaid="COPASI21" name="reaction_9">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI21">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:21:53Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_4f711a9a_dedc_4ce9_9967_de6ac0aaceff" species="species_7"/>
+          <speciesReference metaid="_5627f12a_2e29_4e4f_8982_d7e21e8b7698" species="species_2"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_76a4e914_975e_40a7_9e01_fd93a1acb031" species="species_9"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="b7731108_0f07_432d_8a46_658b7bd5601f" species="species_7"/>
+          <modifierSpeciesReference metaid="_7a3f1fdb_91d7_492e_8b9d_1916e805436b" species="species_2"/>
+          <modifierSpeciesReference metaid="_4e3f8190_1b98_4898_9d4d_4c80c7b9b55f" species="species_9"/>
+        </listOfModifiers>
+        <kineticLaw metaid="b4d93b57_9b5a_424e_a6cb_fb8038408d95">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> parameter_9 </ci>
+                  <ci> species_7 </ci>
+                  <ci> species_2 </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> parameter_10 </ci>
+                  <ci> species_9 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_10" metaid="COPASI22" name="reaction_10" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI22">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:59:30Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="ff96ef6e_97c6_4dda_9e49_e779597570fb" species="species_9"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="a1298187_36f5_432d_8647_1bb5b334d484" species="species_2"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="e7215b48_4702_4bdd_85bb_c939678e87dc" species="species_9"/>
+        </listOfModifiers>
+        <kineticLaw metaid="d28c2289_1c24_4109_8789_d1d2c2566882">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_11 </ci>
+              <ci> species_9 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_11" metaid="COPASI23" name="reaction_11">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI23">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:59:32Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_78612fee_a467_4cd5_b793_a5cb04ee3ff7" species="species_10"/>
+          <speciesReference metaid="_26f62096_01f5_4be2_a0a0_dc52c6b73d9e" species="species_2"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="b96ace20_20a4_45e0_8c6b_7cdf6209b580" species="species_11"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="bad15d36_0833_4fae_a81b_219be5c81d5a" species="species_10"/>
+          <modifierSpeciesReference metaid="_964cbfb9_ff60_4a2d_b6eb_b08dffd63cb0" species="species_2"/>
+          <modifierSpeciesReference metaid="_47d205e5_3db4_4cad_a574_226785090b21" species="species_11"/>
+        </listOfModifiers>
+        <kineticLaw metaid="f12760ac_31ce_454d_8d71_a4a7cb4938e0">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> parameter_12 </ci>
+                  <ci> species_10 </ci>
+                  <ci> species_2 </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> parameter_13 </ci>
+                  <ci> species_11 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_12" metaid="COPASI24" name="reaction_12">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI24">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:59:31Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_4abed38f_3fa4_4bfe_9aed_2e6778ab55aa" species="species_8"/>
+          <speciesReference metaid="_88f6a8c2_ef65_4fb2_a3c9_5081be6e05db" species="species_4"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_24125435_c6eb_4337_a1bb_8d0e123171e8" species="species_12"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_3c1be07d_5720_4a08_a5b9_f80d2f951893" species="species_8"/>
+          <modifierSpeciesReference metaid="c0bbfa62_b94a_40ef_b0bc_f7275cc6a9eb" species="species_4"/>
+          <modifierSpeciesReference metaid="e8d4fef7_3edf_4324_88c1_37e4a667d3a7" species="species_12"/>
+        </listOfModifiers>
+        <kineticLaw metaid="c41d3bb2_6e61_4711_b67f_574a125f34ab">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> parameter_14 </ci>
+                  <ci> species_8 </ci>
+                  <ci> species_4 </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> parameter_15 </ci>
+                  <ci> species_12 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_13" metaid="COPASI25" name="reaction_13">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI25">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T12:59:33Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_5cc06dc2_1650_4b53_b458_1088bcb292d5" species="species_8"/>
+          <speciesReference metaid="_217fa057_e2cd_4ae0_9bfd_b7594e92496f" species="species_3"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_87ff29da_51a6_4cda_86de_77ce22f0c6ff" species="species_13"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="df6985ff_af0f_4ccb_b058_7632c2cca06c" species="species_8"/>
+          <modifierSpeciesReference metaid="b17c10b8_f57d_4784_b90e_b3130c5e4388" species="species_3"/>
+          <modifierSpeciesReference metaid="a35e8440_613b_490b_a3fb_f7fa5b4c9b86" species="species_13"/>
+        </listOfModifiers>
+        <kineticLaw metaid="c127da4d_d375_4918_bf2c_71387efce3f8">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> parameter_16 </ci>
+                  <ci> species_8 </ci>
+                  <ci> species_3 </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> parameter_17 </ci>
+                  <ci> species_13 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_14" metaid="COPASI26" name="reaction_14" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI26">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:23:23Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfProducts>
+          <speciesReference metaid="d2e5a1da_2025_47a5_8585_676172e9c83b" species="species_3"/>
+        </listOfProducts>
+        <kineticLaw metaid="_560741f8_5ef8_4646_a7bf_72c546e77b59">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <apply>
+                <ci> function_1 </ci>
+                <ci> parameter_22 </ci>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_15" metaid="COPASI27" name="reaction_15" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI27">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:23:37Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfProducts>
+          <speciesReference metaid="e40ba9c3_19f4_4fb7_92ce_b65fe5141183" species="species_5"/>
+        </listOfProducts>
+        <kineticLaw metaid="d3304e62_46d0_4ebb_95d7_4ac86fc89737">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <apply>
+                <ci> function_1 </ci>
+                <ci> parameter_22 </ci>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_16" metaid="COPASI28" name="reaction_16" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI28">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:23:47Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfProducts>
+          <speciesReference metaid="_60825958_0e29_4e2b_b0f5_481fa3c01ac5" species="species_10"/>
+        </listOfProducts>
+        <kineticLaw metaid="fb3e050e_97b3_4b9f_b340_1cd2c65b55ac">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <apply>
+                <ci> function_1 </ci>
+                <ci> parameter_22 </ci>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_17" metaid="COPASI29" name="reaction_17" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI29">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:23:58Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfProducts>
+          <speciesReference metaid="e366d232_123f_46ed_8162_df5a6ddfca38" species="species_1"/>
+        </listOfProducts>
+        <kineticLaw metaid="c3fa7bcf_5c0b_46e2_a4cd_03114f7b3744">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <apply>
+                <ci> function_1 </ci>
+                <ci> parameter_23 </ci>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_18" metaid="COPASI30" name="reaction_18" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI30">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:24:05Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="fe910d7b_d329_488e_b101_00d5390a1cac" species="species_3"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="a65edd7d_ccd6_45f1_85a0_dabb63eb4672" species="species_3"/>
+        </listOfModifiers>
+        <kineticLaw metaid="bf958c6f_0e40_4ae7_b635_fd073ec2e8c1">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_20 </ci>
+              <ci> species_3 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_19" metaid="COPASI31" name="reaction_19" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI31">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:24:17Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_2509b92e_287b_4f90_802b_da84cd1e1732" species="species_4"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="b98b1fa9_3909_4d6f_ad4a_cb5688f163da" species="species_4"/>
+        </listOfModifiers>
+        <kineticLaw metaid="ccaab439_5026_4a74_91d4_1350a0b6bac9">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_20 </ci>
+              <ci> species_4 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_20" metaid="COPASI32" name="reaction_20" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI32">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:24:28Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="a688b341_fdf2_4e63_ae27_12ea80cb1050" species="species_2"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_9a61f1c7_eb55_4598_aaaa_2b3bd31824c0" species="species_2"/>
+        </listOfModifiers>
+        <kineticLaw metaid="aaa40882_dcef_4e6b_9e3d_4f1d85ddb87b">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_20 </ci>
+              <ci> species_2 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_21" metaid="COPASI33" name="reaction_21" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI33">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:24:42Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="d1905a3e_19f8_4d3d_88f8_6a1afc3e8703" species="species_7"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="e44033b1_6417_453c_a59d_bd8b4cd21332" species="species_7"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_01345802_1551_43fa_a0e6_ed2861245310">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_21 </ci>
+              <ci> species_7 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_22" metaid="COPASI34" name="reaction_22" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI34">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:24:56Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="f69733fb_30c5_4180_ac75_714545284a35" species="species_8"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="c4712b13_c61b_49df_ba4c_60c2100fa73c" species="species_8"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_110d2056_394c_47a0_b455_e37f1b2a9173">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_21 </ci>
+              <ci> species_8 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_23" metaid="COPASI35" name="reaction_23" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI35">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:25:10Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_2017e444_44ae_4caa_bcaf_b40a80653370" species="species_5"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_69a472a4_65ac_4363_b5e8_344c9d2fc4e9" species="species_5"/>
+        </listOfModifiers>
+        <kineticLaw metaid="d7bb0971_066a_4acb_8528_74b0528c58ef">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_21 </ci>
+              <ci> species_5 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_24" metaid="COPASI36" name="reaction_24" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI36">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:25:17Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_6052716e_58b5_4474_9571_41a83b429ab6" species="species_6"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="b63545db_7a52_4f56_8d1d_b0234ac144df" species="species_6"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_84ade495_0299_4f94_a375_11c809d759ec">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_21 </ci>
+              <ci> species_6 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_25" metaid="COPASI37" name="reaction_25" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI37">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:25:25Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_8b3d856d_f7cf_4f49_82a1_240aa63d1b18" species="species_1"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="c296542c_ab07_4eb6_a912_11d823e404da" species="species_1"/>
+        </listOfModifiers>
+        <kineticLaw metaid="af1b56a8_743c_4276_975f_64414945a087">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_21 </ci>
+              <ci> species_1 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_26" metaid="COPASI38" name="reaction_26" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI38">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:25:32Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="e33c7b05_3a67_4745_82b2_929fcf286f4e" species="species_10"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_7f7cb9d5_8ecd_4b3d_a4ca_0d9a197e05f9" species="species_10"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_706cdcf9_f870_4782_b624_90715fbd9721">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_21 </ci>
+              <ci> species_10 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_27" metaid="COPASI39" name="reaction_28" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI39">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:25:45Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_68883ff8_05c2_4a36_98c5_35c3f7fddb54" species="species_11"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_103f07fc_8fa0_4636_a0d9_dd5d718a5654" species="species_11"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_666252fe_3f80_4b82_8ef6_e59fcd09c6ef">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_21 </ci>
+              <ci> species_11 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_28" metaid="COPASI40" name="reaction_29" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI40">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:25:51Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_73cf87cd_abd4_462e_adaf_361ec2fbae05" species="species_12"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_009e85ca_a74c_45cf_87e6_ef31f8e56790" species="species_12"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_71ecaf59_3952_43bb_a94a_77b8dc3d0fcd">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_21 </ci>
+              <ci> species_12 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_29" metaid="COPASI41" name="reaction_30" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI41">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-10T17:25:57Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_3d02e849_a997_4806_baff_4a156a3f3a6b" species="species_13"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_7ec7c03a_a208_4111_987b_5a52bd6bd61a" species="species_13"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_0c7622fc_c18b_45aa_aa49_23930aaf1dc5">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_21 </ci>
+              <ci> species_13 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_30" metaid="COPASI42" name="reaction_27" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI42">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-15T11:55:18Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="ed3e4e03_7397_43b9_83ad_539456dd45a8" species="species_9"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="baa7d18f_4df2_41f7_9996_ade6b10ce204" species="species_9"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_983848dd_0287_4486_8369_454f0e13209a">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_21 </ci>
+              <ci> species_9 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_31" metaid="COPASI43" name="reaction_31" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI43">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-20T10:23:41Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_898035ea_c987_4bbf_bc53_a75fdc5f77bc" species="species_9"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_708f8d7e_c9ea_4977_bebc_382b9cce94ce" species="species_9"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_6c43152e_1b3d_4224_b371_156c68ec5279">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_18 </ci>
+              <ci> species_9 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_32" metaid="COPASI44" name="reaction_32" reversible="false">
+        <annotation>
+<COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI44">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2012-11-20T11:37:35Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+                                </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_06d78efc_9d94_410c_a575_e253405f920b" species="species_6"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="cacd27b1_fb06_44df_8724_2552fddb1478" species="species_6"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_4278d151_a186_43b3_b7fb_901254579ec3">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> compartment_1 </ci>
+              <ci> parameter_19 </ci>
+              <ci> species_6 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/sbml_features/CMakeLists.txt
+++ b/test/sbml_features/CMakeLists.txt
@@ -3,6 +3,7 @@ add_test_executable(
         ${SharedTestFiles}
         boolean_delay.cpp
         invalid_sbml.cpp
+        valid_sbml.cpp
 )
 
 # make test_targets list global to all tests

--- a/test/sbml_features/valid_sbml.cpp
+++ b/test/sbml_features/valid_sbml.cpp
@@ -1,0 +1,28 @@
+#include "gtest/gtest.h"
+#include "rrRoadRunner.h"
+#include "rrException.h"
+#include "rrUtils.h"
+#include "rrTestSuiteModelSimulation.h"
+#include "sbml/SBMLTypes.h"
+#include "sbml/SBMLReader.h"
+#include "../test_util.h"
+#include <filesystem>
+#include "RoadRunnerTest.h"
+
+using namespace testing;
+using namespace rr;
+using namespace std;
+using std::filesystem::path;
+
+class SBMLFeatures : public RoadRunnerTest {
+public:
+    path SBMLFeaturesDir = rrTestModelsDir_ / "SBMLFeatures";
+    SBMLFeatures() = default;
+};
+
+TEST_F(SBMLFeatures, validSBML_UTF_8)
+{
+    RoadRunner rri((SBMLFeaturesDir / "BIOMD0000000447_url.xml").string());
+    rri.simulate();
+}
+

--- a/test/semantic_STS/sbml_test_suite.cpp
+++ b/test/semantic_STS/sbml_test_suite.cpp
@@ -249,10 +249,10 @@ public:
 };
 
 
-TEST_F(SbmlTestSuite, DISABLED_test_single)
+TEST_F(SbmlTestSuite, test_single)
 {
     // Use when need to run one test.
-    EXPECT_TRUE(RunTest(1821));
+    EXPECT_TRUE(RunTest(1511));
 }
 TEST_F(SbmlTestSuite, t1)
 {


### PR DESCRIPTION
Also managed to discover where the problem was with the volume/concentration rates:  when d[S1]/dt is set via a rate rule and its compartment's dC/dt is also set by a rate rule, the rate of change for the amount needs to be:
```
[S1]*dC/dt + C*d[S1]/dt.
```
However, the math was reversed, so it was instead:
```
C*dC/dt + [S1]*d[S1]/dt
```
This mostly fixes the VolumeConcentrationRates tag in the SBML test suite, but I didn't turn that on yet because one of the tests has an unrelated problem with event triggers.

Also fixed a couple error messages that I found along the way.