### PR TITLE
Throw a domain error when libsbml validation indicates the file might not be SBML at all.

### DIFF
--- a/source/SBMLValidator.cpp
+++ b/source/SBMLValidator.cpp
@@ -140,6 +140,9 @@ namespace rr
                 if (err)
                 {
                     errmsg = "  Error from libsbml:\n" + err->getMessage();
+                    if (err->getErrorId() == 10103) {
+                        throw std::domain_error("Invalid SBML, but valid XML.  It's possible that this is not an SBML file at all, but something else.");
+                    }
                 }
                 throw std::runtime_error("SBML document unable to be read." + errmsg);
             }

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1485,6 +1485,9 @@ namespace rr {
         catch (const std::runtime_error &e) {
             throw e;
         }
+        catch (const std::domain_error& e) {
+            throw e;
+        }
         catch (const std::exception &e) {
             std::string errors = validateSBML(impl->document.get());
 

--- a/test/models/SBMLFeatures/manifest.xml
+++ b/test/models/SBMLFeatures/manifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<omexManifest xmlns="http://identifiers.org/combine.specifications/omex-manifest">
+  <content location="BIOMD0000000018-biopax2.owl" format="http://purl.org/NET/mediatypes/application/rdf+xml" master="false"/>
+  <content location="BIOMD0000000018-biopax3.owl" format="http://purl.org/NET/mediatypes/application/rdf+xml" master="false"/>
+  <content location="BIOMD0000000018-matlab.m" format="http://purl.org/NET/mediatypes/text/x-matlab" master="false"/>
+  <content location="BIOMD0000000018-octave.m" format="http://purl.org/NET/mediatypes/text/x-matlab" master="false"/>
+  <content location="BIOMD0000000018.m" format="http://purl.org/NET/mediatypes/text/x-matlab" master="false"/>
+  <content location="BIOMD0000000018.ode" format="http://purl.org/NET/mediatypes/text/x-ode" master="false"/>
+  <content location="BIOMD0000000018.pdf" format="http://purl.org/NET/mediatypes/application/PDF" master="false"/>
+  <content location="BIOMD0000000018.png" format="http://purl.org/NET/mediatypes/image/png" master="false"/>
+  <content location="BIOMD0000000018.sci" format="http://purl.org/NET/mediatypes/application/x-scilab" master="false"/>
+  <content location="BIOMD0000000018.svg" format="http://purl.org/NET/mediatypes/image/svg+xml" master="false"/>
+  <content location="BIOMD0000000018.vcml" format="http://purl.org/NET/mediatypes/application/vcml+xml" master="false"/>
+  <content location="BIOMD0000000018_url.sedml" format="http://identifiers.org/combine.specifications/sed-ml" master="true"/>
+  <content location="BIOMD0000000018_url.xml" format="http://identifiers.org/combine.specifications/sbml" master="false"/>
+  <content location="metadata.rdf" format="http://identifiers.org/combine.specifications/omex-metadata" master="false"/>
+</omexManifest>

--- a/test/sbml_features/invalid_sbml.cpp
+++ b/test/sbml_features/invalid_sbml.cpp
@@ -25,3 +25,7 @@ TEST_F(SBMLFeatures, InvalidSBML_badXML)
     EXPECT_THROW(RoadRunner rri("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n  <model metaid=\"x\" id=\"x\">\n    <listOfCompartments>\n      <compartment sboTerm=\"SBO:0000410\" id=\"default_compartment\" spatialDimensions=\"3\" size=\"1\" constant=\"true\"/>\n    </listOfCompartments>\n  </model>\n</sbml>\n2.0.5"), std::runtime_error);
 }
 
+TEST_F(SBMLFeatures, NotActuallySBML)
+{
+    EXPECT_THROW(RoadRunner rr((SBMLFeaturesDir / "manifest.xml").string()), std::domain_error);
+}


### PR DESCRIPTION
Change the error message as well.  Fixes #1048.