### PR TITLE
Fix the issue with handling simulations starting from equiblrium that contain piecewise functions

### DIFF
--- a/source/CVODEIntegrator.cpp
+++ b/source/CVODEIntegrator.cpp
@@ -546,6 +546,7 @@ namespace rr {
                     // called when a event root is found clears out all pending events and applies
                     // them.
                     applyPendingEvents(timeEnd);
+                    reInit(timeEnd);
                 }
 
                 if (listener) {


### PR DESCRIPTION
'CVode' algorithm is not patient enough to wait for the upcoming change in the amount of species. So, starting from an equilibrium state, after a couple of iterations, it starts to multiply the time by factor of 10 to find a non-zero solution. This leads to a bug when a piecewise function with repeating zero output intervals is used.

To fix this issue, 'reInit' function that calls 'CVodeReInit' is called after each time step so as to refresh the algorithm at each step.