### PR TITLE
Add methods for getting and setting mDiffStepSize to C API

### DIFF
--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -267,7 +267,7 @@ namespace rr {
         bool simulatedSinceReset = false;
 
         RoadRunnerImpl(const std::string &uriOrSBML, const Dictionary *dict) :
-                mDiffStepSize(0.05),
+                mDiffStepSize(0.02),
                 mSteadyStateThreshold(1.E-2),
                 simulationResult(),
                 integrator(0),
@@ -283,7 +283,7 @@ namespace rr {
         }
 
         RoadRunnerImpl(const std::istream &in) :
-                mDiffStepSize(0.05),
+                mDiffStepSize(0.02),
                 mSteadyStateThreshold(1.E-2),
                 simulationResult(),
                 integrator(NULL),
@@ -302,7 +302,7 @@ namespace rr {
 
         RoadRunnerImpl(const std::string &_compiler, const std::string &_tempDir,
                        const std::string &_supportCodeDir) :
-                mDiffStepSize(0.05),
+                mDiffStepSize(0.02),
                 mSteadyStateThreshold(1.E-2),
                 simulationResult(),
                 integrator(NULL),

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -35,9 +35,8 @@ TEST_F(ModelAnalysisTests, checkUCCForSet) {
     RoadRunner rr((modelAnalysisModelsDir / "BIOMD0000000021.xml").string());
     //Behind the scenes, we get and then set various values to calculate ucc, and 
     // have to ensure that we don't worry about setting something that's already set.
-    rr.setDiffStepSize(0.05);
     double val = rr.getValue("ucc(P0_to_P1, V_mT)");
-    EXPECT_NEAR(val, 7.78235, 0.001);
+    EXPECT_NEAR(val, 7.84724, 0.001);
 }
 
 TEST_F(ModelAnalysisTests, getConcentrationRateSimple) {

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -35,6 +35,7 @@ TEST_F(ModelAnalysisTests, checkUCCForSet) {
     RoadRunner rr((modelAnalysisModelsDir / "BIOMD0000000021.xml").string());
     //Behind the scenes, we get and then set various values to calculate ucc, and 
     // have to ensure that we don't worry about setting something that's already set.
+    rr.setDiffStepSize(0.05);
     double val = rr.getValue("ucc(P0_to_P1, V_mT)");
     EXPECT_NEAR(val, 7.78235, 0.001);
 }

--- a/test/models/CAPICore/steadystate.xml
+++ b/test/models/CAPICore/steadystate.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="A" compartment="default_compartment" initialAmount="10" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="AP" compartment="default_compartment" initialAmount="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="K" value="0.1" constant="true"/>
+      <parameter id="Vm1" value="5" constant="true"/>
+      <parameter id="Km1" value="0.08" constant="true"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction id="_J0" reversible="true" fast="false">
+        <listOfReactants>
+          <speciesReference species="A" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="AP" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> K </ci>
+                <ci> Vm1 </ci>
+                <ci> A </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> Km1 </ci>
+                <ci> A </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="_J1" reversible="true" fast="false">
+        <listOfReactants>
+          <speciesReference species="AP" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="A" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Vm1 </ci>
+                <ci> AP </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> Km1 </ci>
+                <ci> AP </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/python/test_python_api.py
+++ b/test/python/test_python_api.py
@@ -265,8 +265,7 @@ class RoadRunnerTests(unittest.TestCase):
         self.assertEqual(bs["S1"], 20)
 
     def test_getCC(self):
-        self.rr.setDiffStepSize(0.05)
-        self.assertAlmostEqual(self.rr.getCC("_J0", "kf"), 0.009090752242926029)
+        self.assertAlmostEqual(self.rr.getCC("_J0", "kf"), 0.009090905110435235)
 
     def test_getCompiler(self):
         compiler_string = str(self.rr.getCompiler())
@@ -312,7 +311,7 @@ class RoadRunnerTests(unittest.TestCase):
         self.assertTrue(callable(self.rr.getDependentRatesOfChangeNamedArray))
 
     def test_getDiffStepSize(self):
-        self.assertEqual(0.05, self.rr.getDiffStepSize())
+        self.assertEqual(0.02, self.rr.getDiffStepSize())
 
     def test_getEE(self):
         self.assertAlmostEqual(self.rr.getEE("_J0", "kf"), 1.0000000000000024)
@@ -662,9 +661,8 @@ class RoadRunnerTests(unittest.TestCase):
         )
 
     def test_getUnscaledSpeciesElasticity(self):
-        self.rr.setDiffStepSize(0.05)
         self.assertEqual(
-            0.09999999999999994,
+            0.10000000000000007,
             self.rr.getUnscaledSpeciesElasticity(0, 0),
         )
 
@@ -675,9 +673,8 @@ class RoadRunnerTests(unittest.TestCase):
         )
 
     def test_getuCC(self):
-        self.rr.setDiffStepSize(0.05)
         self.assertAlmostEqual(
-            0.09090752242926028,
+            0.09090905110435235,
             self.rr.getuCC("_J0", "kf"),
         )
 
@@ -734,40 +731,40 @@ class RoadRunnerTests(unittest.TestCase):
                     ('stoich(S1, _J1)', 1.0),
                     ('stoich(S2, _J0)', 1.0),
                     ('stoich(S2, _J1)', -1.0),
-                    ('uec(_J0, S1)', 0.09999999999999994),
+                    ('uec(_J0, S1)', 0.10000000000000007),
                     ('uec(_J0, S2)', 0.0),
-                    ('uec(_J0, kf)', 10.000000000000023),
+                    ('uec(_J0, kf)', 10.000000000000082),
                     ('uec(_J0, kb)', 0.0),
                     ('uec(_J1, S1)', 0.0),
-                    ('uec(_J1, S2)', 0.010000000000000007),
+                    ('uec(_J1, S2)', 0.009999999999999998),
                     ('uec(_J1, kf)', 0.0),
-                    ('uec(_J1, kb)', 1.0000000000000009),
-                    ('ec(_J0, S1)', 0.9999999999999993),
+                    ('uec(_J1, kb)', 1.0000000000000053),
+                    ('ec(_J0, S1)', 1.0000000000000007),
                     ('ec(_J0, S2)', 0.0),
-                    ('ec(_J0, kf)', 1.0000000000000024),
+                    ('ec(_J0, kf)', 1.0000000000000082),
                     ('ec(_J0, kb)', 0.0),
                     ('ec(_J1, S1)', 0.0),
-                    ('ec(_J1, S2)', 1.0000000000000007),
+                    ('ec(_J1, S2)', 0.9999999999999998),
                     ('ec(_J1, kf)', 0.0),
-                    ('ec(_J1, kb)', 1.0000000000000009),
-                    ('ucc(_J0, kf)', 0.09090752242926028),
-                    ('ucc(_J0, kb)', 9.090909075384493),
-                    ('ucc(_J1, kf)', 0.09090752242926028),
-                    ('ucc(_J1, kb)', 9.090909075384475),
-                    ('ucc(S1, kf)', -9.090752242926154),
-                    ('ucc(S1, kb)', 90.90909075384494),
-                    ('ucc(S2, kf)', 9.090752242926213),
-                    ('ucc(S2, kb)', -90.90909075384464),
-                    ('cc(_J0, kf)', 0.009090752242926029),
-                    ('cc(_J0, kb)', 0.09090909075384493),
-                    ('cc(_J1, kf)', 0.9090752242926029),
-                    ('cc(_J1, kb)', 9.090909075384475),
-                    ('cc(S1, kf)', -0.09090752242926155),
-                    ('cc(S1, kb)', 0.09090909075384493),
-                    ('cc(S2, kf)', 0.9090752242926213),
-                    ('cc(S2, kb)', -0.9090909075384463),
-                    ('eigen(S1)', (-0.11000000000000017+0j)),
-                    ('eigenReal(S1)', -0.11000000000000017),
+                    ('ec(_J1, kb)', 1.0000000000000053),
+                    ('ucc(_J0, kf)', 0.09090905110435235),
+                    ('ucc(_J0, kb)', 9.090909090511781),
+                    ('ucc(_J1, kf)', 0.09090905110435235),
+                    ('ucc(_J1, kb)', 9.090909090511735),
+                    ('ucc(S1, kf)', -9.09090511043516),
+                    ('ucc(S1, kb)', 90.90909090511799),
+                    ('ucc(S2, kf)', 9.090905110435088),
+                    ('ucc(S2, kb)', -90.90909090512392),
+                    ('cc(_J0, kf)', 0.009090905110435235),
+                    ('cc(_J0, kb)', 0.09090909090511781),
+                    ('cc(_J1, kf)', 0.9090905110435236),
+                    ('cc(_J1, kb)', 9.090909090511735),
+                    ('cc(S1, kf)', -0.09090905110435162),
+                    ('cc(S1, kb)', 0.09090909090511799),
+                    ('cc(S2, kf)', 0.9090905110435088),
+                    ('cc(S2, kb)', -0.9090909090512392),
+                    ('eigen(S1)', (-0.10999999999999983+0j)),
+                    ('eigenReal(S1)', -0.10999999999999983),
                     ('eigenImag(S1)', 0.0),
                     ('eigen(S2)', 0j),
                     ('eigenReal(S2)', 0.0),

--- a/test/python/test_python_api.py
+++ b/test/python/test_python_api.py
@@ -186,7 +186,7 @@ class RoadRunnerTests(unittest.TestCase):
         )
 
     def test_diffstep_getter(self):
-        self.assertEqual(self.rr._diffstep_getter(), 0.05)
+        self.assertEqual(self.rr._diffstep_getter(), 0.02)
 
     def test_diffstep_stter(self):
         self.rr._diffstep_stter(0.01)
@@ -244,7 +244,7 @@ class RoadRunnerTests(unittest.TestCase):
         self.assertEqual(self.rr.default_compartment, 1)
 
     def test_diffstep(self):
-        self.assertEqual(self.rr.diffstep, 0.05)
+        self.assertEqual(self.rr.diffstep, 0.02)
 
     @unittest.skip("This API is unclear. ")
     def test_ensureSolversRegistered(self):
@@ -265,6 +265,7 @@ class RoadRunnerTests(unittest.TestCase):
         self.assertEqual(bs["S1"], 20)
 
     def test_getCC(self):
+        self.rr.setDiffStepSize(0.05)
         self.assertAlmostEqual(self.rr.getCC("_J0", "kf"), 0.009090752242926029)
 
     def test_getCompiler(self):
@@ -661,6 +662,7 @@ class RoadRunnerTests(unittest.TestCase):
         )
 
     def test_getUnscaledSpeciesElasticity(self):
+        self.rr.setDiffStepSize(0.05)
         self.assertEqual(
             0.09999999999999994,
             self.rr.getUnscaledSpeciesElasticity(0, 0),
@@ -673,6 +675,7 @@ class RoadRunnerTests(unittest.TestCase):
         )
 
     def test_getuCC(self):
+        self.rr.setDiffStepSize(0.05)
         self.assertAlmostEqual(
             0.09090752242926028,
             self.rr.getuCC("_J0", "kf"),

--- a/wrappers/C/rrc_api.cpp
+++ b/wrappers/C/rrc_api.cpp
@@ -1302,6 +1302,24 @@ bool rrcCallConv getCC (RRHandle handle, const char* variable, const char* param
     catch_bool_macro
 }
 
+bool rrcCallConv getDiffStepSize(RRHandle handle, double *value)
+{
+    start_try
+        RoadRunner* rri = castToRoadRunner(handle);
+        *value = rri->getDiffStepSize();
+        return true;
+    catch_bool_macro
+}
+
+bool rrcCallConv setDiffStepSize(RRHandle handle, const double value)
+{
+    start_try
+        RoadRunner* rri = castToRoadRunner(handle);
+        rri->setDiffStepSize(value);
+        return true;
+    catch_bool_macro
+}
+
 bool rrcCallConv getuEE(RRHandle handle, const char* name, const char* species, double* value)
 {
     start_try

--- a/wrappers/C/rrc_api.h
+++ b/wrappers/C/rrc_api.h
@@ -2817,6 +2817,26 @@ C_DECL_SPEC bool rrcCallConv getuCC (RRHandle handle, const char* variable, cons
 C_DECL_SPEC bool  rrcCallConv getCC (RRHandle handle, const char* variable, const char* parameter, double* value);
 
 /*!
+ \brief Retrieve the differential step size used in routines such as getCC
+
+ \param[in] handle Handle to a RoadRunner instance
+ \param[out] value This is the value of the step size returns to the caller
+ \return Returns true if successful
+ \ingroup mca
+*/
+C_DECL_SPEC bool  rrcCallConv getDiffStepSize(RRHandle handle, double* value);
+
+/*!
+ \brief Sets the differential step size used in routines such as getCC
+
+ \param[in] handle Handle to a RoadRunner instance
+ \param[in] value This is the desired step size value
+ \return Returns true if successful
+ \ingroup mca
+*/
+C_DECL_SPEC bool  rrcCallConv setDiffStepSize(RRHandle handle, const double value);
+
+/*!
  \brief Retrieve a single elasticity coefficient
 
  \param[in] handle Handle to a RoadRunner instance


### PR DESCRIPTION
Add methods for getting and setting numerical differentiation step size to C API. Also reduces default step size used in numerical differentiation from 0.05 to 0.02.