### PR TITLE
The issue with calcualting the steady state changes the selection vector is fixed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,8 +137,7 @@ stages:
               # for example, it looks like this:
               # - https://dev.azure.com/TheRoadrunnerProject/libroadrunner-deps/_build?definitionId=9
               pipeline: 9
-              runVersion: 'latestFromBranch'
-              runBranch: 'refs/heads/release'
+              runVersion: 'latest'
               artifact: libroadrunner-deps-$(Agent.OS)-$(BuildType)
               path: $(DEPS_INSTALL_PREFIX)
             displayName: Download libroadrunner-deps install artifacts
@@ -272,8 +271,7 @@ stages:
               source: 'specific'
               project: 'libroadrunner-deps'
               pipeline: 9
-              runVersion: 'latestFromBranch'
-              runBranch: 'refs/heads/release'
+              runVersion: 'latest'
               artifact: libroadrunner-deps-$(Agent.OS)-Release
               path: $(DEPS_INSTALL_PREFIX)
             displayName: Download libroadrunner-deps install artifacts
@@ -503,8 +501,7 @@ stages:
               source: 'specific'
               project: 'libroadrunner-deps'
               pipeline: 9
-              runVersion: 'latestFromBranch'
-              runBranch: 'refs/heads/release'
+              runVersion: 'latest'
               artifact: libroadrunner-deps-$(Agent.OS)-$(BuildType)
               path: $(DEPS_INSTALL_PREFIX)
             displayName: Download libroadrunner-deps install artifacts
@@ -594,7 +591,7 @@ stages:
           - powershell: |
               where.exe conda
               where.exe python
-              conda update conda -y -c conda-forge
+              # conda update conda -y -c conda-forge
               conda install numpy
               conda install python=3.11 -c conda-forge
               conda --version
@@ -637,8 +634,7 @@ stages:
               source: 'specific'
               project: 'libroadrunner-deps'
               pipeline: 9
-              runVersion: 'latestFromBranch'
-              runBranch: 'refs/heads/release'
+              runVersion: 'latest'
               artifact: libroadrunner-deps-$(Agent.OS)-Release
               path: $(DEPS_INSTALL_PREFIX)
             displayName: Download libroadrunner-deps install artifacts
@@ -867,8 +863,7 @@ stages:
               source: 'specific'
               project: 'libroadrunner-deps'
               pipeline: 9
-              runVersion: 'latestFromBranch'
-              runBranch: 'refs/heads/release'
+              runVersion: 'latest'
               artifact: libroadrunner-deps-$(Agent.OS)-$(BuildType)
               path: $(DEPS_INSTALL_PREFIX)
             displayName: Download libroadrunner-deps install artifacts

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -3228,21 +3228,37 @@ namespace rr {
     }
 
     size_t RoadRunner::createDefaultSteadyStateSelectionList() {
-        impl->mSteadyStateSelection.clear();
-        // default should be independent floating species only ...
         std::vector<std::string> floatingSpecies = getFloatingSpeciesIds();
         size_t numFloatingSpecies = floatingSpecies.size();
+        // default should be independent floating species only ...
         //int numIndSpecies = getNumberOfIndependentSpecies();
-        //impl->mSteadyStateSelection.resize(numIndSpecies);
-        impl->mSteadyStateSelection.resize(numFloatingSpecies);
-        //for (int i = 0; i < numIndSpecies; i++)
+        int numberOfMatchedFloatingSpecies = 0;
         for (int i = 0; i < numFloatingSpecies; i++) {
-            SelectionRecord aRec;
-            aRec.selectionType = SelectionRecord::FLOATING_CONCENTRATION;
-            aRec.p1 = floatingSpecies[i];
-            aRec.index = i;
-            impl->mSteadyStateSelection[i] = aRec;
+            for (int j = 0; j < impl->mSteadyStateSelection.size(); j++) {
+                if (floatingSpecies[i] == impl->mSteadyStateSelection[j].p1) {
+                    numberOfMatchedFloatingSpecies++;
+                    break;
+                }
+            }
         }
+
+        // only creates the list if floating species are changed since the previous list was created
+        if (numberOfMatchedFloatingSpecies != numFloatingSpecies ||
+            numberOfMatchedFloatingSpecies != impl->mSteadyStateSelection.size()) {
+            impl->mSteadyStateSelection.clear();
+            // default should be independent floating species only ...
+            //impl->mSteadyStateSelection.resize(numIndSpecies);
+            impl->mSteadyStateSelection.resize(numFloatingSpecies);
+            //for (int i = 0; i < numIndSpecies; i++)
+            for (int i = 0; i < numFloatingSpecies; i++) {
+                SelectionRecord aRec;
+                aRec.selectionType = SelectionRecord::FLOATING_CONCENTRATION;
+                aRec.p1 = floatingSpecies[i];
+                aRec.index = i;
+                impl->mSteadyStateSelection[i] = aRec;
+            }
+        }
+
         return impl->mSteadyStateSelection.size();
     }
 

--- a/test/rrtest_files/reversible_Jacobian.rrtest
+++ b/test/rrtest_files/reversible_Jacobian.rrtest
@@ -168,7 +168,7 @@ J3 = 0.397696
 J4 = 0.397696
 
 [Get Steady State Selection List]
-"[Node1] [Node3] [Node4] [Node2]"
+"[Node1] [Node2] [Node3] [Node4]"
 
 [Reduced Jacobian]
  -0.73  0        0     0.41


### PR DESCRIPTION
- before creating a new steady state selection list, it is checked if the floating species list is changed since the last time it was created; if so, a new list is created. Otherwise, the previous one is used

- azure pipeline is updated as libroadrunner-deps version is updatd to the latest and
    conda update on windows is commented


This PR fixes #1148 issue.