### PR TITLE
Update all docs to use 'rr' instead of 'r'

### DIFF
--- a/docs/source/C++APIReference/index.rst
+++ b/docs/source/C++APIReference/index.rst
@@ -70,7 +70,7 @@ done with the <TT>integrator</TT> keyword, i.e.
 
 .. code-block: python
 
-    r.simulate(0, 10, 100, integrator="MyIntegratorName")
+    rr.simulate(0, 10, 100, integrator="MyIntegratorName")
 
 Or, in C++:
 
@@ -78,7 +78,7 @@ Or, in C++:
 
     BasicDictionary d;
     d.setItem("integrator", "MyIntegratorName")
-    r.simulate(&d);
+    rr.simulate(&d);
 
 To create a new integrator, one first needs to create an object that implments the Integrator interface,
 tell RoadRunner about it.
@@ -222,8 +222,8 @@ RoadRunner::simulate method in C++. In Python, this would be:
 
 .. code-block:: python
 
-    r.simulate(integrator='euler', exampleParameter1=123456, exampleParameter2='some value');
-    print(r.integrator)
+    rr.simulate(integrator='euler', exampleParameter1=123456, exampleParameter2='some value');
+    print(rr.integrator)
 
 .. code-block:
     :caption: Output:
@@ -240,13 +240,13 @@ would be:
 
 .. code:block: C++
 
-    SimulateOptions& opt = r.getSimulateOptions();
+    SimulateOptions& opt = rr.getSimulateOptions();
     opt.setItem("integrator", "euler")
     opt.setItem("exampleParameter1", 123456);
     opt.setItem("exampleParameter2", "some value");
-    r.simulate();
+    rr.simulate();
 
-    cout << r.getIntegrator()->toString() << endl;
+    cout << rr.getIntegrator()->toString() << endl;
 
 The EulerIntegrator.h file serves as a complete example of creating an new integrator.
 This example was written entierly in the header file for clarity, but a real integrator

--- a/docs/source/PythonAPIReference/cls_ExecutableModel.rst
+++ b/docs/source/PythonAPIReference/cls_ExecutableModel.rst
@@ -3,7 +3,7 @@ __________________________________
 
 All of the SBML model variables are accessed via the ``RoadRunner.model`` object. This is an instance of
 the ExecutableModel class described here. One always access the model object that belongs to the top
-RoadRunner object, i.e. ``r.model``, where ``r`` is an instance of the ``RoadRunner`` class.
+RoadRunner object, i.e. ``rr.model``, where ``rr`` is an instance of the ``RoadRunner`` class.
 
 The ExecutableModel class also implements the Python dictionary protocol, so that it can be used as
 a dictionary. The dictionary keys are all of the symbols specified in the original model as well as
@@ -15,7 +15,7 @@ a number of selection strings described in the Selections section.
    Get a list of all the keys that this model has. This is a very good way of looking at all the
    available symbols and selection strings:
 
-   >>> r.model.keys()
+   >>> rr.model.keys()
    [ 'S1', 'S2', '[S1]', '[S2]', 'compartment', 'k1', 'cm0',
      'reaction1',  'init([S1])',  'init([S2])', 'init(S1)',
      'init(S2)',  "S1'"]
@@ -26,7 +26,7 @@ a number of selection strings described in the Selections section.
 
    Get a list of key / value pairs of all the selections / values in the model.
 
-   >>> r.model.items()
+   >>> rr.model.items()
    [('S1', 0.5), ('S2', 9.99954570660308), ('[S1]', 0.5), ('[S2]', 9.99954570660308),
    ('default_compartment', 1.0), ('k1', 1.0), ('init(k1)', 1.0), ('_J0', 0.5), ('init([S1])', 10.0),
    ('init([S2])', 0.0), ('init(S1)', 10.0), ('init(S2)', 0.0), ("S1'", -0.5), ("S2'", 0.5)]
@@ -37,12 +37,12 @@ a number of selection strings described in the Selections section.
 
    Implements the python ``[]`` indexing operator, so the model values can be accessed like::
 
-     >>> r.model["S1"]
+     >>> rr.model["S1"]
      0.0
 
    Following notation is also accepted::
 
-     >>> r.S1
+     >>> rr.S1
      0.0
 
 
@@ -51,15 +51,15 @@ a number of selection strings described in the Selections section.
 
    Implements the python ``[]`` indexing operator for setting values::
 
-	   >>> r.model["S1]
+	   >>> rr.model["S1]
 	   0.0
-	   >>> r.model["S1"] = 1.3
-	   >>> r.model["S1"]
+	   >>> rr.model["S1"] = 1.3
+	   >>> rr.model["S1"]
 	   1.3
 
    Following notation is also accepted::
 
-   >>> r.S1 = 1.0
+   >>> rr.S1 = 1.0
 
    Note, some keys are read only such as values defined by rules, or calculated values such as
    reaction rates. If one attempts to set the value of a read-only symbol,
@@ -75,7 +75,7 @@ Floating Species
 
    Return a list of all floating species SBML ids.
 
-   >>> r.getFloatingSpeciesIds()
+   >>> rr.getFloatingSpeciesIds()
    ['S1', 'S2', 'S3', 'S4']
 
 
@@ -84,7 +84,7 @@ Floating Species
 
    Return a list of dependent floating species SBML ids.
 
-   >>> r.getDependentFloatingSpeciesIds()
+   >>> rr.getDependentFloatingSpeciesIds()
    ['S4']
 
 
@@ -93,7 +93,7 @@ Floating Species
 
    Return a list of independent floating species SBML ids.
 
-   >>> r.getIndependentFloatingSpeciesIds()
+   >>> rr.getIndependentFloatingSpeciesIds()
    ['S1', 'S2', 'S3']
 
 
@@ -102,7 +102,7 @@ Floating Species
 
    Return a list of all floating species concentration ids.
 
-   >>> r.getFloatingSpeciesConcentrationIds()
+   >>> rr.getFloatingSpeciesConcentrationIds()
    ['[S1]', '[S2]', '[S3]', '[S4]']
    
 
@@ -111,7 +111,7 @@ Floating Species
 
    Return the number of floating species in the model.
 
-   >>> r.getNumFloatingSpecies()
+   >>> rr.getNumFloatingSpecies()
    2
 
 
@@ -127,12 +127,12 @@ Floating Species
 
    To get all the amounts::
 
-     >>> r.model.getFloatingSpeciesAmounts()
+     >>> rr.model.getFloatingSpeciesAmounts()
      array([ 0.97390578,  1.56331018,  1.15301155,  1.22717548])
 
    To get amounts from index 0 and 1::
 
-     >>> r.model.getFloatingSpeciesAmounts([0,1])
+     >>> rr.model.getFloatingSpeciesAmounts([0,1])
      array([ 0.97390578,  1.56331018])
 
 
@@ -144,10 +144,10 @@ Floating Species
 
    :param numpy.ndarray values: the values to set.
 
-   >>> r.model.getFloatingSpeciesAmounts([0,1])
+   >>> rr.model.getFloatingSpeciesAmounts([0,1])
    array([ 0.97390578,  1.56331018])
-   >>> r.model.setFloatingSpeciesAmounts([1.0, 1.5])
-   >>> r.model.getFloatingSpeciesAmounts([0,1])
+   >>> rr.model.setFloatingSpeciesAmounts([1.0, 1.5])
+   >>> rr.model.getFloatingSpeciesAmounts([0,1])
    array([ 1. ,  1.5])
 
 
@@ -161,7 +161,7 @@ Floating Species
    :returns: an array of floating species concentrations.
    :rtype: numpy.ndarray
 
-   >>> r.model.getFloatingSpeciesConcentrations()
+   >>> rr.model.getFloatingSpeciesConcentrations()
    array([  4.54293397e-04,   9.99954571e+00])
 
 
@@ -177,10 +177,10 @@ Floating Species
                                array of all the  values to set.
    :param numpy.ndarray values: the values to set.
 
-   >>> r.model.getFloatingSpeciesConcentrations()
+   >>> rr.model.getFloatingSpeciesConcentrations()
    array([  4.54293397e-04,   9.99954571e+00])
-   >>> r.model.setFloatingSpeciesConcentrations([0],[0.5])
-   >>> r.model.getFloatingSpeciesConcentrations()
+   >>> rr.model.setFloatingSpeciesConcentrations([0],[0.5])
+   >>> rr.model.getFloatingSpeciesConcentrations()
    array([ 0.5       ,  9.99954571])
 
    
@@ -199,7 +199,7 @@ The following methods allow access to the floating species initial condition val
 
    Return a list of the floating species amount initial amount selection symbols.
 
-   >>> r.model.getFloatingSpeciesInitAmountIds()
+   >>> rr.model.getFloatingSpeciesInitAmountIds()
    ['init(S1)', 'init(S2)']
 
 
@@ -208,7 +208,7 @@ The following methods allow access to the floating species initial condition val
 
    Return a list of the floating species amount initial concentration selection symbols.
 
-   >>> r.model.getFloatingSpeciesInitConcentrationIds()
+   >>> rr.model.getFloatingSpeciesInitConcentrationIds()
    ['init([S1])', 'init([S2])']
 
 
@@ -223,7 +223,7 @@ The following methods allow access to the floating species initial condition val
    :rtype: numpy.ndarray
 
 
-   >>> r.model.getFloatingSpeciesInitConcentrations()
+   >>> rr.model.getFloatingSpeciesInitConcentrations()
    array([ 10.,   0.])
 
 
@@ -236,8 +236,8 @@ The following methods allow access to the floating species initial condition val
    :param numpy.ndarray index: (optional) an index array indicating which items to return.
 
 
-   >>> r.model.setFloatingSpeciesInitConcentrations([0], [1])
-   >>> r.model.getFloatingSpeciesInitConcentrations()
+   >>> rr.model.setFloatingSpeciesInitConcentrations([0], [1])
+   >>> rr.model.getFloatingSpeciesInitConcentrations()
    array([ 1.,  0.])
 
 
@@ -252,7 +252,7 @@ The following methods allow access to the floating species initial condition val
    :rtype: numpy.ndarray
 
 
-   >>> r.model.getFloatingSpeciesInitAmounts()
+   >>> rr.model.getFloatingSpeciesInitAmounts()
    array([ 10.,   0.])
 
 
@@ -265,8 +265,8 @@ The following methods allow access to the floating species initial condition val
    :param numpy.ndarray index: (optional) an index array indicating which items to return.
 
 
-   >>> r.model.setFloatingSpeciesInitAmounts([0], [0.1])
-   >>> r.model.getFloatingSpeciesInitAmounts()
+   >>> rr.model.setFloatingSpeciesInitAmounts([0], [0.1])
+   >>> rr.model.getFloatingSpeciesInitAmounts()
    array([ 0.1,  0. ])
 
 
@@ -283,7 +283,7 @@ Boundary Species
    :returns: an array of the boundary species amounts.
    :rtype: numpy.ndarray
 
-   >>> r.model.getBoundarySpeciesAmounts()
+   >>> rr.model.getBoundarySpeciesAmounts()
    array([ 15.,   0.])
 
 
@@ -297,7 +297,7 @@ Boundary Species
    :returns: an array of the boundary species concentrations.
    :rtype: numpy.ndarray
 
-   >>> r.getBoundarySpeciesConcentrations()
+   >>> rr.getBoundarySpeciesConcentrations()
    array([ 0.5,   0.])
 
 
@@ -310,7 +310,7 @@ Boundary Species
    :returns: a list of boundary species ids.
 
 
-   >>> r.getBoundarySpeciesIds()
+   >>> rr.getBoundarySpeciesIds()
    ['X0', 'X1']
 
 
@@ -323,7 +323,7 @@ Boundary Species
    :returns: a list of boundary species concentration ids.
 
 
-   >>> r.getBoundarySpeciesConcentrationIds()
+   >>> rr.getBoundarySpeciesConcentrationIds()
    ['[X0]', '[X1]']   
    
    
@@ -333,7 +333,7 @@ Boundary Species
    Return the number of boundary species in the model.
 
 
-   >>> r.getNumBoundarySpecies()
+   >>> rr.getNumBoundarySpecies()
    2
 
 
@@ -350,8 +350,8 @@ Boundary Species
    :param numpy.ndarray values: the values to set.
 
 
-   >>> r.model.setBoundarySpeciesConcentrations([0], [1])
-   >>> r.getBoundarySpeciesConcentrations()
+   >>> rr.model.setBoundarySpeciesConcentrations([0], [1])
+   >>> rr.getBoundarySpeciesConcentrations()
    array([ 1.,  0.])
 
 
@@ -368,7 +368,7 @@ Compartments
    :returns: a list of compartment ids.
 
 
-   >>> r.getCompartmentIds()
+   >>> rr.getCompartmentIds()
    ['compartment1']
 
 
@@ -383,7 +383,7 @@ Compartments
    :rtype: numpy.ndarray.
 
 
-   >>> r.getCompartmentVolumes()
+   >>> rr.getCompartmentVolumes()
    array([ 1.])
 
 
@@ -395,7 +395,7 @@ Compartments
    :rtype: int
 
 
-   >>> r.getNumCompartments()
+   >>> rr.getNumCompartments()
    1
 
 
@@ -415,8 +415,8 @@ Compartments
    :param numpy.ndarray values: the values to set.
 
 
-   >>> r.model.setCompartmentVolumes([0], [2.5])
-   >>> r.getCompartmentVolumes()
+   >>> rr.model.setCompartmentVolumes([0], [2.5])
+   >>> rr.getCompartmentVolumes()
    array([ 2.5])
 
 
@@ -443,7 +443,7 @@ Global Parameters
    :rtype: numpy.ndarray.
 
 
-   >>> r.getGlobalParameterValues()
+   >>> rr.getGlobalParameterValues()
    array([ 10. ,  10. ,  10. ,   2.5,   0.5])
 
 
@@ -453,7 +453,7 @@ Global Parameters
 
    Returns the number of global parameters in the model.
 
-   >>> r.getNumGlobalParameters()
+   >>> rr.getNumGlobalParameters()
    5
 
 
@@ -470,8 +470,8 @@ Global Parameters
    :param numpy.ndarray values: the values to set.
 
 
-   >>> r.model.setGlobalParameterValues([0], [1.5])
-   >>> r.getGlobalParameterValues()
+   >>> rr.model.setGlobalParameterValues([0], [1.5])
+   >>> rr.getGlobalParameterValues()
    array([  1.5,  10. ,  10. ,   2.5,   0.5])
 
 
@@ -484,7 +484,7 @@ Reactions
    Return the number of reactions in the model.
 
 
-   >>> r.getNumReactions()
+   >>> rr.getNumReactions()
    5
 
 
@@ -497,7 +497,7 @@ Reactions
    :returns: a list of reaction ids.
 
 
-   >>> r.getReactionIds()
+   >>> rr.getReactionIds()
    ['J0', 'J1', 'J2', 'J3', 'J4']
 
 
@@ -512,7 +512,7 @@ Reactions
    :rtype: numpy.ndarray
 
 
-   >>> r.getReactionRates()
+   >>> rr.getReactionRates()
    array([ 0.14979613,  2.37711263,  2.68498886,  2.41265507,  1.89417737])
 
 Events
@@ -523,7 +523,7 @@ Events
 
    Returns the number of events.
 
-   >>> r.getNumEvents()
+   >>> rr.getNumEvents()
    1
 
 
@@ -535,7 +535,7 @@ Rate Rules
 
    Returns the number of rate rules.
 
-   >>> r.getNumRateRules()
+   >>> rr.getNumRateRules()
    1
 
    
@@ -546,7 +546,7 @@ Rate Rules
 
    :returns: a list of event ids.
    
-   >>> r.model.getEventIds()
+   >>> rr.model.getEventIds()
    ['E1']
    
    
@@ -567,7 +567,7 @@ Stoichiometry
    :param reactionIndex: a reaction index from :meth:`getReactionIds`
 
 
-   >>> r.model.getStoichiometry(1, 3)
+   >>> rr.model.getStoichiometry(1, 3)
    1.0
 
 
@@ -584,7 +584,7 @@ Refer to :attr:`RoadRunner.conservedMoietyAnalysis` and :attr:`Config.LOADSBMLOP
    :rtype: int
 
 
-   >>> r.getNumConservedMoieties()
+   >>> rr.getNumConservedMoieties()
    1
 
 
@@ -598,7 +598,7 @@ Refer to :attr:`RoadRunner.conservedMoietyAnalysis` and :attr:`Config.LOADSBMLOP
    :returns: a list of compartment ids.
 
 
-   >>> r.getConservedMoietyIds()
+   >>> rr.getConservedMoietyIds()
    ['_CSUM0']
 
 
@@ -613,7 +613,7 @@ Refer to :attr:`RoadRunner.conservedMoietyAnalysis` and :attr:`Config.LOADSBMLOP
    :rtype: numpy.ndarray.
 
 
-   >>> r.getConservedMoietyValues()
+   >>> rr.getConservedMoietyValues()
    array([ 2.])
 
 
@@ -635,8 +635,8 @@ Refer to :attr:`RoadRunner.conservedMoietyAnalysis` and :attr:`Config.LOADSBMLOP
    :param numpy.ndarray values: the values to set.
 
 
-   >>> r.model.setConservedMoietyValues([0], [5])
-   >>> r.getConservedMoietyValues()
+   >>> rr.model.setConservedMoietyValues([0], [5])
+   >>> rr.getConservedMoietyValues()
    array([ 5.])
 
 
@@ -652,7 +652,7 @@ Misc
 
    :returns: a list of all component ids widely used in time course selections.
 
-        >>> r.model.getAllTimeCourseComponentIds()
+        >>> rr.model.getAllTimeCourseComponentIds()
         ['time', 'S1', 'S2', 'S3', 'k1', 'k2', 'default_compartment', '_J0', '_J1']
 
 
@@ -663,7 +663,7 @@ Misc
    Get various info about the model.
 
 
-   >>> print(r.getInfo())
+   >>> print(rr.getInfo())
    <roadrunner.RoadRunner() {
    'this' : 13DEF5F8
    'modelLoaded' : true
@@ -706,7 +706,7 @@ Misc
    Get the model name specified in the SBML.
 
 
-   >>> r.model.getModelName()
+   >>> rr.model.getModelName()
    'feedback'
 
 
@@ -717,7 +717,7 @@ Misc
    integrator. So, if one ran a simulation from time = 0 to time = 10, the model will then have it's
    time = 10.
 
-   >>> r.model.getTime()
+   >>> rr.model.getTime()
    40.0
 
 

--- a/docs/source/PythonAPIReference/cls_Integrator.rst
+++ b/docs/source/PythonAPIReference/cls_Integrator.rst
@@ -83,21 +83,21 @@ CVODE
 
     Specifies the scalar or vector absolute tolerance based on amount of species. A potentially different absolute tolerance for each vector component could be set using a double vector. CVODE then calculates a vector of error weights which is used in all error and convergence tests. The weighted RMS norm for the absolute tolerance should not become smaller than this value. Default value is Config::CVODE_MIN_ABSOLUTE.
     
-    >>> r.integrator.absolute_tolerance = 1
-    >>> r.integrator.absolute_tolerance = [1, 0.1, 0.01, 0.001] // setting vairous tolerance for each species
+    >>> rr.integrator.absolute_tolerance = 1
+    >>> rr.integrator.absolute_tolerance = [1, 0.1, 0.01, 0.001] // setting vairous tolerance for each species
     
 
 .. attribute:: Integrator.initial_time_step
 
     Specifies the initial time step size. If inappropriate, CVODE will attempt to estimate a better initial time step. Default value is 0.0
 
-    >>> r.integrator.initial_time_step = 1
+    >>> rr.integrator.initial_time_step = 1
 
 .. attribute:: Integrator.maximum_adams_order
 
     Specifies the maximum order for Adams-Moulton intergration. This integration method is used for non-stiff problems. Default value is 12.
 
-    >>> r.integrator.maximum_adams_order = 20
+    >>> rr.integrator.maximum_adams_order = 20
 
 .. attribute:: Integrator.maximum_bdf_order
 
@@ -123,7 +123,7 @@ CVODE
 
     Perform a multiple time step simulation. Default value is false.
 
-    >>> r.integrator.multiple_steps = True
+    >>> rr.integrator.multiple_steps = True
 
 .. attribute:: Integrator.relative_tolerance
 
@@ -145,14 +145,14 @@ Gillespie
 
     RoadRunner's implementation of the standard Gillespie Direct Method SSA. The granularity of this simulator is individual molecules and kinetic processes are stochastic. Results will, in general, be different in each run, but a sufficiently large ensemble of runs should be statistically correct.
 
-    Can be used with the `r.gillespie function <https://libroadrunner.readthedocs.io/en/latest/api_reference.html?highlight=r%20gillespie#RoadRunner.RoadRunner.gillespie/>`_ or by setting integrator to gillespie (see below)
+    Can be used with the `rr.gillespie function <https://libroadrunner.readthedocs.io/en/latest/PythonAPIReference/cls_RoadRunner.html#RoadRunner.RoadRunner.gillespie>`_ or by setting integrator to gillespie (see below)
 
 .. attribute:: Integrator.initial_time_step
 
     Specifies the initial time step size. If inappropriate, CVODE will attempt to estimate a better initial time step. Default value is 0.0
 
-    >>> r.setIntegrator('gillespie') # set integrator first
-    >>> r.integrator.initial_time_step = 2
+    >>> rr.setIntegrator('gillespie') # set integrator first
+    >>> rr.integrator.initial_time_step = 2
 
 
 .. attribute:: Integrator.maximum_time_step
@@ -189,14 +189,14 @@ Euler
 
     The Euler method is one of the simplest approaches to solving a first order ODE. Given the rate of change of function f at time t, it computes the new value of f as ``f(t+h) = f(t) + h*f'(t)``, where h is the time step. Euler's method is rarely used in practice due to poor numerical robustness. Can be used with:
 
-    >>> r.setIntegrator('euler')
+    >>> rr.setIntegrator('euler')
 
 RK4
 ---
     
     Runge-Kutta methods are a family of algorithms for solving ODEs. They have considerably better accuracy than the Euler method. This integrator is a standard 4th order Runge-Kutta solver. Can be used with:
 
-    >>> r.setIntegrator('rk4')
+    >>> rr.setIntegrator('rk4')
 
 
 RK45
@@ -209,8 +209,8 @@ RK45
 
     Specifies the maximum error tolerance allowed. Default value is 1e-12.
 
-    >>> r.setIntegrator('rk45') # set integrator first
-    >>> r.integrator.epsilon = 1e-10
+    >>> rr.setIntegrator('rk45') # set integrator first
+    >>> rr.integrator.epsilon = 1e-10
 
 .. attribute:: Integrator.maximum_time_step
 

--- a/docs/source/PythonAPIReference/cls_RoadRunner.rst
+++ b/docs/source/PythonAPIReference/cls_RoadRunner.rst
@@ -38,26 +38,26 @@ _________________________
 
    Some examples of loading files on Mac or Linux::
    
-       >>> r.load("myfile.xml")                               # load a file from the current directory
-       >>> r.load("/Users/Fred/myfile.xml")                   # absolute path
-       >>> r.load("http://sbml.org/example_system.xml")       # remote file
+       >>> rr.load("myfile.xml")                               # load a file from the current directory
+       >>> rr.load("/Users/Fred/myfile.xml")                   # absolute path
+       >>> rr.load("http://sbml.org/example_system.xml")       # remote file
 
 
    Or on Windows:
 
-       >>> r.load("myfile.xml")                                  # load a file from the current directory
-       >>> r.load("file://localhost/c:/Users/Fred/myfile.xml")   # using a URI
+       >>> rr.load("myfile.xml")                                  # load a file from the current directory
+       >>> rr.load("file://localhost/c:/Users/Fred/myfile.xml")   # using a URI
 
    One may also load the contents of a document::
 
        >>> myfile = open("myfile.xml, "r")
        >>> contents = file.read()
-       >>> r.load(contents)
+       >>> rr.load(contents)
        
    Loading in a raw SBML string is also possible:
 
        >>> sbmlstr = rr.getCurrentSBML()         # Or any other properly formatted SBML string block
-       >>> r.load(sbmlstr)
+       >>> rr.load(sbmlstr)
 
    In future version, we will also support loading directly from a libSBML Document object. 
 
@@ -77,18 +77,18 @@ _________________________
    
    Some examples of saving binary files on Mac or Linux::
    
-       >>> r.saveState("current_state.txt")                        # save the state to a file from the current directory
-       >>> r.saveState("/Users/Fred/current_state.txt")            # absolute path
+       >>> rr.saveState("current_state.txt")                        # save the state to a file from the current directory
+       >>> rr.saveState("/Users/Fred/current_state.txt")            # absolute path
 
 
    Or on Windows:
 
-       >>> r.saveState("current_state.txt")                        # save the state to a file from the current directory
-       >>> r.saveState("file://localhost/c:/Users/Fred/current_state.txt")   # using a URI
+       >>> rr.saveState("current_state.txt")                        # save the state to a file from the current directory
+       >>> rr.saveState("file://localhost/c:/Users/Fred/current_state.txt")   # using a URI
 
    One may also save in a human-readable format:
 
-       >>> r.saveState("current_state.txt", 'r')
+       >>> rr.saveState("current_state.txt", 'r')
        
 
    :param document: The file path where the current state will be stored
@@ -110,14 +110,14 @@ _________________________
    
    Some examples of reloading binary files on Mac or Linux::
    
-       >>> r.loadState("current_state.txt")                        # load the state from a file from the current directory
-       >>> r.loadState("/Users/Fred/current_state.txt")            # absolute path
+       >>> rr.loadState("current_state.txt")                        # load the state from a file from the current directory
+       >>> rr.loadState("/Users/Fred/current_state.txt")            # absolute path
 
 
    Or on Windows:
 
-       >>> r.loadState("current_state.txt")                        # load the state from a file from the current directory
-       >>> r.loadState("file://localhost/c:/Users/Fred/current_state.txt")   # using a URI
+       >>> rr.loadState("current_state.txt")                        # load the state from a file from the current directory
+       >>> rr.loadState("file://localhost/c:/Users/Fred/current_state.txt")   # using a URI
 
    :param document: The file path where the state of simulation will be loaded from
    :type name: str
@@ -332,10 +332,10 @@ Model Access
    Clears the currently loaded model and all associated memory.
    Returns True if memory was freed, False if no model was loaded in the first place.
    
-   >>> r.isModelLoaded()
+   >>> rr.isModelLoaded()
    True
-   >>> r.clearModel()
-   >>> r.isModelLoaded()
+   >>> rr.clearModel()
+   >>> rr.isModelLoaded()
    False
    
    
@@ -366,7 +366,7 @@ Model Access
 
    Resets time, all floating species, and rates to their CURRENT initial values.
    Also resets all global parameters back to the values they had when the model was first loaded.
-   "Current" initial values are set by using ``r.setValue('init(S1)', 5)`` which sets a species 
+   "Current" initial values are set by using ``rr.setValue('init(S1)', 5)`` which sets a species 
    named S1 to have current initial value of 5. Note it is NOT the initial values of when the model was first loaded in.
 
 .. method:: RoadRunner.resetParameter()
@@ -403,7 +403,7 @@ Model Access
    
    To enable, type:
    
-   >>> r.conservedMoietyAnalysis = True
+   >>> rr.conservedMoietyAnalysis = True
    
    
 Model Editing
@@ -427,8 +427,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.addSpeciesConcentration("s1", "compartment", 0.1, False) # it will not regenerate the model, nothing actually happened
-   >>> r.addSpeciesConcentration("s2", "compartment", 0.1, True)  # new model is generated and saved
+   >>> rr.addSpeciesConcentration("s1", "compartment", 0.1, False) # it will not regenerate the model, nothing actually happened
+   >>> rr.addSpeciesConcentration("s2", "compartment", 0.1, True)  # new model is generated and saved
   
    :param str sid: the ID of the species to be added
    :param str compartment: the compartment of the species to be added
@@ -463,8 +463,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.removeSpecies("s1", false) # it will not regenerate the model, nothing actually happened
-   >>> r.removeSpecies("s2", true)  # new model is generated and saved
+   >>> rr.removeSpecies("s1", false) # it will not regenerate the model, nothing actually happened
+   >>> rr.removeSpecies("s2", true)  # new model is generated and saved
 
    :param str sid: the ID of the species to be removed
    :param bool forceRegenerate: indicate whether the new model is regenerated after this function call
@@ -484,8 +484,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.addReaction("r1", ["s1"], ["s2"], "s1 * k1", False) # it will not regenerate the model, nothing actually happened
-   >>> r.addReaction("r2", ["s2"], ["s1"], "s2 * k1", True)  # new model is generated and saved
+   >>> rr.addReaction("r1", ["s1"], ["s2"], "s1 * k1", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.addReaction("r2", ["s2"], ["s1"], "s2 * k1", True)  # new model is generated and saved
   
   
    :param str rid: the ID of the reaction to be added
@@ -525,8 +525,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.removeReaction("r1", False) # it will not regenerate the model, nothing actually happened
-   >>> r.removeReaction("r2", True)  # new model is generated and saved
+   >>> rr.removeReaction("r1", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.removeReaction("r2", True)  # new model is generated and saved
 
    :param str rid: the ID of the reaction to be removed
    :param bool forceRegenerate: indicate whether the new model is regenerated after this function call
@@ -546,8 +546,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.addParameter("p1", 0.1, False) # it will not regenerate the model, nothing actually happened
-   >>> r.addParameter("p2", 0.1, True)  # new model is generated and saved
+   >>> rr.addParameter("p1", 0.1, False) # it will not regenerate the model, nothing actually happened
+   >>> rr.addParameter("p2", 0.1, True)  # new model is generated and saved
   
    :param str pid: the ID of the parameter to be added
    :param double value: the initial value of the parameter to be added
@@ -579,8 +579,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.removeParameter("p1", False) # it will not regenerate the model, nothing actually happened
-   >>> r.removeParameter("p2", True)  # new model is generated and saved
+   >>> rr.removeParameter("p1", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.removeParameter("p2", True)  # new model is generated and saved
 
    :param str pid: the ID of the parameter to be removed
    :param bool forceRegenerate: indicate whether the new model is regenerated after this function call
@@ -601,8 +601,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.addCompartment("c1", 0.1, False) # it will not regenerate the model, nothing actually happened
-   >>> r.addCompartment("c2", 0.1, True)  # new model is generated and saved
+   >>> rr.addCompartment("c1", 0.1, False) # it will not regenerate the model, nothing actually happened
+   >>> rr.addCompartment("c2", 0.1, True)  # new model is generated and saved
   
    :param str cid: the ID of the compartment to be added
    :param double initVolume: the initial volume of the compartment to be added
@@ -634,8 +634,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.removeCompartment("c1", False) # it will not regenerate the model, nothing actually happened
-   >>> r.removeCompartment("c2", True)  # new model is generated and saved
+   >>> rr.removeCompartment("c1", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.removeCompartment("c2", True)  # new model is generated and saved
 
    :param str cid: the ID of the compartment to be removed
    :param bool forceRegenerate: indicate whether the new model is regenerated after this function call
@@ -655,8 +655,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.setKineticLaw("r1", "s1 * k1", False) # it will not regenerate the model, nothing actually happened
-   >>> r.setKineticLaw("r2", "s2 * k1", True)  # new model is generated and saved
+   >>> rr.setKineticLaw("r1", "s1 * k1", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.setKineticLaw("r2", "s2 * k1", True)  # new model is generated and saved
   
   
    :param str rid: the ID of the reaction to be modified
@@ -677,8 +677,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.addAssignmentRule("s1", "s1 * k1", False) # it will not regenerate the model, nothing actually happened
-   >>> r.addAssignmentRule("s2", "s2 * k1", True)  # new model is generated and saved
+   >>> rr.addAssignmentRule("s1", "s1 * k1", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.addAssignmentRule("s2", "s2 * k1", True)  # new model is generated and saved
   
   
    :param str vid: the ID of the variable that the new rule assigns formula to
@@ -699,8 +699,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.addRateRule("s1", "k1", False) # it will not regenerate the model, nothing actually happened
-   >>> r.addRateRule("s2", "k1", True)  # new model is generated and saved
+   >>> rr.addRateRule("s1", "k1", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.addRateRule("s2", "k1", True)  # new model is generated and saved
   
   
    :param str vid: the ID of the variable that the new rule assigns formula to
@@ -725,8 +725,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.removeRules("s1", False) # it will not regenerate the model, nothing actually happened
-   >>> r.removeRules("s2", True)  # new model is generated and saved
+   >>> rr.removeRules("s1", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.removeRules("s2", True)  # new model is generated and saved
 
    :param str vid: the ID of the variables that rules assign formula to
    :param bool forceRegenerate: indicate whether the new model is regenerated after this function call
@@ -746,8 +746,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.addEvent("e1", False, "s1 > 0", False) # it will not regenerate the model, nothing actually happened
-   >>> r.addEvent("e2", False, "s2 == s1", True)  # new model is generated and saved
+   >>> rr.addEvent("e1", False, "s1 > 0", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.addEvent("e2", False, "s2 == s1", True)  # new model is generated and saved
   
   
    :param str eid: the ID of the event to be added
@@ -771,8 +771,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
    For example,
    
-   >>> r.addTrigger("e1", "s1 > 0", False) # it will not regenerate the model, nothing actually happened
-   >>> r.addTrigger("e2", "s2 == s1", True)  # new model is generated and saved
+   >>> rr.addTrigger("e1", "s1 > 0", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.addTrigger("e2", "s2 == s1", True)  # new model is generated and saved
   
   
    :param str eid: the ID of the event to add the trigger to
@@ -832,8 +832,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
     For example,
    
-   >>> r.addEventAssignment("e1", "s1", "k1", False) # it will not regenerate the model, nothing actually happened
-   >>> r.addEventAssignment("e2", "s2", "s1", True)  # new model is generated and saved
+   >>> rr.addEventAssignment("e1", "s1", "k1", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.addEventAssignment("e2", "s2", "s1", True)  # new model is generated and saved
    
   
    :param str eid: the ID of the event to add the event assignment to
@@ -857,8 +857,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
     For example,
    
-   >>> r.removeEventAssignment("e1", "s1", False) # it will not regenerate the model, nothing actually happened
-   >>> r.removeEventAssignment("e2", "s2", True)  # new model is generated and saved
+   >>> rr.removeEventAssignment("e1", "s1", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.removeEventAssignment("e2", "s2", True)  # new model is generated and saved
    
   
    :param str eid: the ID of the event 
@@ -882,8 +882,8 @@ Easy edit to the model without modifying and reloading sbml files.
    
     For example,
    
-   >>> r.removeEvent("e1", False) # it will not regenerate the model, nothing actually happened
-   >>> r.removeEvent("e2", True)  # new model is generated and saved
+   >>> rr.removeEvent("e1", False) # it will not regenerate the model, nothing actually happened
+   >>> rr.removeEvent("e2", True)  # new model is generated and saved
    
   
    :param str eid: the ID of the event to be removed
@@ -896,13 +896,13 @@ Easy edit to the model without modifying and reloading sbml files.
 
    For example:
 
-   >>>> r.addCompartment ('c1', 0.1)
-   >>>> r.addSpeciesConcentration ('s1', 'c1', 1.5, False, False)
-   >>>> r.addSpeciesConcentration ('s2', 'c1', 0.0, False, False)
-   >>>> r.addParameter('k1', 0.2)
-   >>>> r.addReaction ('r1', ['s1'], ['s2'], 's1*k1')
-   >>>> r.regenerateModel()
-   >>>> r.simulate()
+   >>>> rr.addCompartment ('c1', 0.1)
+   >>>> rr.addSpeciesConcentration ('s1', 'c1', 1.5, False, False)
+   >>>> rr.addSpeciesConcentration ('s2', 'c1', 0.0, False, False)
+   >>>> rr.addParameter('k1', 0.2)
+   >>>> rr.addReaction ('r1', ['s1'], ['s2'], 's1*k1')
+   >>>> rr.regenerateModel()
+   >>>> rr.simulate()
 
 Simulation
 ----------
@@ -933,7 +933,7 @@ All simulation related tasks can be accomplished with the single ``simulate`` me
         5: output file path. The file to which simulation results will be written. If this is specified and
         nonempty, simulation output will be written to output_file every Config::K_ROWS_PER_WRITE generated.
         Note that simulate() will not return the result matrix if it is writing to output_file.
-        It will also not keep any simulation data, so in that case one should not call ``r.plot()``
+        It will also not keep any simulation data, so in that case one should not call ``rr.plot()``
         without arguments. This should be specified when one cannot, or does not want to, keep the 
         entire result matrix in memory.
 
@@ -981,19 +981,19 @@ All simulation related tasks can be accomplished with the single ``simulate`` me
 
    Simulate from time zero to 40 time units 
    
-   >>> result = r.gillespie (0, 40)
+   >>> result = rr.gillespie (0, 40)
 
    Simulate on a grid with 10 points from start 0 to end time 40 
    
-   >>> result = r.gillespie (0, 40, 10)
+   >>> result = rr.gillespie (0, 40, 10)
 
    Simulate from time zero to 40 time units using the given selection list 
    
-   >>> result = r.gillespie (0, 40, [‘time’, ‘S1’])
+   >>> result = rr.gillespie (0, 40, [‘time’, ‘S1’])
 
    Simulate from time zero to 40 time units, on a grid with 20 points using the given selection list 
    
-   >>> result = r.gillespie (0, 40, 20, [‘time’, ‘S1’])
+   >>> result = rr.gillespie (0, 40, 20, [‘time’, ‘S1’])
    
 
 .. py:function:: RoadRunner.plot(result=None, loc='upper left', show=True)
@@ -1003,7 +1003,7 @@ All simulation related tasks can be accomplished with the single ``simulate`` me
   
    To plot data currently held by roadrunner that was generated in the last simulation, use:
    
-   >>> r.plot() 
+   >>> rr.plot() 
    
    If you are using Tellurium, see `tellurium.ExtendedRoadRunner.plot <https://tellurium.readthedocs.io/en/latest/tellurium_methods.html#tellurium.tellurium.ExtendedRoadRunner.plot>`_ which supports extra arguements.
    
@@ -1035,8 +1035,8 @@ Steady State
    a steady state calculation. This list may be set by assigning a list
    of valid selection symbols::
 
-     >>> r.steadyStateSelections = ['S1', '[S2]', 'P1']
-     >>> r.steadyStateSelections
+     >>> rr.steadyStateSelections = ['S1', '[S2]', 'P1']
+     >>> rr.steadyStateSelections
      ['S1', '[S2]', 'P1']
 
 
@@ -1411,17 +1411,17 @@ Analysis
      import roadrunner
      from matplotlib import pyplot as plt
 
-     r = te.loada("""
-         $Xo -> x1; k1*Xo - k2*x1;
-          x1 -> x2; k2*x1 - k3*x2;
-          x2 ->; k3*x2;
+     rr = te.loada("""
+          $Xo -> x1; k1*Xo - k2*x1;
+           x1 -> x2; k2*x1 - k3*x2;
+           x2 ->; k3*x2;
 
-          k1 = 0.5; k2 = 0.23; k3 = 0.4;  Xo = 5;
+           k1 = 0.5; k2 = 0.23; k3 = 0.4;  Xo = 5;
      """)
 
-     r.steadyState()
+     rr.steadyState()
 
-     m = r.getFrequencyResponse(0.001, 5, 1000, 'Xo', 'x2', True, False)
+     m = rr.getFrequencyResponse(0.001, 5, 1000, 'Xo', 'x2', True, False)
 
      fig = plt.figure(figsize=(10,4))
 
@@ -1446,7 +1446,7 @@ Analysis
    :returns: a named array of floating species rates of change.
    :rtype: numpy.ndarray
 
-   >>> r.getRatesOfChange()
+   >>> rr.getRatesOfChange()
              MKKK,       MKKK_P,      MKK,      MKK_P,    MKK_PP,     MAPK,   MAPK_P,  MAPK_PP
    [[ 0.000503289, -0.000503289, 0.537508, -0.0994839, -0.438024, 0.061993, 0.108417, -0.17041]]
    
@@ -1460,7 +1460,7 @@ Analysis
    :returns: a named array of independent floating species rates of change.
    :rtype: numpy.ndarray
 
-   >>> r.getIndependentRatesOfChange()
+   >>> rr.getIndependentRatesOfChange()
            MKK_P,   MAPK_P,        MKKK,      MKK,     MAPK
    [[ -0.0994839, 0.108417, 0.000503289, 0.537508, 0.061993]]
 
@@ -1474,7 +1474,7 @@ Analysis
    :returns: a named array of dependent floating species rates of change.
    :rtype: numpy.ndarray
 
-   >>> r.getDependentRatesOfChange()
+   >>> rr.getDependentRatesOfChange()
          MKK_PP,       MKKK_P,  MAPK_PP
    [[ -0.438024, -0.000503289, -0.17041]]
      

--- a/docs/source/PythonAPIReference/cls_SteadyStateSolver.rst
+++ b/docs/source/PythonAPIReference/cls_SteadyStateSolver.rst
@@ -17,7 +17,7 @@ NLEQ2
 
     To enable, type:
 
-    >>> r.getSteadyStateSolver().allow_presimulation = True
+    >>> rr.getSteadyStateSolver().allow_presimulation = True
 
 
 .. attribute:: SteadyStateSolver.presimulation_tolerance
@@ -25,21 +25,21 @@ NLEQ2
 
     Tolerance for presimulation before steady state analysis. Absolute tolerance used by presimulation routine. Only used when allow_presimulation is True. Default value is 1e-3.
 
-    >>> r.getSteadyStateSolver().presimulation_tolerance = 1e-2
+    >>> rr.getSteadyStateSolver().presimulation_tolerance = 1e-2
 
 
 .. attribute:: SteadyStateSolver.presimulation_maximum_steps
 
     Maximum number of steps that can be taken for presimulation before steady state analysis. Takes priority over presimulation_time. Only used when allow_presimulation is True. Default value is 100.
 
-    >>> r.getSteadyStateSolver().presimulation_maximum_steps = 50
+    >>> rr.getSteadyStateSolver().presimulation_maximum_steps = 50
 
 
 .. attribute:: SteadyStateSolver.presimulation_time
 
     End time for presimulation steady state analysis. Only used when allow_presimulation is True. Default value is 100.
 
-    >>> r.getSteadyStateSolver().presimulation_time = 50
+    >>> rr.getSteadyStateSolver().presimulation_time = 50
 
 
 .. attribute:: SteadyStateSolver.allow_approx
@@ -48,28 +48,28 @@ NLEQ2
 
     To disable, type:
 
-    >>> r.getSteadyStateSolver().allow_approx = False
+    >>> rr.getSteadyStateSolver().allow_approx = False
 
 
 .. attribute:: SteadyStateSolver.approx_tolerance
 
     Tolerance for steady state approximation routine. Absolute tolerance used by steady state approximation routine. Only used when steady state approximation routine is used. Default value is 1e-12.
 
-    >>> r.getSteadyStateSolver().approx_tolerance = 1e-6
+    >>> rr.getSteadyStateSolver().approx_tolerance = 1e-6
 
 
 .. attribute:: SteadyStateSolver.approx_maximum_steps
 
     Maximum number of steps that can be taken for steady state approximation routine. Takes priority over approx_time. Only used when steady state approximation routine is used. Default value is 10000.
 
-    >>> r.getSteadyStateSolver().approx_maximum_steps = 5000
+    >>> rr.getSteadyStateSolver().approx_maximum_steps = 5000
 
 
 .. attribute:: SteadyStateSolver.approx_time
 
     End time for steady state approximation routine. approx_maximum_steps takes priority. Only used when steady state approximation routine is used. Default value is 10000.
 
-    >>> r.getSteadyStateSolver().approx_time = 5000
+    >>> rr.getSteadyStateSolver().approx_time = 5000
 
 
 .. attribute:: SteadyStateSolver.broyden_method
@@ -78,35 +78,35 @@ NLEQ2
 
     To enable, type:
    
-   >>> r.getSteadyStateSolver().broyden_method = 1
+   >>> rr.getSteadyStateSolver().broyden_method = 1
 
 
 .. attribute:: SteadyStateSolver.linearity
 
     Specifies linearity of the problem. 1 is for linear problem and 4 is for extremly nonlinear problem. Default value is 3.
 
-    >>> r.getSteadyStateSolver().linearity = 1
+    >>> rr.getSteadyStateSolver().linearity = 1
 
 
 .. attribute:: SteadyStateSolver.maximum_iterations
 
     The maximum number of iterations the solver is allowed to use. Iteration caps off at the maximum, regardless of whether a solution has been reached. Default value is 100.
 
-    >>> r.getSteadyStateSolver().maximum_iterations = 50
+    >>> rr.getSteadyStateSolver().maximum_iterations = 50
 
 
 .. attribute:: SteadyStateSolver.minimum_damping
 
     The minimum damping factor used by the algorithm. Default value is 1e-4.
 
-    >>> r.getSteadyStateSolver().minimum_damping = 1e-20
+    >>> rr.getSteadyStateSolver().minimum_damping = 1e-20
 
 
 .. attribute:: SteadyStateSolver.relative_tolerance
 
     Specifies the relative tolerance used by the solver. Default value is 1e-16.
 
-    >>> r.getSteadyStateSolver().relative_tolerance = 1e-15
+    >>> rr.getSteadyStateSolver().relative_tolerance = 1e-15
 
 
 .. method:: SteadyStateSolver.solve()

--- a/docs/source/parallel/multiprocessing/_brown2004_multiprocessing_pool.py
+++ b/docs/source/parallel/multiprocessing/_brown2004_multiprocessing_pool.py
@@ -21,19 +21,19 @@ NCORES = cpu_count()
 NSIMS = 10000
 
 
-def simulate_worker(r: RoadRunner):
-    r.resetAll()
-    r.simulate(0, 10000, 10000)
+def simulate_worker(rr: RoadRunner):
+    rr.resetAll()
+    rr.simulate(0, 10000, 10000)
 
 
-def parallel(r: RoadRunner, N: int):
+def parallel(rr: RoadRunner, N: int):
     p = Pool(processes=cpu_count())
-    p.map(simulate_worker, [r for i in range(N)])
+    p.map(simulate_worker, [rr for i in range(N)])
 
 
-def serial(r: RoadRunner, N: int):
+def serial(rr: RoadRunner, N: int):
     for i in range(N):
-        r.simulate(0, 10000, 10000)
+        rr.simulate(0, 10000, 10000)
 
 
 if __name__ == '__main__':
@@ -45,10 +45,10 @@ if __name__ == '__main__':
     for i in nsimsVec:
         start = time.time()
 
-        r = RoadRunner(tmf.SimpleFlux().str())
-        # r = RoadRunner(tmf.Brown2004().str())
-        serial(r, N=i)
-        # parallel(r, N=i)
+        rr = RoadRunner(tmf.SimpleFlux().str())
+        # rr = RoadRunner(tmf.Brown2004().str())
+        serial(rr, N=i)
+        # parallel(rr, N=i)
 
         duration = time.time() - start
 

--- a/docs/source/parallel/multiprocessing/brown2004_multiprocessing_pool.py
+++ b/docs/source/parallel/multiprocessing/brown2004_multiprocessing_pool.py
@@ -12,19 +12,19 @@ NCORES = cpu_count()
 NSIMS = 10000
 
 
-def simulate_worker(r: RoadRunner):
-  r.resetAll()
-  r.simulate(0, 10000, 10000)
+def simulate_worker(rr: RoadRunner):
+  rr.resetAll()
+  rr.simulate(0, 10000, 10000)
 
 
-def parallel(r : RoadRunner, N: int):
+def parallel(rr : RoadRunner, N: int):
   p = Pool(processes=cpu_count())
-  p.map(simulate_worker, [r for i in range(N)])
+  p.map(simulate_worker, [rr for i in range(N)])
 
 
-def serial(r: RoadRunner, N: int):
+def serial(rr: RoadRunner, N: int):
   for i in range(N):
-    r.simulate(0, 10000, 10000)
+    rr.simulate(0, 10000, 10000)
 
 
 if __name__ == '__main__':
@@ -33,10 +33,10 @@ if __name__ == '__main__':
   for i in nsimsVec:
     start = time.time()
 
-    # r = RoadRunner(tmf.SimpleFlux().str())
-    r = RoadRunner(tmf.Brown2004().str())
-    # serial(r, N=i)
-    parallel(r, N=i)
+    # rr = RoadRunner(tmf.SimpleFlux().str())
+    rr = RoadRunner(tmf.Brown2004().str())
+    # serial(rr, N=i)
+    parallel(rr, N=i)
 
     duration = time.time() - start
 

--- a/docs/source/parallel/multiprocessing/brown2004_ray_library.py
+++ b/docs/source/parallel/multiprocessing/brown2004_ray_library.py
@@ -18,15 +18,15 @@ ray.init(ignore_reinit_error=True)
 class SimulatorActorPath(object):
     """Ray actor to execute simulations."""
 
-    def __init__(self, r: RoadRunner):
-        self.r: RoadRunner = r
+    def __init__(self, rr: RoadRunner):
+        self.rr: RoadRunner = rr
 
     def simulate(self, size=1):
         num_points = 10000
         # results = np.ndarray((size, num_points, 2))  # 2 for 1 model species and time
         for k in range(size):
-            self.r.resetAll()
-            self.r.simulate(0, 100, num_points)
+            self.rr.resetAll()
+            self.rr.simulate(0, 100, num_points)
         # return results
 
 
@@ -42,13 +42,13 @@ if __name__ == '__main__':
     NSIMS = 100000
 
     # create our roadrunner instance
-    r = RoadRunner(sbml)
+    rr = RoadRunner(sbml)
 
     # set the seed for reproducuble example
-    gillespie_integrator = r.getIntegrator()
+    gillespie_integrator = rr.getIntegrator()
     gillespie_integrator.seed = 1234
 
-    simulators = [SimulatorActorPath.remote(r) for _ in range(NCORES)]
+    simulators = [SimulatorActorPath.remote(rr) for _ in range(NCORES)]
 
     # run simulations
     tc_ids = []

--- a/docs/source/parallel/multiprocessing/gillespie_simulations_mpi4py.py
+++ b/docs/source/parallel/multiprocessing/gillespie_simulations_mpi4py.py
@@ -29,13 +29,13 @@ if __name__ == '__main__':
     sbml = tmf.BatchImmigrationDeath03().str()
 
     # create our roadrunner instance
-    r = RoadRunner(sbml)
+    rr = RoadRunner(sbml)
 
     # set up a stochastic simulation
-    r.setIntegrator('gillespie')
+    rr.setIntegrator('gillespie')
 
     # set the seed for reproducuble example
-    gillespie_integrator = r.getIntegrator()
+    gillespie_integrator = rr.getIntegrator()
     gillespie_integrator.seed = 1234
 
     # the time it took in serial

--- a/docs/source/parallel/multiprocessing/gillespie_simulations_multiprocessing_pool.py
+++ b/docs/source/parallel/multiprocessing/gillespie_simulations_multiprocessing_pool.py
@@ -8,9 +8,9 @@ import cpuinfo # pip install py-cpuinfo
 NCORES = cpu_count()
 NSIMS = 1000000
 
-def simulate_worker(r: RoadRunner):
-    r.resetAll()
-    return r.simulate(0, 10, 11)
+def simulate_worker(rr: RoadRunner):
+    rr.resetAll()
+    return rr.simulate(0, 10, 11)
 
 
 if __name__ == '__main__':
@@ -21,20 +21,20 @@ if __name__ == '__main__':
     sbml = tmf.BatchImmigrationDeath03().str()
 
     # create our roadrunner instance
-    r = RoadRunner(sbml)
+    rr = RoadRunner(sbml)
 
     # set up a stochastic simulation
-    r.setIntegrator('gillespie')
+    rr.setIntegrator('gillespie')
 
     # set the seed for reproducuble example
-    gillespie_integrator = r.getIntegrator()
+    gillespie_integrator = rr.getIntegrator()
     gillespie_integrator.seed = 1234
 
     # create a processing pool
     p = Pool(processes=NCORES)
 
     # perform the simulations
-    arrays = p.map(simulate_worker, [r for i in range(NSIMS)])
+    arrays = p.map(simulate_worker, [rr for i in range(NSIMS)])
 
     duration = time.time() - start
 

--- a/docs/source/parallel/multiprocessing/gillespie_simulations_ray_library.py
+++ b/docs/source/parallel/multiprocessing/gillespie_simulations_ray_library.py
@@ -18,15 +18,15 @@ ray.init(ignore_reinit_error=True)
 class SimulatorActorPath(object):
     """Ray actor to execute simulations."""
 
-    def __init__(self, r: RoadRunner):
-        self.r: RoadRunner = r
+    def __init__(self, rr: RoadRunner):
+        self.rr: RoadRunner = rr
 
     def simulate(self, size=1):
         num_points = 101
         results = np.ndarray((size, num_points, 2))  # 2 for 1 model species and time
         for k in range(size):
-            self.r.resetAll()
-            results[k] = self.r.simulate(0, 100, num_points)
+            self.rr.resetAll()
+            results[k] = self.rr.simulate(0, 100, num_points)
         return results
 
 
@@ -38,16 +38,16 @@ if __name__ == '__main__':
     sbml = tmf.BatchImmigrationDeath03().str()
 
     # create our roadrunner instance
-    r = RoadRunner(sbml)
+    rr = RoadRunner(sbml)
 
     # set up a stochastic simulation
-    r.setIntegrator('gillespie')
+    rr.setIntegrator('gillespie')
 
     # set the seed for reproducuble example
-    gillespie_integrator = r.getIntegrator()
+    gillespie_integrator = rr.getIntegrator()
     gillespie_integrator.seed = 1234
 
-    simulators = [SimulatorActorPath.remote(r) for _ in range(NCORES)]
+    simulators = [SimulatorActorPath.remote(rr) for _ in range(NCORES)]
 
     # run simulations
     tc_ids = []

--- a/docs/source/parallel/multiprocessing/gillespie_simulations_serial.py
+++ b/docs/source/parallel/multiprocessing/gillespie_simulations_serial.py
@@ -26,13 +26,13 @@ if __name__ == '__main__':
     sbml = tmf.BatchImmigrationDeath03().str()
 
     # create our roadrunner instance
-    r = RoadRunner(sbml)
+    rr = RoadRunner(sbml)
 
     # set up a stochastic simulation
-    r.setIntegrator('gillespie')
+    rr.setIntegrator('gillespie')
 
     # set the seed for reproducible example
-    gillespie_integrator = r.getIntegrator()
+    gillespie_integrator = rr.getIntegrator()
     gillespie_integrator.seed = 1234
 
     start_time = 0
@@ -42,8 +42,8 @@ if __name__ == '__main__':
     # preallocate for efficiency
     data = np.ndarray((NSIMS, num_points, 2))
     for simulation_number in range(NSIMS):
-        r.resetAll()
-        data[simulation_number] = r.simulate(start_time, end_time, num_points)
+        rr.resetAll()
+        data[simulation_number] = rr.simulate(start_time, end_time, num_points)
 
     print(data)
     print(data.shape)

--- a/docs/source/parallel/multiprocessing/gillespie_simulations_threading.py
+++ b/docs/source/parallel/multiprocessing/gillespie_simulations_threading.py
@@ -21,10 +21,10 @@ class SimulationWorkerThread(Thread):
         self.results_queue = results_queue
 
     def run(self) -> None:
-        for r in iter(self.input_queue.get, "STOP"):
-            assert isinstance(r, RoadRunner)
-            r.resetAll()
-            self.results_queue.put(r.simulate(0, 10, NSTEPS))
+        for rr in iter(self.input_queue.get, "STOP"):
+            assert isinstance(rr, RoadRunner)
+            rr.resetAll()
+            self.results_queue.put(rr.simulate(0, 10, NSTEPS))
 
 if __name__ == '__main__':
     # setup timing
@@ -34,13 +34,13 @@ if __name__ == '__main__':
     sbml = tmf.BatchImmigrationDeath03().str()
 
     # create our roadrunner instance
-    r = RoadRunner(sbml)
+    rr = RoadRunner(sbml)
 
     # set up a stochastic simulation
-    r.setIntegrator('gillespie')
+    rr.setIntegrator('gillespie')
 
     # set the seed for reproducuble example
-    gillespie_integrator = r.getIntegrator()
+    gillespie_integrator = rr.getIntegrator()
     gillespie_integrator.seed = 1234
 
     input_queue = Queue()
@@ -48,7 +48,7 @@ if __name__ == '__main__':
 
     # populate input queue
     for i in range(NSIMS):
-        input_queue.put(r)
+        input_queue.put(rr)
 
     # create threads
     for _ in range(NTHREADS):

--- a/docs/source/tutorial/changing_initial_conditions.rst
+++ b/docs/source/tutorial/changing_initial_conditions.rst
@@ -5,11 +5,11 @@ There are a number of methods to get and set the initial conditions of a loaded 
 specify a given initial conditions we use the notation, ``init()``.  The values stored in the
 initial conditions are applied to the model whenever it is reset. The list of all initial condition
 symbols can be obtained by the methods, :meth:`~ExecutableModel.getFloatingSpeciesInitAmountIds()`
-and :meth:`~ExecutableModel.getFloatingSpeciesInitConcentrationIds()` assuming ``r`` is a RoadRunner
+and :meth:`~ExecutableModel.getFloatingSpeciesInitConcentrationIds()` assuming ``rr`` is a RoadRunner
 instance. As with all other selection symbols, the :meth:`~ExecutableModel.keys()` returns all
 available selection symbols:
 
-  >>>  r.model.keys()
+  >>>  rr.model.keys()
   [ 'S1', 'S2', '[S1]', '[S2]', 'compartment', 'k1', '_CSUM0',
     'reaction1',  'init([S1])',  'init([S2])', 'init(S1)',
     'init(S2)',  "S1'"]
@@ -17,34 +17,34 @@ available selection symbols:
 Symbols for selecting initial values specifically for amounts and concentrations can be obtained
 via:
 
-  >>> r.model.getFloatingSpeciesInitAmountIds()
+  >>> rr.model.getFloatingSpeciesInitAmountIds()
   ['init(S1)', 'init(S2)']
 
-  >>> r.model.getFloatingSpeciesInitConcentrationIds()
+  >>> rr.model.getFloatingSpeciesInitConcentrationIds()
   ['init([S1])', 'init([S2])']
 
 Getting or setting initial values is easily accomplished using the array operator and the selection
 symbols:
 
-  >>> r.model["init(S1)"]
+  >>> rr.model["init(S1)"]
   0.00015
 
-  >>> r.model["init([S1])"]
+  >>> rr.model["init([S1])"]
   2.9999999999999997e-05
 
-  >>> r.model["init([S1])"] = 2
+  >>> rr.model["init([S1])"] = 2
 
-  >>> r.model["init(S1)"]
+  >>> rr.model["init(S1)"]
   10.0
 
 The values for the initial conditions for all floating species can be obtained using the calls:
 
-  >>> r.model.getFloatingSpeciesInitConcentrations()
+  >>> rr.model.getFloatingSpeciesInitConcentrations()
   array([ 0.7,  5.6])
 
 Initial conditions can be set using the two methods for all species in one call:
 
-  >>> r.model.setFloatingSpeciesInitAmounts ([3.4, 5.6])
+  >>> rr.model.setFloatingSpeciesInitAmounts ([3.4, 5.6])
 
 
-  >>> r.model.setFloatingSpeciesInitConcentrations ([6.7, 0.1])
+  >>> rr.model.setFloatingSpeciesInitConcentrations ([6.7, 0.1])

--- a/docs/source/tutorial/loading_models.rst
+++ b/docs/source/tutorial/loading_models.rst
@@ -38,6 +38,6 @@ Additionally, there are a couple models **included with libRoadRunner**. The mod
 and ``Test_1.xml`` are available in the ``roadrunner.testing`` module. To access these use::
 
    import roadrunner.testing as test
-   r = test.getRoadRunner('feedback.xml')
+   rr = test.getRoadRunner('feedback.xml')
 
 There are a few additional models in the ``models/`` directory of the distribution, where you installed libRoadRunner.

--- a/docs/source/tutorial/plotting_data.rst
+++ b/docs/source/tutorial/plotting_data.rst
@@ -25,7 +25,7 @@ Below is a simplified version of the :meth:`~RoadRunner.plot()` method. You may 
 customized version and even attach it to the RoadRunner object. The first argument is a RoadRunner
 object instance, and the second is a flag which tells the method to show the plot or not::
 
-  def plot(r, show=True):
+  def plot(rr, show=True):
 
       import pylab as p
 
@@ -36,7 +36,7 @@ object instance, and the second is a flag which tells the method to show the plo
 
       # assume result is a standard numpy array
 
-      selections = r.timeCourseSelections
+      selections = rr.timeCourseSelections
 
       if len(result.shape) != 2 or result.shape[1] != len(selections):
           raise Exception("simulation result columns not equal to number of selections,"
@@ -58,7 +58,7 @@ object instance, and the second is a flag which tells the method to show the plo
 You can attach your plotting function to the RoadRunner object by simply setting the plot
 method::
 
-  def my_plot(r, show):
+  def my_plot(rr, show):
       pass
 
   import roadrunner

--- a/docs/source/tutorial/solvers.rst
+++ b/docs/source/tutorial/solvers.rst
@@ -8,14 +8,14 @@ By default, RoadRunner uses CVODE, a real differential equation solver from the
 SUNDIALS suite. Internally, CVODE features an adaptive timestep. However, unless `variableStep`
 is specified in the call to :meth:`~RoadRunner.simulate()`, the output will contain evenly spaced intervals.
 
-  >>>  r.simulate(0, 10, 10)
+  >>>  rr.simulate(0, 10, 10)
   # Output will contain evenly spaced intervals
-  >>>  r.simulate(variableStep=True)
+  >>>  rr.simulate(variableStep=True)
   # Intervals will vary according to CVODE step size
 
 To use basic 4th-order Runge-Kutta integrator ('rk4'), call :meth:`~RoadRunner.setIntegrator()`:
 
-  >>>  r.setIntegrator('rk4')
+  >>>  rr.setIntegrator('rk4')
 
 Runge-Kutta always uses a fixed step size, and does not support events.
 RoadRunner supports Runge-Kutta-Fehlberg Method ('rkf45') as well as a stochastic integrator based on Gillespie algorithm ('gilliespie'). To get a list of all available integrators, run:
@@ -26,7 +26,7 @@ RoadRunner supports Runge-Kutta-Fehlberg Method ('rkf45') as well as a stochasti
 Some integrators, such as CVODE, have parameters which can be set by the user.
 To see a list of these settings, use :meth:`~roadrunner.Solver.getSettings()` on an integrator instance:
 
-  >>>  r.getIntegrator().getSettings()
+  >>>  rr.getIntegrator().getSettings()
   ('relative_tolerance',
   'absolute_tolerance',
   'stiff',
@@ -41,41 +41,41 @@ To see a list of these settings, use :meth:`~roadrunner.Solver.getSettings()` on
 
 To set a parameter, you can use both methods described below:
 
-  >>>  r.getIntegrator().relative_tolerance = 1e-10
-  >>>  r.getIntegrator().setValue('relative_tolerance', 1e-10)
+  >>>  rr.getIntegrator().relative_tolerance = 1e-10
+  >>>  rr.getIntegrator().setValue('relative_tolerance', 1e-10)
 
 Be sure to set the parameter to the correct type, which can be obtained from
 the parameter's hint or description:
 
-  >>>  r.getIntegrator().getHint('relative_tolerance')
+  >>>  rr.getIntegrator().getHint('relative_tolerance')
   'Specifies the scalar relative tolerance (double).'
-  >>>  r.getIntegrator().getDescription('relative_tolerance')
+  >>>  rr.getIntegrator().getDescription('relative_tolerance')
   '(double) CVODE calculates a vector of error weights which is used in all error and convergence tests. The weighted RMS norm for the relative tolerance should not become smaller than this value.'
 
 Parameters also have a display name:
 
-  >>>  r.getIntegrator().getDisplayName('relative_tolerance')
+  >>>  rr.getIntegrator().getDisplayName('relative_tolerance')
   'Relative Tolerance'
 
 If you prefer to change settings on integrators without switching the current integrator,
 you can use :meth:`~RoadRunner.getIntegratorByName()` as follows:
 
-  >>>  r.getIntegratorByName('gillespie').seed = 12345
+  >>>  rr.getIntegratorByName('gillespie').seed = 12345
 
 Also, if you find yourself switching back and forth between integrators a lot, you can use
 :meth:`~RoadRunner.setIntegratorSetting()`.
 
-  >>>  r.setIntegratorSetting('gillespie', 'seed', 12345)
+  >>>  rr.setIntegratorSetting('gillespie', 'seed', 12345)
 
 The other type of solver is a steady-state solver, which works in essentially the same way:
 
-  >>>  r.getSteadyStateSolver().getSettings()
+  >>>  rr.getSteadyStateSolver().getSettings()
   ('maximum_iterations',
   'minimum_damping',
   'relative_tolerance')
-  >>>  r.getSteadyStateSolver().getHint('maximum_iterations')
+  >>>  rr.getSteadyStateSolver().getHint('maximum_iterations')
   'The maximum number of iterations the solver is allowed to use (int)'
-  >>>  r.getSteadyStateSolver().getDescription('maximum_iterations')
+  >>>  rr.getSteadyStateSolver().getDescription('maximum_iterations')
   '(int) Iteration caps off at the maximum, regardless of whether a solution has been reached'
 
 The steady state solver is invoked by a call to :meth:`~RoadRunner.steadyState()`.

--- a/docs/source/tutorial/what_is_rr.rst
+++ b/docs/source/tutorial/what_is_rr.rst
@@ -36,7 +36,7 @@ class ``RoadRunner`` and e.g. ``rr.model`` of class ``ExecutableModel``.
 **ExecutableModel**
  - Represents a compiled sbml model
  - Properties to get and set any state variables.
- - Initialized when SBML is loaded ``r.load('mymodel.xml')``
+ - Initialized when SBML is loaded ``rr.load('mymodel.xml')``
 
 The Python API is a very clean simple interface that uses all native Python objects. 
 All the returned types are structured `Numpy` arrays. 
@@ -110,12 +110,12 @@ the rest are whatever is selected. The easies way to plot is to use :meth:`RoadR
 Using libRoadRunner in `IPython <http://ipython.org/>`_ you can **get documentation** 
 easily using a ``?`` after the object or method::
 
-  >>>  r.plot?
+  >>>  rr.plot?
 
   Type:        instancemethod
   String form: <bound method RoadRunner.plot of <roadrunner.RoadRunner() { this = 0x101c70a00 }>>
   File:        /Users/andy/Library/Python/2.7/lib/python/site-packages/roadrunner/roadrunner.py
-  Definition:  r.plot(self, show=True)
+  Definition:  rr.plot(self, show=True)
   Docstring:
   RoadRunner.plot([show])
   

--- a/source/EulerIntegrator.h
+++ b/source/EulerIntegrator.h
@@ -41,9 +41,9 @@ namespace rr {
     * the parameters as keyword arguments is
     *
     * @code
-    * r.simulate(integrator='euler', exampleParameter1=123456, exampleParameter2='some value');
+    * rr.simulate(integrator='euler', exampleParameter1=123456, exampleParameter2='some value');
     *
-    * print(r.integrator)
+    * print(rr.integrator)
     * < roadrunner.EulerIntegrator()
     * { 'this' : 0x101f28350
     * 'exampleParameter1' : 123456

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -327,27 +327,27 @@ namespace rr {
          * For example, to perform a simulation from time 0 to 10 with 1000 steps, using a
          * stiff integtator, you would:
          * @code
-         * RoadRunner r = RoadRunner("someFile.xml");
-         * SimulateOptions opt = r.getSimulateOptions();
+         * RoadRunner rr = RoadRunner("someFile.xml");
+         * SimulateOptions opt = rr.getSimulateOptions();
          * opt.start = 0;
          * opt.duration = 10;
          * opt.steps = 1000;
-         * const DoubleMatrix *result = r.simulate(&opt);
+         * const DoubleMatrix *result = rr.simulate(&opt);
          * @endcode
          *
          * Similarly, options specific to a particular integrator, such as the 'seed' option
          * with the Gillespie
          * integrator, this is set via the 'setIntegrator' "integrator" key, i.e.
          * @code
-         * RoadRunner r = RoadRunner("someFile.xml");
-         * r.setIntegrator("gillespie");
+         * RoadRunner rr = RoadRunner("someFile.xml");
+         * rr.setIntegrator("gillespie");
          * SimulateOptions opt;
          * opt.start = 0;
          * opt.duration = 10;
          * opt.steps = 1000;
          * opt.setItem("stiff", true);
          * opt.setItem("seed", 12345);
-         * const DoubleMatrix *result = r.simulate(&opt);
+         * const DoubleMatrix *result = rr.simulate(&opt);
          * @endcode
          * Here, the "integrator" specifies the integrator to use. The "stiff" key
          * is only used by the deterministic solvers, and it is safely ignored by the
@@ -510,7 +510,7 @@ namespace rr {
          *
          * For example, to reset the floating species, time and rate rule values:
          * @code
-         * r.reset(SelectionRecord::TIME | SelectionRecord::RATE | SelectionRecord::FLOATING);
+         * rr.reset(SelectionRecord::TIME | SelectionRecord::RATE | SelectionRecord::FLOATING);
          * @endcode
          *
          * @param options a bitmask made from the SelectionRecord::SelectionTypes values.

--- a/test/TestModelFactory.h
+++ b/test/TestModelFactory.h
@@ -409,7 +409,7 @@ public:
  *      print(m.getGlobalParameterIds())
  *      print(m.getGlobalParameterValues())
  *      return m
- *  r = ss("""
+ *  rr = ss("""
  *  model x
  *      S1 = 10;
  *      S20 = 1;

--- a/wrappers/Python/roadrunner/roadrunner.i
+++ b/wrappers/Python/roadrunner/roadrunner.i
@@ -1578,7 +1578,7 @@ namespace std { class ostream{}; }
                 if end is not None and "time" in selections_lower:
                     lastresult_time = result[len(result)-1][selections_lower.index("time")]
                     if end - lastresult_time > end/10000:
-                        warnings.warn("Simulation requested end time point (" + str(end) + ") not reached, because the maximum number of steps reached.  Possible solutions include:\n  * Setting an explicit number of points (i.e. r.simulate(" + str(start) + ", " + str(end) + ", 1001)\n  * Setting r.integrator.variable_step_size to 'False'\n  * Setting r.integrator.max_output_rows to a larger number ")
+                        warnings.warn("Simulation requested end time point (" + str(end) + ") not reached, because the maximum number of steps reached.  Possible solutions include:\n  * Setting an explicit number of points (i.e. rr.simulate(" + str(start) + ", " + str(end) + ", 1001)\n  * Setting rr.integrator.variable_step_size to 'False'\n  * Setting rr.integrator.max_output_rows to a larger number ")
 
             return result
 


### PR DESCRIPTION
Whenever referencing a roadrunner object, use 'rr' instead of 'r'.  Mostly docs, some examples and error/warnings.