### PR TITLE
Try making function not 'RR_DECLSPEC' for docs.

### DIFF
--- a/source/rrIniKey.h
+++ b/source/rrIniKey.h
@@ -35,7 +35,7 @@ public:
     int                              AsInt() const;
     double                           AsFloat() const;
     std::complex<double>             AsComplex() const;
-    friend RR_DECLSPEC std::ostream& operator<<(std::ostream& stream, const IniKey& aKey);
+    friend std::ostream& operator<<(std::ostream& stream, const IniKey& aKey);
 };
 /** @endcond PRIVATE */
 }


### PR DESCRIPTION
The class itself is declared that way; maybe we don't need the function in particular?