### PR TITLE
fixSetValueWithExpressionsContainingVariables

### DIFF
--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -156,10 +156,11 @@ int LLVMExecutableModel::setValues(bool (*funcPtr)(LLVMModelData*, int, double),
             {
                 s << ", as it is defined by an assignment rule, and can not be set independently.";
             }
-            else if (symbols->hasInitialAssignmentRule(id))
-            {
-                s << ", as it is defined by an initial assignment rule and can not be set independently.";
-            }
+            /// commented to let the user set a value using with an expression containing variables
+            //else if (symbols->hasInitialAssignmentRule(id))
+            //{
+                //s << ", as it is defined by an initial assignment rule and can not be set independently.";
+            //}
             else if (symbols->hasRateRule(id))
             {
                 s << ", as it is defined by a rate rule and can not be set independently.";

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -39,6 +39,13 @@ TEST_F(ModelAnalysisTests, issue1031) {
 
 }
 
+TEST_F(ModelAnalysisTests, issue1132) {
+    rr::RoadRunner rr((modelAnalysisModelsDir / "simple_model_with_initial_assignments.xml").string());
+
+    rr.steadyState();
+    ls::DoubleMatrix sfcc = rr.getScaledFluxControlCoefficientMatrix();
+}
+
 
 TEST_F(ModelAnalysisTests, issue1020_full) {
     //Config::setValue(Config::LLVM_BACKEND, Config::LLVM_BACKEND_VALUES::LLJIT);

--- a/test/models/ModelAnalysis/simple_model_with_initial_assignments.xml
+++ b/test/models/ModelAnalysis/simple_model_with_initial_assignments.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.13.2 with libSBML version 5.20.0. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="Xo" compartment="default_compartment" initialConcentration="5" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+      <species id="S1" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="k1" value="0.45" constant="true"/>
+      <parameter id="k2" value="0.23" constant="true"/>
+      <parameter id="k3" value="0.6" constant="true"/>
+      <parameter id="V1" value="2.3" constant="true"/>
+    </listOfParameters>
+    <listOfInitialAssignments>
+      <initialAssignment symbol="S1">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <divide/>
+            <cn> 5.6 </cn>
+            <ci> V1 </ci>
+          </apply>
+        </math>
+      </initialAssignment>
+    </listOfInitialAssignments>
+    <listOfReactions>
+      <reaction id="_J0" reversible="true" fast="false">
+        <listOfReactants>
+          <speciesReference species="Xo" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="S1" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <minus/>
+              <apply>
+                <times/>
+                <ci> k1 </ci>
+                <ci> Xo </ci>
+              </apply>
+              <apply>
+                <times/>
+                <ci> k2 </ci>
+                <ci> S1 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="_J1" reversible="true" fast="false">
+        <listOfReactants>
+          <speciesReference species="S1" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> k3 </ci>
+              <ci> S1 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>
+


### PR DESCRIPTION
the check in setValues function for the symbols that has assignment rule is commneted to avoid getting error while setting the values of with an expression containing variables.