### PR TITLE
Plugin loader restructure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,10 +38,10 @@ stages:
           matrix:
             64-bit Mac Release:
               BuildType: Release
-              LLVM_DOWNLOAD_LINK: 'https://github.com/sys-bio/llvm-13.x/releases/download/llvmorg-13.0.0/llvm-13.x-clang13-universal-binaries-rel.zip'
+              LLVM_DOWNLOAD_LINK: 'https://github.com/sys-bio/llvm-13.x/releases/download/llvmorg-13.0.0/llvm-13.x-macosx_11_7_x86_64.zip'
             64-bit Mac Debug:
               BuildType: Debug
-              LLVM_DOWNLOAD_LINK: 'https://github.com/sys-bio/llvm-13.x/releases/download/llvmorg-13.0.0/llvm-13.x-clang13-universal-binaries-rel.zip'
+              LLVM_DOWNLOAD_LINK: 'https://github.com/sys-bio/llvm-13.x/releases/download/llvmorg-13.0.0/llvm-13.x-macosx_11_7_x86_64.zip'
         variables:
           LLVM_CACHE: 'false'
           PythonName: 'py39'
@@ -218,7 +218,7 @@ stages:
           SWIG_CACHE: 'false'
           MINICONDA_CACHE: 'false'
           LLVM_CACHE: 'false'
-          LLVM_DOWNLOAD_LINK: 'https://github.com/sys-bio/llvm-13.x/releases/download/llvmorg-13.0.0/llvm-13.x-clang13-universal-binaries-rel.zip'
+          LLVM_DOWNLOAD_LINK: 'https://github.com/sys-bio/llvm-13.x/releases/download/llvmorg-13.0.0/llvm-13.x-macosx_11_7_x86_64.zip'
         steps:
           - checkout: self
             submodules: recursive

--- a/rrplugins/plugins/add_noise/add_noise.cpp
+++ b/rrplugins/plugins/add_noise/add_noise.cpp
@@ -116,5 +116,9 @@ The AddNoise plugin was developed at the University of Washington by Totte Karls
 
 }
 
+POCO_BEGIN_MANIFEST(tlp::Plugin)
+	POCO_EXPORT_CLASS(addNoise::AddNoise)
+POCO_END_MANIFEST
+
 
 

--- a/rrplugins/plugins/add_noise/add_noise.h
+++ b/rrplugins/plugins/add_noise/add_noise.h
@@ -5,6 +5,7 @@
 #include "telTelluriumData.h"
 #include "add_noise_worker.h"
 #include "rrplugins/core/tel_api.h"
+#include "Poco/ClassLibrary.h"
 
 //---------------------------------------------------------------------------
 namespace addNoise

--- a/rrplugins/plugins/auto2000/telAutoPlugin.cpp
+++ b/rrplugins/plugins/auto2000/telAutoPlugin.cpp
@@ -489,3 +489,10 @@ points if IPS=0, 1";
 
 
 }
+
+POCO_BEGIN_MANIFEST(tlp::Plugin)
+	POCO_EXPORT_CLASS(AutoPlugin)
+POCO_END_MANIFEST 
+
+
+

--- a/rrplugins/plugins/auto2000/telAutoPlugin.h
+++ b/rrplugins/plugins/auto2000/telAutoPlugin.h
@@ -7,6 +7,7 @@
 #include "telAutoWorker.h"
 #include "telAutoConstants.h"
 #include "telAutoTelluriumInterface.h"
+#include "Poco/ClassLibrary.h"
 //---------------------------------------------------------------------------
 
 using telauto::AutoTellurimInterface;

--- a/rrplugins/plugins/chisquare/csChiSquare.cpp
+++ b/rrplugins/plugins/chisquare/csChiSquare.cpp
@@ -142,3 +142,10 @@ namespace cs_ChiSquare {
     }
 
 }
+
+POCO_BEGIN_MANIFEST(tlp::Plugin)
+	POCO_EXPORT_CLASS(cs_ChiSquare::ChiSquare)
+POCO_END_MANIFEST
+
+
+

--- a/rrplugins/plugins/chisquare/csChiSquare.h
+++ b/rrplugins/plugins/chisquare/csChiSquare.h
@@ -4,6 +4,7 @@
 #include "telProperty.h"
 #include "rrplugins/pluginBaseClass/telCPPPlugin.h"
 #include "csChiWorker.h"
+#include "Poco/ClassLibrary.h"
 //---------------------------------------------------------------------------
 
 namespace cs_ChiSquare {

--- a/rrplugins/plugins/hello_roadrunner/hello.cpp
+++ b/rrplugins/plugins/hello_roadrunner/hello.cpp
@@ -38,5 +38,9 @@ namespace hello
     #endif
 }
 
+POCO_BEGIN_MANIFEST(tlp::Plugin)
+	POCO_EXPORT_CLASS(hello::Hello)
+POCO_END_MANIFEST
+
 
 

--- a/rrplugins/plugins/hello_roadrunner/hello.h
+++ b/rrplugins/plugins/hello_roadrunner/hello.h
@@ -4,6 +4,7 @@
 #include "rrplugins/pluginBaseClass/telCPPPlugin.h"
 #include "telTelluriumData.h"
 #include "rrplugins/core/tel_api.h"
+#include "Poco/ClassLibrary.h"
 
 namespace hello
 {

--- a/rrplugins/plugins/levenberg_marquardt/lm.cpp
+++ b/rrplugins/plugins/levenberg_marquardt/lm.cpp
@@ -395,3 +395,9 @@ and the columns of the jacobian.";
 
 }
 
+POCO_BEGIN_MANIFEST(tlp::Plugin)
+	POCO_EXPORT_CLASS(lmfit::LM)
+POCO_END_MANIFEST
+
+
+

--- a/rrplugins/plugins/levenberg_marquardt/lm.h
+++ b/rrplugins/plugins/levenberg_marquardt/lm.h
@@ -5,6 +5,7 @@
 #include "lmWorker.h"
 #include "lib/lmmin.h"
 #include "telplugins_types.h"
+#include "Poco/ClassLibrary.h"
 //---------------------------------------------------------------------------
 
 namespace lmfit

--- a/rrplugins/plugins/monte_carlo_bs/bsMonteCarlo.cpp
+++ b/rrplugins/plugins/monte_carlo_bs/bsMonteCarlo.cpp
@@ -233,3 +233,10 @@ Internally this data is used to calcualte residual data.";
     }
 
 }
+
+POCO_BEGIN_MANIFEST(tlp::Plugin)
+	POCO_EXPORT_CLASS(bsmc::MonteCarlo)
+POCO_END_MANIFEST
+
+
+

--- a/rrplugins/plugins/monte_carlo_bs/bsMonteCarlo.h
+++ b/rrplugins/plugins/monte_carlo_bs/bsMonteCarlo.h
@@ -5,6 +5,7 @@
 #include "telCPPPlugin.h"
 #include "telTelluriumData.h"
 #include "bsWorker.h"
+#include "Poco/ClassLibrary.h"
 
 namespace bsmc
 {

--- a/rrplugins/plugins/nelder_mead/nmNelderMead.cpp
+++ b/rrplugins/plugins/nelder_mead/nmNelderMead.cpp
@@ -376,3 +376,10 @@ Model data can only be generated for selections present in the experimental data
     }
 
 }
+
+POCO_BEGIN_MANIFEST(tlp::Plugin)
+	POCO_EXPORT_CLASS(nmfit::NelderMead)
+POCO_END_MANIFEST
+
+
+

--- a/rrplugins/plugins/nelder_mead/nmNelderMead.h
+++ b/rrplugins/plugins/nelder_mead/nmNelderMead.h
@@ -7,6 +7,7 @@
 #include "telCPPPlugin.h"
 #include "telplugins_types.h"
 #include "nmWorker.h"
+#include "Poco/ClassLibrary.h"
 //---------------------------------------------------------------------------
 
 namespace nmfit

--- a/rrplugins/plugins/test_model/TestModel.cpp
+++ b/rrplugins/plugins/test_model/TestModel.cpp
@@ -223,3 +223,9 @@ string  theModel =
 </sbml>\n\
 ";
 
+POCO_BEGIN_MANIFEST(tlp::Plugin)
+	POCO_EXPORT_CLASS(testModel::TestModel)
+POCO_END_MANIFEST
+
+
+

--- a/rrplugins/plugins/test_model/TestModel.h
+++ b/rrplugins/plugins/test_model/TestModel.h
@@ -5,6 +5,7 @@
 #include "telTelluriumData.h"
 #include "rrplugins/core/tel_api.h"
 #include "telplugins_types.h"
+#include "Poco/ClassLibrary.h"
 //---------------------------------------------------------------------------
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -280,7 +280,7 @@ add_subdirectory(serialization)
 add_subdirectory(PerformanceTests)
 add_subdirectory(python)
 
-if (WIN32 AND BUILD_RR_PLUGINS)
+if (BUILD_RR_PLUGINS)
    set(
         SharedPluginTestFiles
         # path *must* be absolute to work in cmake functions/macros


### PR DESCRIPTION
The problem with loading the Python rrplugins in Linux is now fixed by introducing the Poco ClassLoader macros for each plugin.