### PR TITLE
Add rootfinding breaks for when piecewise conditions change.

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -225,7 +225,7 @@ if (BUILD_LLVM)
             llvm/FunctionResolver.cpp
             llvm/GetEventValuesCodeGen.cpp
             llvm/GetInitialValuesCodeGen.cpp
-            llvm/getPiecewiseTriggerCodeGen.cpp
+            llvm/GetPiecewiseTriggerCodeGen.cpp
             llvm/GetValuesCodeGen.cpp
             llvm/Jit.cpp
             llvm/JitFactory.cpp
@@ -271,7 +271,7 @@ if (BUILD_LLVM)
             llvm/GetEventValuesCodeGen.h
             llvm/GetInitialValueCodeGenBase.h
             llvm/GetInitialValuesCodeGen.h
-            llvm/getPiecewiseTriggerCodeGen.h
+            llvm/GetPiecewiseTriggerCodeGen.h
             llvm/GetValueCodeGenBase.h
             llvm/GetValuesCodeGen.h
             llvm/Jit.h

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -225,6 +225,7 @@ if (BUILD_LLVM)
             llvm/FunctionResolver.cpp
             llvm/GetEventValuesCodeGen.cpp
             llvm/GetInitialValuesCodeGen.cpp
+            llvm/GetPiecewiseTriggersCodeGen.cpp
             llvm/GetValuesCodeGen.cpp
             llvm/Jit.cpp
             llvm/JitFactory.cpp
@@ -270,6 +271,7 @@ if (BUILD_LLVM)
             llvm/GetEventValuesCodeGen.h
             llvm/GetInitialValueCodeGenBase.h
             llvm/GetInitialValuesCodeGen.h
+            llvm/GetPiecewiseTriggersCodeGen.h
             llvm/GetValueCodeGenBase.h
             llvm/GetValuesCodeGen.h
             llvm/Jit.h

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -225,7 +225,7 @@ if (BUILD_LLVM)
             llvm/FunctionResolver.cpp
             llvm/GetEventValuesCodeGen.cpp
             llvm/GetInitialValuesCodeGen.cpp
-            llvm/GetPiecewiseTriggersCodeGen.cpp
+            llvm/getPiecewiseTriggerCodeGen.cpp
             llvm/GetValuesCodeGen.cpp
             llvm/Jit.cpp
             llvm/JitFactory.cpp
@@ -271,7 +271,7 @@ if (BUILD_LLVM)
             llvm/GetEventValuesCodeGen.h
             llvm/GetInitialValueCodeGenBase.h
             llvm/GetInitialValuesCodeGen.h
-            llvm/GetPiecewiseTriggersCodeGen.h
+            llvm/getPiecewiseTriggerCodeGen.h
             llvm/GetValueCodeGenBase.h
             llvm/GetValuesCodeGen.h
             llvm/Jit.h

--- a/source/CVODEIntegrator.cpp
+++ b/source/CVODEIntegrator.cpp
@@ -39,6 +39,8 @@ namespace rr {
 
     int cvodeRootFcn(realtype t, N_Vector y, realtype *gout, void *userData);
 
+    int cvodePiecewiseRootFcn(realtype t, N_Vector y, realtype* gout, void* userData);
+
 
     // Sets the value of an element in a N_Vector object
     inline void SetVector(N_Vector v, int Index, double Value) {
@@ -698,15 +700,15 @@ namespace rr {
                                      cvodeRootFcn)) != CV_SUCCESS) {
                 handleCVODEError(err);
             }
-            rrLog(Logger::LOG_TRACE) << "CVRootInit executed.....";
+            rrLog(Logger::LOG_TRACE) << "CVRootInit executed for events.....";
         }
 
         if (mModel->getNumPiecewiseTriggers() > 0) {
-            if ((err = CVodeRootInit(mCVODE_Memory, mModel->getNumEvents(),
-                cvodeRootFcn)) != CV_SUCCESS) {
+            if ((err = CVodeRootInit(mCVODE_Memory, mModel->getNumPiecewiseTriggers(),
+                                     cvodePiecewiseRootFcn)) != CV_SUCCESS) {
                 handleCVODEError(err);
             }
-            rrLog(Logger::LOG_TRACE) << "CVRootInit executed.....";
+            rrLog(Logger::LOG_TRACE) << "CVRootInit executed for piecewise functions.....";
         }
 
         /**
@@ -1047,6 +1049,21 @@ namespace rr {
         double *y = NV_DATA_S(y_vector);
 
         model->getEventRoots(time, y, gout);
+
+        return CV_SUCCESS;
+    }
+
+
+    int cvodePiecewiseRootFcn(realtype time, N_Vector y_vector, realtype* gout, void* user_data) {
+        CVODEIntegrator* cvInstance = (CVODEIntegrator*)user_data;
+
+        assert(cvInstance && "user data pointer is NULL on CVODE root callback");
+
+        ExecutableModel* model = cvInstance->mModel;
+
+        double* y = NV_DATA_S(y_vector);
+
+        model->getPiecewiseTriggerRoots(time, y, gout);
 
         return CV_SUCCESS;
     }

--- a/source/CVODEIntegrator.cpp
+++ b/source/CVODEIntegrator.cpp
@@ -657,11 +657,6 @@ namespace rr {
         mStateVector = N_VNew_Serial(allocStateVectorSize);
         variableStepPostEventState.resize(allocStateVectorSize);
 
-
-//        for (int i = 0; i < allocStateVectorSize; i++) {
-//            SetVector(mStateVector, i, 0.);
-//        }
-//         set mStateVector to the values that are currently in the model
         auto states = new double[allocStateVectorSize];
         mModel->getStateVector(states);
 
@@ -701,6 +696,14 @@ namespace rr {
         if (mModel->getNumEvents() > 0) {
             if ((err = CVodeRootInit(mCVODE_Memory, mModel->getNumEvents(),
                                      cvodeRootFcn)) != CV_SUCCESS) {
+                handleCVODEError(err);
+            }
+            rrLog(Logger::LOG_TRACE) << "CVRootInit executed.....";
+        }
+
+        if (mModel->getNumPiecewiseTriggers() > 0) {
+            if ((err = CVodeRootInit(mCVODE_Memory, mModel->getNumEvents(),
+                cvodeRootFcn)) != CV_SUCCESS) {
                 handleCVODEError(err);
             }
             rrLog(Logger::LOG_TRACE) << "CVRootInit executed.....";

--- a/source/CVODEIntegrator.h
+++ b/source/CVODEIntegrator.h
@@ -315,6 +315,8 @@ namespace rr {
 
         friend int cvodeRootFcn(double t, N_Vector y, double *gout, void *g_data);
 
+        friend int cvodePiecewiseRootFcn(double t, N_Vector y, double* gout, void* g_data);
+
     };
 
     template <class SundialsType = CVODEIntegrator>

--- a/source/CVODEIntegrator.h
+++ b/source/CVODEIntegrator.h
@@ -313,9 +313,7 @@ namespace rr {
 
         friend int cvodeDyDtFcn(double t, N_Vector cv_y, N_Vector cv_ydot, void *f_data);
 
-        friend int cvodeRootFcn(double t, N_Vector y, double *gout, void *g_data);
-
-        friend int cvodePiecewiseRootFcn(double t, N_Vector y, double* gout, void* g_data);
+        friend int cvodeEventAndPiecewiseRootFcn(double t, N_Vector y, double *gout, void *g_data);
 
     };
 

--- a/source/llvm/CodeGenBase.h
+++ b/source/llvm/CodeGenBase.h
@@ -78,7 +78,6 @@ protected:
             builder(*mgc.getJitNonOwning()->getBuilderNonOwning()),
             options(mgc.getOptions()),
             function(0)
-//            functionPassManager(mgc.getJitNonOwning().getFunctionPassManager())
     {
 
     };
@@ -89,7 +88,6 @@ protected:
      * could potentially be null, everything else is guaranteed to be valid
      */
     const libsbml::Model *model;
-    const std::vector<const libsbml::ASTNode> piecewiseTriggers;
 
     const LLVMModelDataSymbols &dataSymbols;
     const LLVMModelSymbols &modelSymbols;

--- a/source/llvm/CodeGenBase.h
+++ b/source/llvm/CodeGenBase.h
@@ -89,6 +89,7 @@ protected:
      * could potentially be null, everything else is guaranteed to be valid
      */
     const libsbml::Model *model;
+    const std::vector<const libsbml::ASTNode> piecewiseTriggers;
 
     const LLVMModelDataSymbols &dataSymbols;
     const LLVMModelSymbols &modelSymbols;

--- a/source/llvm/GetPiecewiseTriggerCodeGen.cpp
+++ b/source/llvm/GetPiecewiseTriggerCodeGen.cpp
@@ -1,17 +1,17 @@
 /*
- * GetPiecewiseTriggersCodeGen.cpp
+ * GetPiecewiseTriggerCodeGen.cpp
  *
  *  Created on: Aug 10, 2013
  *      Author: andy
  */
 #pragma hdrstop
-#include "GetPiecewiseTriggersCodeGen.h"
+#include "GetPiecewiseTriggerCodeGen.h"
 #include "LLVMException.h"
 #include "ModelDataSymbolResolver.h"
 #include "rrLogger.h"
 
 #include <Poco/Logger.h>
-#include <llvm/GetPiecewiseTriggersCodeGen.h>
+#include <llvm/GetPiecewiseTriggerCodeGen.h>
 #include <vector>
 
 using namespace llvm;
@@ -20,13 +20,16 @@ using namespace libsbml;
 
 namespace rrllvm
 {
-    GetPiecewiseTriggersCodeGen::GetPiecewiseTriggersCodeGen(const ModelGeneratorContext& mgc)
-        : CodeGenBase<GetPiecewiseTriggersCodeGen_FunctionPtr>(mgc)
+    const char* GetPiecewiseTriggerCodeGen::FunctionName = "getPiecewiseTrigger";
+    const char* GetPiecewiseTriggerCodeGen::IndexArgName = "triggerIndx";
+
+    GetPiecewiseTriggerCodeGen::GetPiecewiseTriggerCodeGen(const ModelGeneratorContext& mgc)
+        : CodeGenBase<GetPiecewiseTriggerCodeGen_FunctionPtr>(mgc)
         , piecewiseTriggers(mgc.getPiecewiseTriggers())
     {
     };
 
-    llvm::Value* GetPiecewiseTriggersCodeGen::codeGen()
+    llvm::Value* GetPiecewiseTriggerCodeGen::codeGen()
     {
         // make the set init value function
         llvm::Type* argTypes[] = {
@@ -82,15 +85,12 @@ namespace rrllvm
         return this->verifyFunction();
     }
 
-    const char* GetPiecewiseTriggersCodeGen::FunctionName = "getPiecewiseTriggers";
-    const char* GetPiecewiseTriggersCodeGen::IndexArgName = "triggerIndx";
-
-    llvm::Type* GetPiecewiseTriggersCodeGen::getRetType()
+    llvm::Type* GetPiecewiseTriggerCodeGen::getRetType()
     {
         return llvm::Type::getInt8Ty(context);
     };
 
-    llvm::Value* GetPiecewiseTriggersCodeGen::createRet(llvm::Value* value)
+    llvm::Value* GetPiecewiseTriggerCodeGen::createRet(llvm::Value* value)
     {
         if (!value)
         {

--- a/source/llvm/GetPiecewiseTriggerCodeGen.h
+++ b/source/llvm/GetPiecewiseTriggerCodeGen.h
@@ -1,12 +1,12 @@
 /*
- * GetPiecewiseTriggersCodeGen.h
+ * GetPiecewiseTriggerCodeGen.h
  *
  *  Created on: Aug 10, 2013
  *      Author: andy
  */
 
-#ifndef RRLLVMGetPiecewiseTriggersCodeGen_H_
-#define RRLLVMGetPiecewiseTriggersCodeGen_H_
+#ifndef RRLLVMGetPiecewiseTriggerCodeGen_H_
+#define RRLLVMGetPiecewiseTriggerCodeGen_H_
 
 #include "CodeGenBase.h"
 #include "ModelGeneratorContext.h"
@@ -24,19 +24,20 @@
 
 namespace rrllvm
 {
+    //Based on GetEventTriggerCodeGen (-LS)
 
-    typedef void (*GetPiecewiseTriggersCodeGen_FunctionPtr)(LLVMModelData*);
+    typedef unsigned char (*GetPiecewiseTriggerCodeGen_FunctionPtr)(LLVMModelData*, size_t);
 
-    class GetPiecewiseTriggersCodeGen :
-        public CodeGenBase<GetPiecewiseTriggersCodeGen_FunctionPtr>
+    class GetPiecewiseTriggerCodeGen :
+        public CodeGenBase<GetPiecewiseTriggerCodeGen_FunctionPtr>
     {
     public:
-        GetPiecewiseTriggersCodeGen(const ModelGeneratorContext& mgc);
-        virtual ~GetPiecewiseTriggersCodeGen() {};
+        GetPiecewiseTriggerCodeGen(const ModelGeneratorContext& mgc);
+        virtual ~GetPiecewiseTriggerCodeGen() {};
 
         llvm::Value* codeGen();
 
-        typedef GetPiecewiseTriggersCodeGen_FunctionPtr FunctionPtr;
+        typedef GetPiecewiseTriggerCodeGen_FunctionPtr FunctionPtr;
 
         static const char* FunctionName;
         static const char* IndexArgName;

--- a/source/llvm/GetPiecewiseTriggersCodeGen.cpp
+++ b/source/llvm/GetPiecewiseTriggersCodeGen.cpp
@@ -20,6 +20,11 @@ using namespace libsbml;
 
 namespace rrllvm
 {
+    GetPiecewiseTriggersCodeGen::GetPiecewiseTriggersCodeGen(const ModelGeneratorContext& mgc)
+        : CodeGenBase<GetPiecewiseTriggersCodeGen_FunctionPtr>(mgc)
+        , piecewiseTriggers(mgc.getPiecewiseTriggers())
+    {
+    };
 
     llvm::Value* GetPiecewiseTriggersCodeGen::codeGen()
     {
@@ -55,7 +60,7 @@ namespace rrllvm
         // entry block terminator
         this->builder.SetInsertPoint(entry);
 
-        llvm::SwitchInst* s = this->builder.CreateSwitch(args[1], def, this->piecewiseTriggers->size());
+        llvm::SwitchInst* s = this->builder.CreateSwitch(args[1], def, piecewiseTriggers->size());
 
         for (uint i = 0; i < piecewiseTriggers->size(); ++i)
         {
@@ -65,7 +70,7 @@ namespace rrllvm
             this->builder.SetInsertPoint(block);
             resolver.flushCache();
 
-            llvm::Value* value = astCodeGen.codeGenBoolean(this->piecewiseTriggers[i]);
+            llvm::Value* value = astCodeGen.codeGenBoolean((*piecewiseTriggers)[i]);
 
             // convert type to return type
             value = createRet(value);

--- a/source/llvm/GetPiecewiseTriggersCodeGen.cpp
+++ b/source/llvm/GetPiecewiseTriggersCodeGen.cpp
@@ -1,0 +1,105 @@
+/*
+ * GetPiecewiseTriggersCodeGen.cpp
+ *
+ *  Created on: Aug 10, 2013
+ *      Author: andy
+ */
+#pragma hdrstop
+#include "GetPiecewiseTriggersCodeGen.h"
+#include "LLVMException.h"
+#include "ModelDataSymbolResolver.h"
+#include "rrLogger.h"
+
+#include <Poco/Logger.h>
+#include <llvm/GetPiecewiseTriggersCodeGen.h>
+#include <vector>
+
+using namespace llvm;
+
+using namespace libsbml;
+
+namespace rrllvm
+{
+
+    llvm::Value* GetPiecewiseTriggersCodeGen::codeGen()
+    {
+        // make the set init value function
+        llvm::Type* argTypes[] = {
+            llvm::PointerType::get(ModelDataIRBuilder::getStructType(this->module), 0),
+            llvm::Type::getInt32Ty(this->context)
+        };
+
+        const char* argNames[] = {
+            "modelData", IndexArgName
+        };
+
+        llvm::Value* args[] = { 0, 0 };
+
+        llvm::Type* retType = getRetType();
+
+        llvm::BasicBlock* entry = this->codeGenHeader(FunctionName, retType,
+            argTypes, argNames, args);
+
+        ModelDataLoadSymbolResolver resolver(args[0], this->modelGenContext);
+
+        ASTNodeCodeGen astCodeGen(this->builder, resolver, this->modelGenContext, args[0]);
+
+        // default, return NaN
+        llvm::BasicBlock* def = llvm::BasicBlock::Create(this->context, "default", this->function);
+        this->builder.SetInsertPoint(def);
+
+        llvm::Value* defRet = createRet(0);
+        this->builder.CreateRet(defRet);
+
+        // write the switch at the func entry point, the switch is also the
+        // entry block terminator
+        this->builder.SetInsertPoint(entry);
+
+        llvm::SwitchInst* s = this->builder.CreateSwitch(args[1], def, this->piecewiseTriggers->size());
+
+        for (uint i = 0; i < piecewiseTriggers->size(); ++i)
+        {
+            char block_name[64];
+            std::sprintf(block_name, "piecewiseTrigger_%i_block", i);
+            llvm::BasicBlock* block = llvm::BasicBlock::Create(this->context, block_name, this->function);
+            this->builder.SetInsertPoint(block);
+            resolver.flushCache();
+
+            llvm::Value* value = astCodeGen.codeGenBoolean(this->piecewiseTriggers[i]);
+
+            // convert type to return type
+            value = createRet(value);
+
+            this->builder.CreateRet(value);
+            s->addCase(llvm::ConstantInt::get(llvm::Type::getInt32Ty(this->context), i), block);
+        }
+
+        return this->verifyFunction();
+    }
+
+    const char* GetPiecewiseTriggersCodeGen::FunctionName = "getPiecewiseTriggers";
+    const char* GetPiecewiseTriggersCodeGen::IndexArgName = "triggerIndx";
+
+    llvm::Type* GetPiecewiseTriggersCodeGen::getRetType()
+    {
+        return llvm::Type::getInt8Ty(context);
+    };
+
+    llvm::Value* GetPiecewiseTriggersCodeGen::createRet(llvm::Value* value)
+    {
+        if (!value)
+        {
+            return llvm::ConstantInt::get(getRetType(), 0xff, false);
+        }
+        else
+        {
+            return builder.CreateIntCast(value, getRetType(), false);
+        }
+    }
+
+
+} /* namespace rr */
+
+
+
+

--- a/source/llvm/GetPiecewiseTriggersCodeGen.h
+++ b/source/llvm/GetPiecewiseTriggersCodeGen.h
@@ -1,0 +1,62 @@
+/*
+ * GetPiecewiseTriggersCodeGen.h
+ *
+ *  Created on: Aug 10, 2013
+ *      Author: andy
+ */
+
+#ifndef RRLLVMGetPiecewiseTriggersCodeGen_H_
+#define RRLLVMGetPiecewiseTriggersCodeGen_H_
+
+#include "CodeGenBase.h"
+#include "ModelGeneratorContext.h"
+#include "SymbolForest.h"
+#include "ASTNodeCodeGen.h"
+#include "ASTNodeFactory.h"
+#include "ModelDataIRBuilder.h"
+#include "ModelDataSymbolResolver.h"
+#include "LLVMException.h"
+#include "rrLogger.h"
+#include <sbml/Model.h>
+#include <Poco/Logger.h>
+#include <vector>
+#include <cstdio>
+
+namespace rrllvm
+{
+
+    typedef double (*GetPiecewiseTriggersCodeGen_FunctionPtr)(LLVMModelData*, size_t);
+
+    /** @class GetPiecewiseTriggersCodeGen
+    * Class for getting piecewise trigger values.
+    */
+    class GetPiecewiseTriggersCodeGen : public
+        CodeGenBase<GetPiecewiseTriggersCodeGen>
+    {
+    public:
+        GetPiecewiseTriggersCodeGen(const ModelGeneratorContext& mgc) :
+            CodeGenBase<GetPiecewiseTriggersCodeGen_FunctionPtr>(mgc)
+        {
+        };
+
+        virtual ~GetPiecewiseTriggersCodeGen() {};
+
+        llvm::Value* codeGen();
+
+        typedef GetPiecewiseTriggersCodeGen_FunctionPtr FunctionPtr;
+
+        static const char* FunctionName;
+        static const char* IndexArgName;
+
+        llvm::Type* getRetType();
+
+        llvm::Value* createRet(llvm::Value*);
+    };
+
+
+} /* namespace rr */
+
+
+
+
+#endif /* RRLLVMGETVALUECODEGENBASE_H_ */

--- a/source/llvm/GetPiecewiseTriggersCodeGen.h
+++ b/source/llvm/GetPiecewiseTriggersCodeGen.h
@@ -25,20 +25,13 @@
 namespace rrllvm
 {
 
-    typedef double (*GetPiecewiseTriggersCodeGen_FunctionPtr)(LLVMModelData*, size_t);
+    typedef void (*GetPiecewiseTriggersCodeGen_FunctionPtr)(LLVMModelData*);
 
-    /** @class GetPiecewiseTriggersCodeGen
-    * Class for getting piecewise trigger values.
-    */
-    class GetPiecewiseTriggersCodeGen : public
-        CodeGenBase<GetPiecewiseTriggersCodeGen>
+    class GetPiecewiseTriggersCodeGen :
+        public CodeGenBase<GetPiecewiseTriggersCodeGen_FunctionPtr>
     {
     public:
-        GetPiecewiseTriggersCodeGen(const ModelGeneratorContext& mgc) :
-            CodeGenBase<GetPiecewiseTriggersCodeGen_FunctionPtr>(mgc)
-        {
-        };
-
+        GetPiecewiseTriggersCodeGen(const ModelGeneratorContext& mgc);
         virtual ~GetPiecewiseTriggersCodeGen() {};
 
         llvm::Value* codeGen();
@@ -51,6 +44,9 @@ namespace rrllvm
         llvm::Type* getRetType();
 
         llvm::Value* createRet(llvm::Value*);
+
+    private:
+        const std::vector<libsbml::ASTNode*>* piecewiseTriggers;
     };
 
 

--- a/source/llvm/Jit.cpp
+++ b/source/llvm/Jit.cpp
@@ -128,6 +128,8 @@ namespace rrllvm {
                 "eventTrigger"));
         modelResources->eventAssignPtr = reinterpret_cast<EventAssignCodeGen::FunctionPtr>(lookupFunctionAddress(
                 "eventAssign"));
+        modelResources->getPiecewiseTriggerPtr = reinterpret_cast<GetPiecewiseTriggerCodeGen::FunctionPtr>(lookupFunctionAddress(
+                "getPiecewiseTrigger"));
         modelResources->evalVolatileStoichPtr = reinterpret_cast<EvalVolatileStoichCodeGen::FunctionPtr>(lookupFunctionAddress(
                 "evalVolatileStoich"));
         modelResources->evalConversionFactorPtr = reinterpret_cast<EvalConversionFactorCodeGen::FunctionPtr>(lookupFunctionAddress(

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -2489,6 +2489,34 @@ void  LLVMExecutableModel::getEventRoots(double time, const double* y, double* g
     return;
 }
 
+void  LLVMExecutableModel::getPiecewiseTriggerRoots(double time, const double* y, double* gdot)
+{
+    modelData->time = time;
+
+    double* savedRateRules = modelData->rateRuleValuesAlias;
+    double* savedFloatingSpeciesAmounts = modelData->floatingSpeciesAmountsAlias;
+
+    if (y)
+    {
+        modelData->rateRuleValuesAlias = const_cast<double*>(y);
+        modelData->floatingSpeciesAmountsAlias = const_cast<double*>(y + modelData->numRateRules);
+
+        evalVolatileStoichPtr(modelData);
+    }
+
+    for (uint i = 0; i < modelData->numPiecewiseTriggers; ++i)
+    {
+        unsigned char triggered = getPiecewiseTriggerPtr(modelData, i);
+
+        gdot[i] = triggered ? 1.0 : -1.0;
+    }
+
+    modelData->rateRuleValuesAlias = savedRateRules;
+    modelData->floatingSpeciesAmountsAlias = savedFloatingSpeciesAmounts;
+
+    return;
+}
+
 double LLVMExecutableModel::getNextPendingEventTime(bool pop)
 {
     return pendingEvents.getNextPendingEventTime();

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -1876,8 +1876,7 @@ void LLVMExecutableModel::getEventIds(std::list<std::string>& out)
 
 int LLVMExecutableModel::getNumPiecewiseTriggers()
 {
-    return 0;
-    //return modelData->numPiecewiseTriggers;
+    return modelData->numPiecewiseTriggers;
 }
 
 void LLVMExecutableModel::getAssignmentRuleIds(std::list<std::string>& out)

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -182,6 +182,7 @@ LLVMExecutableModel::LLVMExecutableModel() :
     getEventDelayPtr(0),
     eventTriggerPtr(0),
     eventAssignPtr(0),
+    getPiecewiseTriggerPtr(0),
     evalVolatileStoichPtr(0),
     evalConversionFactorPtr(0),
     setBoundarySpeciesAmountPtr(0),
@@ -229,6 +230,7 @@ LLVMExecutableModel::LLVMExecutableModel(
     getEventDelayPtr(modelResources->getEventDelayPtr),
     eventTriggerPtr(modelResources->eventTriggerPtr),
     eventAssignPtr(modelResources->eventAssignPtr),
+    getPiecewiseTriggerPtr(modelResources->getPiecewiseTriggerPtr),
     evalVolatileStoichPtr(modelResources->evalVolatileStoichPtr),
     evalConversionFactorPtr(modelResources->evalConversionFactorPtr),
     setBoundarySpeciesAmountPtr(modelResources->setBoundarySpeciesAmountPtr),
@@ -294,6 +296,7 @@ LLVMExecutableModel::LLVMExecutableModel(std::istream& in, uint modelGeneratorOp
     getEventDelayPtr = resources->getEventDelayPtr;
     eventTriggerPtr = resources->eventTriggerPtr;
     eventAssignPtr = resources->eventAssignPtr;
+    getPiecewiseTriggerPtr = resources->getPiecewiseTriggerPtr;
     evalVolatileStoichPtr = resources->evalVolatileStoichPtr;
     evalConversionFactorPtr = resources->evalConversionFactorPtr;
     setBoundarySpeciesAmountPtr = resources->setBoundarySpeciesAmountPtr;
@@ -1871,6 +1874,12 @@ void LLVMExecutableModel::getEventIds(std::list<std::string>& out)
     std::copy(eventIds.begin(), eventIds.end(), std::back_inserter(out));
 }
 
+int LLVMExecutableModel::getNumPiecewiseTriggers()
+{
+    return 0;
+    //return modelData->numPiecewiseTriggers;
+}
+
 void LLVMExecutableModel::getAssignmentRuleIds(std::list<std::string>& out)
 {
     std::vector<std::string> arIds = symbols->getAssignmentRuleIds();
@@ -2462,12 +2471,6 @@ void  LLVMExecutableModel::getEventRoots(double time, const double* y, double* g
 
     if (y)
     {
-        //memcpy(modelData->rateRuleValues, y,
-        //        modelData->numRateRules * sizeof(double));
-
-        //memcpy(modelData->floatingSpeciesAmounts, y + modelData->numRateRules,
-        //        modelData->numIndFloatingSpecies * sizeof(double));
-
         modelData->rateRuleValuesAlias = const_cast<double*>(y);
         modelData->floatingSpeciesAmountsAlias = const_cast<double*>(y + modelData->numRateRules);
 

--- a/source/llvm/LLVMExecutableModel.h
+++ b/source/llvm/LLVMExecutableModel.h
@@ -490,6 +490,8 @@ public:
 
     virtual void getEventRoots(double time, const double* y, double* gdot);
 
+    virtual void getPiecewiseTriggerRoots(double time, const double* y, double* gdot);
+
     virtual double getNextPendingEventTime(bool pop);
 
     virtual int getPendingEventSize();

--- a/source/llvm/LLVMExecutableModel.h
+++ b/source/llvm/LLVMExecutableModel.h
@@ -32,6 +32,7 @@
 #include "GetEventValuesCodeGen.h"
 #include "EventAssignCodeGen.h"
 #include "EventTriggerCodeGen.h"
+#include "GetPiecewiseTriggerCodeGen.h"
 #include "EvalVolatileStoichCodeGen.h"
 #include "EvalConversionFactorCodeGen.h"
 #include "SetValuesCodeGen.h"
@@ -97,7 +98,7 @@ public:
      * evaluate the initial conditions specified in the sbml, this entails
      * evaluating all InitialAssigments, AssigmentRules, initial values, etc...
      *
-     * The the model state is fully set.
+     * Then the model state is fully set.
      */
     void evalInitialConditions(uint32_t flags = 0);
 
@@ -563,6 +564,9 @@ public:
     virtual int getEventIndex(const std::string& eid);
     virtual std::string getEventId(size_t index);
     virtual void getEventIds(std::list<std::string>& out);
+
+    virtual int getNumPiecewiseTriggers();
+
     virtual void getAssignmentRuleIds(std::list<std::string>& out);
     virtual void getRateRuleIds(std::list<std::string>& out);
     virtual void getInitialAssignmentIds(std::list<std::string>& out);
@@ -656,6 +660,7 @@ private:
     GetEventDelayCodeGen::FunctionPtr getEventDelayPtr;
     EventTriggerCodeGen::FunctionPtr eventTriggerPtr;
     EventAssignCodeGen::FunctionPtr eventAssignPtr;
+    GetPiecewiseTriggerCodeGen::FunctionPtr getPiecewiseTriggerPtr;
     EvalVolatileStoichCodeGen::FunctionPtr evalVolatileStoichPtr;
     EvalConversionFactorCodeGen::FunctionPtr evalConversionFactorPtr;
 

--- a/source/llvm/LLVMModelData.cpp
+++ b/source/llvm/LLVMModelData.cpp
@@ -121,6 +121,7 @@ void LLVMModelData_save(LLVMModelData *data, std::ostream& out)
 	rr::saveBinary(out, data->numInitGlobalParameters);
     
 	rr::saveBinary(out, data->numEvents);
+	//rr::saveBinary(out, data->numPiecewiseTriggers);
 	rr::saveBinary(out, data->stateVectorSize);
 	//Save the stoichiometry matrix
 	rr::csr_matrix_dump_binary(data->stoichiometry, out);
@@ -199,8 +200,9 @@ LLVMModelData* LLVMModelData_from_save(std::istream& in)
 	rr::loadBinary(in, data->numInitGlobalParameters);
 
 	rr::loadBinary(in, data->numEvents);
+	//rr::loadBinary(in, data->numPiecewiseTriggers);
 	rr::loadBinary(in, data->stateVectorSize);
-    
+
 	//Load the stoichiometry matrix
 	data->stoichiometry = rr::csr_matrix_new_from_binary(in);
 

--- a/source/llvm/LLVMModelData.cpp
+++ b/source/llvm/LLVMModelData.cpp
@@ -121,7 +121,7 @@ void LLVMModelData_save(LLVMModelData *data, std::ostream& out)
 	rr::saveBinary(out, data->numInitGlobalParameters);
     
 	rr::saveBinary(out, data->numEvents);
-	//rr::saveBinary(out, data->numPiecewiseTriggers);
+	rr::saveBinary(out, data->numPiecewiseTriggers);
 	rr::saveBinary(out, data->stateVectorSize);
 	//Save the stoichiometry matrix
 	rr::csr_matrix_dump_binary(data->stoichiometry, out);
@@ -200,7 +200,7 @@ LLVMModelData* LLVMModelData_from_save(std::istream& in)
 	rr::loadBinary(in, data->numInitGlobalParameters);
 
 	rr::loadBinary(in, data->numEvents);
-	//rr::loadBinary(in, data->numPiecewiseTriggers);
+	rr::loadBinary(in, data->numPiecewiseTriggers);
 	rr::loadBinary(in, data->stateVectorSize);
 
 	//Load the stoichiometry matrix

--- a/source/llvm/LLVMModelData.h
+++ b/source/llvm/LLVMModelData.h
@@ -118,7 +118,7 @@ struct LLVMModelData
     unsigned                            numEvents;                        // 15
 
     //Piecewise triggers that get treated like events for rootfinding purposes.
-    //unsigned                            numPiecewiseTriggers;             // 16
+    unsigned                            numPiecewiseTriggers;             // 16
 
     /**
      * number of items in the state std::vector.

--- a/source/llvm/LLVMModelData.h
+++ b/source/llvm/LLVMModelData.h
@@ -117,23 +117,26 @@ struct LLVMModelData
     //Event stuff
     unsigned                            numEvents;                        // 15
 
+    //Piecewise triggers that get treated like events for rootfinding purposes.
+    //unsigned                            numPiecewiseTriggers;             // 16
+
     /**
      * number of items in the state std::vector.
      * should be numIndFloatingSpecies + numRateRules
      */
-    unsigned                            stateVectorSize;                  // 16
+    unsigned                            stateVectorSize;                  // 17
 
     /**
      * the state std::vector, this is usually a pointer to a block of data
      * owned by the integrator.
      */
-    double*                             stateVector;                      // 17
+    double*                             stateVector;                      // 18
 
     /**
      * the rate of change of the state std::vector, this is usually a pointer to
      * a block of data owned by the integrator.
      */
-    double*                             stateVectorRate;                  // 18
+    double*                             stateVectorRate;                  // 19
 
     /**
      * the rate of change of all elements who's dynamics are determined
@@ -144,7 +147,7 @@ struct LLVMModelData
      *
      * Normally NULL, only valid durring an evalModel call.
      */
-    double*                             rateRuleRates;                    // 19
+    double*                             rateRuleRates;                    // 20
 
 
 
@@ -154,7 +157,7 @@ struct LLVMModelData
      * This pointer is ONLY valid during an evalModel call, otherwise it is
      * zero. TODO, this needs be be moved to a parameter.
      */
-    double*                             floatingSpeciesAmountRates;       // 20
+    double*                             floatingSpeciesAmountRates;       // 21
 
 
  
@@ -170,8 +173,8 @@ struct LLVMModelData
      * units: volume
      */
 
-    double*                             compartmentVolumesAlias;          // 21
-    double*                             initCompartmentVolumesAlias;      // 22
+    double*                             compartmentVolumesAlias;          // 22
+    double*                             initCompartmentVolumesAlias;      // 23
 
 
     /**
@@ -182,16 +185,16 @@ struct LLVMModelData
 	 * Note that dependent floating species which have a rate rule will not be stored
 	 * in this block, instead, they will be stored in RateRule block
      */
-    double*                             initFloatingSpeciesAmountsAlias;  // 23
+    double*                             initFloatingSpeciesAmountsAlias;  // 24
 
 
-    double*                             boundarySpeciesAmountsAlias;      // 24
-    double*                             initBoundarySpeciesAmountsAlias;  // 25
+    double*                             boundarySpeciesAmountsAlias;      // 25
+    double*                             initBoundarySpeciesAmountsAlias;  // 26
 
-    double*                             globalParametersAlias;            // 26
-    double*                             initGlobalParametersAlias;        // 27
+    double*                             globalParametersAlias;            // 27
+    double*                             initGlobalParametersAlias;        // 28
 
-    double*                             reactionRatesAlias;               // 28
+    double*                             reactionRatesAlias;               // 29
 
     /**
      * All of the elelments which have a rate rule are stored here, including 
@@ -207,7 +210,7 @@ struct LLVMModelData
      * of this struct.
      *
      */
-    double*                             rateRuleValuesAlias;              // 29
+    double*                             rateRuleValuesAlias;              // 30
 
 
 
@@ -218,22 +221,22 @@ struct LLVMModelData
      * This pointer is part of the state std::vector. When any function is called by
      * CVODE, this is actually a pointer to a CVODE owned memory block.
      */
-    double*                             floatingSpeciesAmountsAlias;      // 30
+    double*                             floatingSpeciesAmountsAlias;      // 31
 
     /**
 	 * binary data layout:
      *
-     * compartmentVolumes                [numIndCompartmentVolumes]       // 31
-     * initCompartmentVolumes            [numInitCompartmentVolumes]      // 32
-     * initFloatingSpeciesAmounts        [numInitFloatingSpecies]         // 33
-     * boundarySpeciesAmounts            [numIndBoundarySpecies]          // 34
-     * initBoundarySpeciesAmounts        [numInitBoundarySpecies]         // 35
-     * globalParameters                  [numIndGlobalParameters]         // 36
-     * initGlobalParameters              [numInitGlobalParameters]        // 37
-     * reactionRates                     [numReactions]                   // 38
+     * compartmentVolumes                [numIndCompartmentVolumes]       // 32
+     * initCompartmentVolumes            [numInitCompartmentVolumes]      // 33
+     * initFloatingSpeciesAmounts        [numInitFloatingSpecies]         // 34
+     * boundarySpeciesAmounts            [numIndBoundarySpecies]          // 35
+     * initBoundarySpeciesAmounts        [numInitBoundarySpecies]         // 36
+     * globalParameters                  [numIndGlobalParameters]         // 37
+     * initGlobalParameters              [numInitGlobalParameters]        // 38
+     * reactionRates                     [numReactions]                   // 39
      *
-     * rateRuleValues                    [numRateRules]                   // 39
-     * floatingSpeciesAmounts            [numIndFloatingSpecies]          // 40
+     * rateRuleValues                    [numRateRules]                   // 40
+     * floatingSpeciesAmounts            [numIndFloatingSpecies]          // 41
      */
 
 	 /**

--- a/source/llvm/LLVMModelDataSymbols.cpp
+++ b/source/llvm/LLVMModelDataSymbols.cpp
@@ -333,47 +333,6 @@ int LLVMModelDataSymbols::getGlobalParameterIndex(
     return -1;
 }
 
-/*
-void LLVMModelDataSymbols::initAllocModelDataBuffers(LLVMModelData& m) const
-{
-    // zero out the structure
-    LLVMModelData::init(m);
-
-    // set the buffer sizes
-    m.numIndFloatingSpecies         = independentFloatingSpeciesSize;
-
-    //mData.numDependentSpecies           = ms.mNumDependentSpecies;
-    m.numIndGlobalParameters        = independentGlobalParameterSize;
-    m.numReactions                  = reactionsMap.size();
-    m.numEvents                     = eventAttributes.size();
-    m.numRateRules                  = rateRules.size();
-    m.numIndCompartments            = independentCompartmentSize;
-    m.numIndBoundarySpecies         = independentBoundarySpeciesSize;
-
-    // in certain cases, the data returned by c++ new may be alligned differently than
-    // malloc, so just use calloc here just to be safe, plus calloc returns zero
-    // initialized memory.
-
-    m.floatingSpeciesAmountsAlias = (double*)calloc(m.numIndFloatingSpecies, sizeof(double));
-    m.floatingSpeciesAmountRates = 0;
-    m.rateRuleValuesAlias = (double*)calloc(m.numRateRules, sizeof(double));
-    m.rateRuleRates = 0;
-
-    m.reactionRatesAlias = (double*)calloc(m.numReactions, sizeof(double));
-
-    m.globalParametersAlias = (double*)calloc(m.numIndGlobalParameters, sizeof(double));
-    m.compartmentVolumesAlias = (double*)calloc(m.numIndCompartments, sizeof(double));
-
-    m.boundarySpeciesAmountsAlias = (double*)calloc(m.numIndBoundarySpecies, sizeof(double));
-
-
-    // allocate the stoichiometry matrix
-    m.stoichiometry = rr::csr_matrix_new(m.numIndFloatingSpecies, getReactionSize(),
-            stoichRowIndx, stoichColIndx, std::vector<double>(stoichRowIndx.size(), 0));
-}
-*/
-
-
 const std::vector<uint>& LLVMModelDataSymbols::getStoichRowIndx() const
 {
     return stoichRowIndx;

--- a/source/llvm/LLVMModelDataSymbols.cpp
+++ b/source/llvm/LLVMModelDataSymbols.cpp
@@ -72,34 +72,35 @@ static const char* modelDataFieldsNames[] =  {
         "Stoichiometry",                        // 13
         "RandomPtr",                            // 14
         "NumEvents",                            // 15
-        "StateVectorSize",                      // 16
-        "StateVector",                          // 17
-        "StateVectorRate",                      // 18
-        "RateRuleRates",                        // 19
-        "FloatingSpeciesAmountRates",           // 20
+        "NumPiecewiseTriggers",                 // 16
+        "StateVectorSize",                      // 17
+        "StateVector",                          // 18
+        "StateVectorRate",                      // 19
+        "RateRuleRates",                        // 20
+        "FloatingSpeciesAmountRates",           // 21
 
-        "CompartmentVolumesAlias",              // 21
-        "InitCompartmentVolumesAlias",          // 22
-        "InitFloatingSpeciesAmountsAlias",      // 23
-        "BoundarySpeciesAmountsAlias",          // 24
-        "InitBoundarySpeciesAmountsAlias",      // 25
-        "GlobalParametersAlias",                // 26
-        "InitGlobalParametersAlias",            // 27
-        "ReactionRatesAlias",                   // 28
+        "CompartmentVolumesAlias",              // 22
+        "InitCompartmentVolumesAlias",          // 23
+        "InitFloatingSpeciesAmountsAlias",      // 24
+        "BoundarySpeciesAmountsAlias",          // 25
+        "InitBoundarySpeciesAmountsAlias",      // 26
+        "GlobalParametersAlias",                // 27
+        "InitGlobalParametersAlias",            // 28
+        "ReactionRatesAlias",                   // 29
 
-        "RateRuleValuesAlias",                  // 29
-        "FloatingSpeciesAmountsAlias",          // 30
+        "RateRuleValuesAlias",                  // 30
+        "FloatingSpeciesAmountsAlias",          // 31
 
-        "CompartmentVolumes",                   // 31
-        "InitCompartmentVolumes",               // 32
-        "InitFloatingSpeciesAmounts",           // 33
-        "BoundarySpeciesAmounts",               // 34
-        "InitBoundarySpeciesAmounts",           // 35
-        "GlobalParameters",                     // 36
-        "InitGlobalParameters",                 // 37
-        "ReactionRates",                        // 38
-        "NotSafe_RateRuleValues",               // 39
-        "NotSafe_FloatingSpeciesAmounts"        // 40
+        "CompartmentVolumes",                   // 32
+        "InitCompartmentVolumes",               // 33
+        "InitFloatingSpeciesAmounts",           // 34
+        "BoundarySpeciesAmounts",               // 35
+        "InitBoundarySpeciesAmounts",           // 36
+        "GlobalParameters",                     // 37
+        "InitGlobalParameters",                 // 38
+        "ReactionRates",                        // 39
+        "NotSafe_RateRuleValues",               // 40
+        "NotSafe_FloatingSpeciesAmounts"        // 41
 };
 
 

--- a/source/llvm/LLVMModelDataSymbols.h
+++ b/source/llvm/LLVMModelDataSymbols.h
@@ -51,34 +51,35 @@ enum ModelDataFields {
     Stoichiometry,                            // 13
     RandomPtr,                                // 14
     NumEvents,                                // 15
-    StateVectorSize,                          // 16
-    StateVector,                              // 17
-    StateVectorRate,                          // 18
-    RateRuleRates,                            // 19
-    FloatingSpeciesAmountRates,               // 20
+    NumPiecewiseTriggers,                     // 16
+    StateVectorSize,                          // 17
+    StateVector,                              // 18
+    StateVectorRate,                          // 19
+    RateRuleRates,                            // 20
+    FloatingSpeciesAmountRates,               // 21
 
-    CompartmentVolumesAlias,                  // 21
-    InitCompartmentVolumesAlias,              // 22
-    InitFloatingSpeciesAmountsAlias,          // 23
-    BoundarySpeciesAmountsAlias,              // 24
-    InitBoundarySpeciesAmountsAlias,          // 25
-    GlobalParametersAlias,                    // 26
-    InitGlobalParametersAlias,                // 27
-    ReactionRatesAlias,                       // 28
+    CompartmentVolumesAlias,                  // 22
+    InitCompartmentVolumesAlias,              // 23
+    InitFloatingSpeciesAmountsAlias,          // 24
+    BoundarySpeciesAmountsAlias,              // 25
+    InitBoundarySpeciesAmountsAlias,          // 26
+    GlobalParametersAlias,                    // 27
+    InitGlobalParametersAlias,                // 28
+    ReactionRatesAlias,                       // 29
 
-    RateRuleValuesAlias,                      // 29
-    FloatingSpeciesAmountsAlias,              // 30
+    RateRuleValuesAlias,                      // 30
+    FloatingSpeciesAmountsAlias,              // 31
 
-    CompartmentVolumes,                       // 31
-    InitCompartmentVolumes,                   // 32
-    InitFloatingSpeciesAmounts,               // 33
-    BoundarySpeciesAmounts,                   // 34
-    InitBoundarySpeciesAmounts,               // 35
-    GlobalParameters,                         // 36
-    InitGlobalParameters,                     // 37
-    ReactionRates,                            // 38
-    NotSafe_RateRuleValues,                   // 39
-    NotSafe_FloatingSpeciesAmounts,           // 40
+    CompartmentVolumes,                       // 32
+    InitCompartmentVolumes,                   // 33
+    InitFloatingSpeciesAmounts,               // 34
+    BoundarySpeciesAmounts,                   // 35
+    InitBoundarySpeciesAmounts,               // 36
+    GlobalParameters,                         // 37
+    InitGlobalParameters,                     // 38
+    ReactionRates,                            // 39
+    NotSafe_RateRuleValues,                   // 40
+    NotSafe_FloatingSpeciesAmounts,           // 41
 };
 
 enum EventAtributes

--- a/source/llvm/LLVMModelDataSymbols.h
+++ b/source/llvm/LLVMModelDataSymbols.h
@@ -117,7 +117,7 @@ enum EventAtributes
  * * Most of the indexes used in this class are indexes into ModelData
  * arrays, therefore we use unsigned integers -- these are less error
  * prone and its easier to check if they are valid i.e. only check that
- * they are less than the the array size and we do not have to check that
+ * they are less than the array size and we do not have to check that
  * it is positive.
  *
  * * All symbols from the sbml are reordered such that the independent
@@ -486,12 +486,12 @@ public:
     size_t getEventBufferSize(size_t eventId) const;
 
     /**
-     * the the row indices of non-zero stoichiometry values
+     * the row indices of non-zero stoichiometry values
      */
     const std::vector<uint>& getStoichRowIndx() const;
 
     /**
-     * the the column indices of non-zero stoichiometry values
+     * the column indices of non-zero stoichiometry values
      */
     const std::vector<uint>& getStoichColIndx() const;
 

--- a/source/llvm/LLVMModelGenerator.cpp
+++ b/source/llvm/LLVMModelGenerator.cpp
@@ -661,7 +661,7 @@ namespace rrllvm {
         modelData->numRateRules = numRateRules;
         modelData->numReactions = numReactions;
         modelData->numEvents = static_cast<uint>(symbols.getEventAttributes().size());
-        //modelData->numPiecewiseTriggers = numPiecewiseTriggers;
+        modelData->numPiecewiseTriggers = numPiecewiseTriggers;
 
         // set the aliases to the offsets
         uint offset = 0;

--- a/source/llvm/LLVMModelGenerator.cpp
+++ b/source/llvm/LLVMModelGenerator.cpp
@@ -104,6 +104,7 @@ namespace rrllvm {
         dst->getEventDelayPtr = src->getEventDelayPtr;
         dst->eventTriggerPtr = src->eventTriggerPtr;
         dst->eventAssignPtr = src->eventAssignPtr;
+        dst->getPiecewiseTriggerPtr = src->getPiecewiseTriggerPtr;
         dst->evalVolatileStoichPtr = src->evalVolatileStoichPtr;
         dst->evalConversionFactorPtr = src->evalConversionFactorPtr;
     }
@@ -123,6 +124,7 @@ namespace rrllvm {
         GetEventDelayCodeGen(context).createFunction();
         EventTriggerCodeGen(context).createFunction();
         EventAssignCodeGen(context).createFunction();
+        GetPiecewiseTriggerCodeGen(context).createFunction();
         EvalVolatileStoichCodeGen(context).createFunction();
         EvalConversionFactorCodeGen(context).createFunction();
 
@@ -252,7 +254,7 @@ namespace rrllvm {
         modelGeneratorContext->getJitNonOwning()->addModule();
 
         LLVMModelData* modelData = createModelData(modelGeneratorContext->getModelDataSymbols(),
-            modelGeneratorContext->getRandom());
+            modelGeneratorContext->getRandom(), modelGeneratorContext->getNumPiecewiseTriggers());
 
         uint llvmsize = ModelDataIRBuilder::getModelDataSize(
             modelGeneratorContext->getJitNonOwning()->getModuleNonOwning(),
@@ -520,7 +522,7 @@ namespace rrllvm {
 
             if (sp) {
                 rrLog(Logger::LOG_DEBUG) << "found a cached model for \"" << sbmlMD5 << "\"";
-                return new LLVMExecutableModel(sp, createModelData(*sp->symbols, sp->random));
+                return new LLVMExecutableModel(sp, createModelData(*sp->symbols, sp->random, 0));
             }
             else {
                 rrLog(Logger::LOG_DEBUG) << "no cached model found for " << sbmlMD5
@@ -611,7 +613,7 @@ namespace rrllvm {
         return str;
     }
 
-    LLVMModelData* createModelData(const rrllvm::LLVMModelDataSymbols& symbols, const Random* random) {
+    LLVMModelData* createModelData(const rrllvm::LLVMModelDataSymbols& symbols, const Random* random, uint numPiecewiseTriggers) {
         uint modelDataBaseSize = sizeof(LLVMModelData);
 
         uint numIndCompartments = static_cast<uint>(symbols.getIndependentCompartmentSize());
@@ -659,6 +661,7 @@ namespace rrllvm {
         modelData->numRateRules = numRateRules;
         modelData->numReactions = numReactions;
         modelData->numEvents = static_cast<uint>(symbols.getEventAttributes().size());
+        //modelData->numPiecewiseTriggers = numPiecewiseTriggers;
 
         // set the aliases to the offsets
         uint offset = 0;

--- a/source/llvm/ModelDataIRBuilder.cpp
+++ b/source/llvm/ModelDataIRBuilder.cpp
@@ -52,23 +52,23 @@ static bool isAliasOrPointer(ModelDataFields f)
 {
     /* Model Data alias are between one of the following values */
     /*
-    StateVector,                              // 13
-    StateVectorRate,                          // 14
-    RateRuleRates,                            // 15
-    FloatingSpeciesAmountRates,               // 16
+    StateVector,                              // 18
+    StateVectorRate,                          // 19
+    RateRuleRates,                            // 20
+    FloatingSpeciesAmountRates,               // 21
 
-    CompartmentVolumesAlias,                  // 17
-    CompartmentVolumesInitAlias,              // 18
-    FloatingSpeciesAmountsInitAlias,          // 19
-    ConservedSpeciesAmountsInitAlias,         // 20
-    BoundarySpeciesAmountsAlias,              // 21
-    BoundarySpeciesAmountsInitAlias,          // 22
-    GlobalParametersAlias,                    // 23
-    GlobalParametersInitAlias,                // 24
-    ReactionRatesAlias,                       // 25
+    CompartmentVolumesAlias,                  // 22
+    CompartmentVolumesInitAlias,              // 23
+    FloatingSpeciesAmountsInitAlias,          // 24
+    ConservedSpeciesAmountsInitAlias,         // 25
+    BoundarySpeciesAmountsAlias,              // 26
+    BoundarySpeciesAmountsInitAlias,          // 27
+    GlobalParametersAlias,                    // 28
+    GlobalParametersInitAlias,                // 29
+    ReactionRatesAlias,                       // 30
 
-    RateRuleValuesAlias,                      // 26
-    FloatingSpeciesAmountsAlias,              // 27
+    RateRuleValuesAlias,                      // 31
+    FloatingSpeciesAmountsAlias,              // 32
      */
     return f >= StateVector && f <= FloatingSpeciesAmountsAlias;
 }
@@ -687,34 +687,35 @@ llvm::StructType *ModelDataIRBuilder::createModelDataStructType(llvm::Module *mo
         elements.push_back(csrSparsePtrType); // 13     dcsr_matrix              stoichiometry;
         elements.push_back(voidPtrType);      // 14     void*                    random;
         elements.push_back(int32Type);        // 15     int                      numEvents;
-        elements.push_back(int32Type);        // 16     int                      stateVectorSize;
-        elements.push_back(doublePtrType);    // 17     double*                  stateVector;
-        elements.push_back(doublePtrType);    // 18     double*                  stateVectorRate;
-        elements.push_back(doublePtrType);    // 19     double*                  rateRuleRates;
-        elements.push_back(doublePtrType);    // 20     double*                  floatingSpeciesAmountRates;
+        //elements.push_back(int32Type);        // 16     int                      numPiecewiseTriggers;
+        elements.push_back(int32Type);        // 17     int                      stateVectorSize;
+        elements.push_back(doublePtrType);    // 18     double*                  stateVector;
+        elements.push_back(doublePtrType);    // 19     double*                  stateVectorRate;
+        elements.push_back(doublePtrType);    // 20     double*                  rateRuleRates;
+        elements.push_back(doublePtrType);    // 21     double*                  floatingSpeciesAmountRates;
 
-        elements.push_back(doublePtrType);    // 21     double*                  compartmentVolumesAlias;
-        elements.push_back(doublePtrType);    // 22     double*                  compartmentVolumesInitAlias;
-        elements.push_back(doublePtrType);    // 23     double*                  floatingSpeciesAmountsInitAlias
-        elements.push_back(doublePtrType);    // 24     double*                  boundarySpeciesAmountsAlias;
-        elements.push_back(doublePtrType);    // 25     double*                  boundarySpeciesAmountsInitAlias;
-        elements.push_back(doublePtrType);    // 26     double*                  globalParametersAlias
-        elements.push_back(doublePtrType);    // 27     double*                  globalParametersInitAlias
-        elements.push_back(doublePtrType);    // 28     double*                  reactionRatesAlias
+        elements.push_back(doublePtrType);    // 22     double*                  compartmentVolumesAlias;
+        elements.push_back(doublePtrType);    // 23     double*                  compartmentVolumesInitAlias;
+        elements.push_back(doublePtrType);    // 24     double*                  floatingSpeciesAmountsInitAlias
+        elements.push_back(doublePtrType);    // 25     double*                  boundarySpeciesAmountsAlias;
+        elements.push_back(doublePtrType);    // 26     double*                  boundarySpeciesAmountsInitAlias;
+        elements.push_back(doublePtrType);    // 27     double*                  globalParametersAlias
+        elements.push_back(doublePtrType);    // 28     double*                  globalParametersInitAlias
+        elements.push_back(doublePtrType);    // 29     double*                  reactionRatesAlias
 
-        elements.push_back(doublePtrType);    // 29     double*                  rateRuleValuesAlias
-        elements.push_back(doublePtrType);    // 30     double*                  floatingSpeciesAmountsAlias
+        elements.push_back(doublePtrType);    // 30     double*                  rateRuleValuesAlias
+        elements.push_back(doublePtrType);    // 31     double*                  floatingSpeciesAmountsAlias
 
-        elements.push_back(ArrayType::get(doubleType, numIndCompartments));     // 31 CompartmentVolumes
-        elements.push_back(ArrayType::get(doubleType, numInitCompartments));    // 32 initCompartmentVolumes
-        elements.push_back(ArrayType::get(doubleType, numInitFloatingSpecies)); // 33 initFloatingSpeciesAmounts
-        elements.push_back(ArrayType::get(doubleType, numIndBoundarySpecies));  // 34 boundarySpeciesAmounts
-        elements.push_back(ArrayType::get(doubleType, numInitBoundarySpecies)); // 35 initBoundarySpeciesAmounts
-        elements.push_back(ArrayType::get(doubleType, numIndGlobalParameters)); // 36 globalParameters
-        elements.push_back(ArrayType::get(doubleType, numInitGlobalParameters));// 37 initGlobalParameters
-        elements.push_back(ArrayType::get(doubleType, numReactions));           // 38 reactionRates
-        elements.push_back(ArrayType::get(doubleType, numRateRules));           // 39 rateRuleValues
-        elements.push_back(ArrayType::get(doubleType, numIndFloatingSpecies));  // 40 floatingSpeciesAmounts
+        elements.push_back(ArrayType::get(doubleType, numIndCompartments));     // 32 CompartmentVolumes
+        elements.push_back(ArrayType::get(doubleType, numInitCompartments));    // 33 initCompartmentVolumes
+        elements.push_back(ArrayType::get(doubleType, numInitFloatingSpecies)); // 34 initFloatingSpeciesAmounts
+        elements.push_back(ArrayType::get(doubleType, numIndBoundarySpecies));  // 35 boundarySpeciesAmounts
+        elements.push_back(ArrayType::get(doubleType, numInitBoundarySpecies)); // 36 initBoundarySpeciesAmounts
+        elements.push_back(ArrayType::get(doubleType, numIndGlobalParameters)); // 37 globalParameters
+        elements.push_back(ArrayType::get(doubleType, numInitGlobalParameters));// 38 initGlobalParameters
+        elements.push_back(ArrayType::get(doubleType, numReactions));           // 39 reactionRates
+        elements.push_back(ArrayType::get(doubleType, numRateRules));           // 40 rateRuleValues
+        elements.push_back(ArrayType::get(doubleType, numIndFloatingSpecies));  // 41 floatingSpeciesAmounts
 
         // creates a named struct,
         // the act of creating a named struct should
@@ -954,377 +955,6 @@ llvm::Function* LLVMModelDataIRBuilderTesting::getDispIntDecl(llvm::Module* modu
     }
     return f;
 }
-
-
-
-
-void LLVMModelDataIRBuilderTesting::test(Module *module, IRBuilder<> *build,
-        ExecutionEngine * engine)
-{
-//    TheModule = module;
-//    context = &module->getContext();
-//    rr::builder = build;
-//    TheExecutionEngine = engine;
-//    createDispPrototypes();
-//
-//    callDispInt(23);
-//
-//    structSetProto();
-//
-//    TestStruct s =
-//    { 0 };
-//
-//    s.var3 = (char*) calloc(50, sizeof(char));
-//    s.var5 = (char*) calloc(50, sizeof(char));
-//
-//    sprintf(s.var5, "1234567890");
-//
-//    char* p = (char*) calloc(50, sizeof(char));
-//
-//    dispStruct(&s);
-//
-//    callStructSet(&s, 314, 3.14, 2.78, p, 0, 0);
-//
-//    printf("p: %s\n", p);
-//
-//    dispStruct(&s);
-//
-//    printf("new var5: ");
-//    for (int i = 0; i < 10; i++)
-//    {
-//        printf("{i:%i,c:%i}, ", i, s.var5[i]);
-//    }
-//    printf("\n");
-}
-
-
-
-
-//
-//
-//static Module *TheModule;
-//static IRBuilder<> *builder;
-//static ExecutionEngine *TheExecutionEngine;
-//static LLVMContext *context;
-//
-//static LLVMContext &getContext() {
-//    return *context;
-//}
-//
-//Value *storeInStruct(IRBuilder<> *B, Value *S, Value *V, unsigned index, const char* s = "");
-//Value *loadFromStruct(IRBuilder<> *B, Value *S, unsigned index, const char* s = "");
-//
-//struct TestStruct {
-//    int var0;
-//    double var1;
-//    double var2;
-//    char* var3;
-//    double var4;
-//    char* var5;
-//};
-//
-//StructType* getTestStructType() {
-//    // static StructType *     create (ArrayRef< Type * > Elements, StringRef Name, bool isPacked=false)
-//    std::vector<Type*> elements;
-//    elements.push_back(Type::getInt32Ty(getContext()));   // int var0;
-//    elements.push_back(Type::getDoubleTy(getContext()));  // double var1;
-//    elements.push_back(Type::getDoubleTy(getContext()));  // double var2;
-//    //elements.push_back(ArrayType::get(Type::getInt8Ty(getContext()), 0)); // char* var3;
-//    elements.push_back(Type::getInt8PtrTy(getContext())); // char* var5;
-//    elements.push_back(Type::getDoubleTy(getContext()));  // double var4;
-//    //elements.push_back(ArrayType::get(Type::getInt8Ty(getContext()), 0));   // char[] var5;
-//    elements.push_back(Type::getInt8PtrTy(getContext())); // char* var5; // char* var5;
-//
-//
-//
-//
-//    StructType *s = StructType::create(elements, "TestStruct");
-//
-//    const DataLayout &dl = *TheExecutionEngine->getDataLayout();
-//
-//    size_t llvm_size = dl.getTypeStoreSize(s);
-//
-//    printf("TestStruct size: %i, , LLVM Size: %i\n", sizeof(TestStruct), llvm_size);
-//
-//
-//
-//    return s;
-//}
-//
-//Value *getVar5(Value *testStructPtr, int index) {
-//    GetElementPtrInst *gep = dyn_cast<GetElementPtrInst>(builder->CreateStructGEP(testStructPtr, 5, "var5_gep"));
-//    LoadInst * var5_load = builder.CreateLoad(gep, "var5_load");
-//    //Value *var5_load = loadFromStruct(Builder, testStructPtr, 5, "var5");
-//    gep = dyn_cast<GetElementPtrInst>(builder->CreateConstGEP1_32(var5_load, index, "var5_elem_gep"));
-//    return builder.CreateLoad(gep, "var5_elem");
-//}
-//
-//
-//static void dispStruct(TestStruct *s)
-//{
-//    printf("%s {\n",  __PRETTY_FUNCTION__);
-//    printf("\tvar0: %i\n", s->var0);
-//    printf("\tvar1: %f\n", s->var1);
-//    printf("\tvar2: %f\n", s->var2);
-//    printf("\tvar3: %s\n", s->var3);
-//    printf("\tvar4: %f\n", s->var4);
-//    printf("\tvar5: %s\n", s->var5);
-//    printf("}\n");
-//
-//
-//}
-//
-//static Function* dispStructProto() {
-//
-//    StructType *structType = getTestStructType();
-//    PointerType *structTypePtr = llvm::PointerType::get(structType, 0);
-//    std::vector<Type*> args(1, structTypePtr);
-//    FunctionType *funcType = FunctionType::get(Type::getVoidTy(getContext()), args, false);
-//    Function *f = Function::Create(funcType, Function::InternalLinkage, "dispStruct", TheModule);
-//    return f;
-//}
-//
-//static void dispInt(int i) {
-//    printf("%s, %i\n", __PRETTY_FUNCTION__, i);
-//}
-//
-
-//
-//static void callDispInt(int val) {
-//    // Evaluate a top-level expression into an anonymous function.
-//
-//    Function *func = TheExecutionEngine->FindFunctionNamed("dispInt");
-//
-//    // JIT the function, returning a function pointer.
-//    void *fptr = TheExecutionEngine->getPointerToFunction(func);
-//
-//    // Cast it to the right type (takes no arguments, returns a double) so we
-//    // can call it as a native function.
-//    void (*fp)(int) = (void (*)(int))fptr;
-//
-//    fp(val);
-//}
-//
-//
-//
-
-//
-//static void dispCharStar(char* p) {
-//    printf("%s: %s\n", __PRETTY_FUNCTION__, p);
-//}
-//
-//static Function* dispCharStarProto() {
-//    Function *f = TheModule->getFunction("dispCharStar");
-//    if (f == 0) {
-//        std::vector<Type*>args(1, Type::getInt8PtrTy(getContext()));
-//        FunctionType *funcType = FunctionType::get(Type::getVoidTy(getContext()), args, false);
-//        f = Function::Create(funcType, Function::InternalLinkage, "dispCharStar", TheModule);
-//    }
-//    return f;
-//}
-//
-//static void dispChar(char p) {
-//    printf("%s as char: %c\n", __PRETTY_FUNCTION__, p);
-//    printf("%s as int: %i\n", __PRETTY_FUNCTION__, (int)p);
-//}
-//
-//static Function* dispCharProto() {
-//    Function *f = TheModule->getFunction("dispChar");
-//    if (f == 0) {
-//        std::vector<Type*>args(1, Type::getInt8Ty(getContext()));
-//        FunctionType *funcType = FunctionType::get(Type::getVoidTy(getContext()), args, false);
-//        f = Function::Create(funcType, Function::InternalLinkage, "dispChar", TheModule);
-//    }
-//    return f;
-//}
-//
-//static void createDispPrototypes() {
-//    TheExecutionEngine->addGlobalMapping(dispStructProto(), (void*)dispStruct);
-//    TheExecutionEngine->addGlobalMapping(dispIntProto(), (void*)dispInt);
-//    TheExecutionEngine->addGlobalMapping(dispDoubleProto(), (void*)dispDouble);
-//    TheExecutionEngine->addGlobalMapping(dispCharStarProto(), (void*)dispCharStar);
-//    TheExecutionEngine->addGlobalMapping(dispCharProto(), (void*)dispChar);
-//}
-//
-//static void structSetBody(Function *func) {
-//    // Create a new basic block to start insertion into.
-//    BasicBlock *BB = BasicBlock::Create(getContext(), "entry", func);
-//    builder.SetInsertPoint(BB);
-//
-//    LLVMContext &context = getContext();
-//
-//    std::vector<Value*> args;
-//
-//    // Set names for all arguments.
-//    unsigned idx = 0;
-//    for (Function::arg_iterator ai = func->arg_begin(); ai != func->arg_end();
-//            ++ai, ++idx) {
-//
-//        args.push_back(ai);
-//        //ai->setName(Args[Idx]);
-//
-//        // Add arguments to variable symbol table.
-//        //NamedValues[Args[Idx]] = AI;
-//    }
-//
-//    Value *arg = ConstantInt::get(Type::getInt32Ty(getContext()), 16);
-//
-//    builder.CreateCall(dispIntProto(), args[1], "");
-//
-//    builder.CreateCall(dispDoubleProto(), args[2], "");
-//
-//    //builder->CreateCall(dispDoubleProto(), args[3], "");
-//
-//    builder.CreateCall(dispCharStarProto(), args[4], "");
-//
-//    storeInStruct(builder, args[0], args[1], 0);
-//    storeInStruct(builder, args[0], args[2], 1);
-//    storeInStruct(builder, args[0], args[3], 2);
-//    storeInStruct(builder, args[0], args[5], 4);
-//
-//
-//
-//    Value *var3 = loadFromStruct(builder, args[0], 3, "var3");
-//
-//    //Value *var3 = args[4];
-//
-//    Type *t = var3->getType();
-//
-//    var3->dump();
-//    t->dump();
-//
-//
-//    Value *c = ConstantInt::get(Type::getInt8Ty(getContext()), 's');
-//    Value *gep = builder.CreateConstGEP1_32(var3, 0, "array gep");
-//    builder.CreateStore(c, gep);
-//    gep = builder.CreateConstGEP1_32(var3, 1, "array gep");
-//    builder.CreateStore(c, gep);
-//    gep = builder.CreateConstGEP1_32(var3, 2, "array gep");
-//    builder.CreateStore(c, gep);
-//
-//
-//    c = ConstantInt::get(Type::getInt8Ty(getContext()), '2');
-//
-//    Value *var5_2 = getVar5(args[0], 2);
-//
-//    var5_2->dump();
-//
-//    builder.CreateCall(dispCharProto(), var5_2);
-//
-//
-//
-//    builder.CreateCall(dispCharStarProto(), args[4], "");
-//
-//
-//
-//
-//    // Finish off the function.
-//    builder.CreateRetVoid();
-//
-//    // Validate the generated code, checking for consistency.
-//    verifyFunction(*func);
-//}
-//
-//static Function* structSetProto() {
-//    Function *f = TheModule->getFunction("structSet");
-//
-//    if (f == 0) {
-//        std::vector<Type*> args;
-//        StructType *structType = getTestStructType();
-//        PointerType *structTypePtr = llvm::PointerType::get(structType, 0);
-//        args.push_back(structTypePtr);
-//        args.push_back(Type::getInt32Ty(getContext()));   // int var0;
-//        args.push_back(Type::getDoubleTy(getContext()));  // double var1;
-//        args.push_back(Type::getDoubleTy(getContext()));  // double var2;
-//        args.push_back(Type::getInt8PtrTy(getContext())); // char* var3;
-//        args.push_back(Type::getDoubleTy(getContext()));  // double var4;
-//        args.push_back(Type::getInt8PtrTy(getContext())); // char* var5;
-//
-//        FunctionType *funcType = FunctionType::get(Type::getVoidTy(getContext()), args, false);
-//        f = Function::Create(funcType, Function::InternalLinkage, "structSet", TheModule);
-//
-//
-//        structSetBody(f);
-//
-//    }
-//    return f;
-//}
-//
-//static void callStructSet(TestStruct *s, int var0, double var1, double var2,
-//        char* var3, double var4, char* var5)
-//{
-//    Function *func = TheExecutionEngine->FindFunctionNamed("structSet");
-//
-//    // JIT the function, returning a function pointer.
-//    void *fptr = TheExecutionEngine->getPointerToFunction(func);
-//
-//    // Cast it to the right type (takes no arguments, returns a double) so we
-//    // can call it as a native function.
-//    void (*fp)(TestStruct*, int, double, double, char*, double, char*) =
-//            (void (*)(TestStruct*, int, double, double,char*, double, char*))fptr;
-//
-//    fp(s, var0, var1, var2, var3, var4, var5);
-//
-//
-//
-//}
-//
-//
-//
-//// Store V in structure S element index
-//Value *storeInStruct(IRBuilder<> *B, Value *S, Value *V, unsigned index, const char* s)
-//{
-//    return B->CreateStore(V, B->CreateStructGEP(S, index, s), s);
-//}
-//
-//// Store V in structure S element index
-//Value *loadFromStruct(IRBuilder<> *B, Value *S, unsigned index, const char* s)
-//{
-//    Value *gep = B->CreateStructGEP(S, index, s);
-//    return B->CreateLoad(gep, s);
-//}
-//
-//void dispIntrinsics(Intrinsic::ID id) {
-//    Intrinsic::IITDescriptor ids[8];
-//    SmallVector<Intrinsic::IITDescriptor, 8> table;
-//    Intrinsic::getIntrinsicInfoTableEntries(id, table);
-//
-//    printf("table: %i\n", table.size());
-//
-//    for(unsigned i = 0; i < table.size(); i++) {
-//        ids[i] = table[i];
-//    }
-//
-//    for(unsigned i = 0; i < table.size(); i++) {
-//        Intrinsic::IITDescriptor::IITDescriptorKind kind = ids[i].Kind;
-//        Intrinsic::IITDescriptor::ArgKind argKind = ids[i].getArgumentKind();
-//        unsigned argNum = ids[i].getArgumentNumber();
-//
-//        printf("kind: %i, argKind: %i, argNum: %i\n", kind, argKind, argNum);
-//
-//    }
-//
-//    printf("foo\n");
-//
-//    std::vector<Type*> args(table.size() - 1, Type::getDoubleTy(getContext()));
-//
-//    printf("intrinsic name: %s\n", getName(id, args).c_str());
-//
-//    Function *decl = Intrinsic::getDeclaration(TheModule, id, args);
-//    decl->dump();
-//
-//    FunctionType *func = Intrinsic::getType(getContext(), id, args);
-//
-//    func->dump();
-//
-//    printf("done\n");
-//
-//
-//
-//
-//
-//    //func->dump();
-//}
 
 
 } /* namespace rr */

--- a/source/llvm/ModelDataIRBuilder.cpp
+++ b/source/llvm/ModelDataIRBuilder.cpp
@@ -52,23 +52,22 @@ static bool isAliasOrPointer(ModelDataFields f)
 {
     /* Model Data alias are between one of the following values */
     /*
-    StateVector,                              // 18
-    StateVectorRate,                          // 19
-    RateRuleRates,                            // 20
-    FloatingSpeciesAmountRates,               // 21
+        "StateVector",                          // 18
+        "StateVectorRate",                      // 19
+        "RateRuleRates",                        // 20
+        "FloatingSpeciesAmountRates",           // 21
 
-    CompartmentVolumesAlias,                  // 22
-    CompartmentVolumesInitAlias,              // 23
-    FloatingSpeciesAmountsInitAlias,          // 24
-    ConservedSpeciesAmountsInitAlias,         // 25
-    BoundarySpeciesAmountsAlias,              // 26
-    BoundarySpeciesAmountsInitAlias,          // 27
-    GlobalParametersAlias,                    // 28
-    GlobalParametersInitAlias,                // 29
-    ReactionRatesAlias,                       // 30
+        "CompartmentVolumesAlias",              // 22
+        "InitCompartmentVolumesAlias",          // 23
+        "InitFloatingSpeciesAmountsAlias",      // 24
+        "BoundarySpeciesAmountsAlias",          // 25
+        "InitBoundarySpeciesAmountsAlias",      // 26
+        "GlobalParametersAlias",                // 27
+        "InitGlobalParametersAlias",            // 28
+        "ReactionRatesAlias",                   // 29
 
-    RateRuleValuesAlias,                      // 31
-    FloatingSpeciesAmountsAlias,              // 32
+        "RateRuleValuesAlias",                  // 30
+        "FloatingSpeciesAmountsAlias",          // 31
      */
     return f >= StateVector && f <= FloatingSpeciesAmountsAlias;
 }
@@ -77,17 +76,16 @@ static bool isArray(ModelDataFields f)
 {
     /* arrays are the last elements in the model data struct */
     /*
-     CompartmentVolumes,                       // 28
-     CompartmentVolumesInit,                   // 29
-     FloatingSpeciesAmounts,                   // 30
-     FloatingSpeciesAmountsInit,               // 31
-     ConservedSpeciesAmountsInit,              // 32
-     BoundarySpeciesAmounts,                   // 33
-     BoundarySpeciesAmountsInit,               // 34
-     GlobalParameters,                         // 35
-     GlobalParametersInit,                     // 36
-     RateRuleValues,                           // 37
-     ReactionRates,                            // 38
+        "CompartmentVolumes",                   // 32
+        "InitCompartmentVolumes",               // 33
+        "InitFloatingSpeciesAmounts",           // 34
+        "BoundarySpeciesAmounts",               // 35
+        "InitBoundarySpeciesAmounts",           // 36
+        "GlobalParameters",                     // 37
+        "InitGlobalParameters",                 // 38
+        "ReactionRates",                        // 39
+        "NotSafe_RateRuleValues",               // 40
+        "NotSafe_FloatingSpeciesAmounts"        // 41
      */
 
     return f >= CompartmentVolumes && f <= NotSafe_FloatingSpeciesAmounts;
@@ -687,7 +685,7 @@ llvm::StructType *ModelDataIRBuilder::createModelDataStructType(llvm::Module *mo
         elements.push_back(csrSparsePtrType); // 13     dcsr_matrix              stoichiometry;
         elements.push_back(voidPtrType);      // 14     void*                    random;
         elements.push_back(int32Type);        // 15     int                      numEvents;
-        //elements.push_back(int32Type);        // 16     int                      numPiecewiseTriggers;
+        elements.push_back(int32Type);        // 16     int                      numPiecewiseTriggers;
         elements.push_back(int32Type);        // 17     int                      stateVectorSize;
         elements.push_back(doublePtrType);    // 18     double*                  stateVector;
         elements.push_back(doublePtrType);    // 19     double*                  stateVectorRate;

--- a/source/llvm/ModelDataIRBuilder.h
+++ b/source/llvm/ModelDataIRBuilder.h
@@ -380,9 +380,6 @@ namespace rrllvm
         std::pair<llvm::Function*, llvm::Function*> createFloatingSpeciesAccessors(
             llvm::Module* module, const std::string id);
 
-        void test(llvm::Module* module, llvm::IRBuilder<>* build,
-            llvm::ExecutionEngine* engine);
-
 
         static llvm::Function* getDispIntDecl(llvm::Module* module);
         llvm::CallInst* createDispInt(llvm::Value* intVal);

--- a/source/llvm/ModelGeneratorContext.cpp
+++ b/source/llvm/ModelGeneratorContext.cpp
@@ -28,8 +28,10 @@
 #include "llvm/IR/DataLayout.h"
 #include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/DynamicLibrary.h"
-//#include "llvm/ExecutionEngine/OrcMCJITReplacement.h"
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
+
+#include <sbml/math/ASTNodeType.h>
+#include <sbml/conversion/SBMLFunctionDefinitionConverter.h>
 
 
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
@@ -108,6 +110,7 @@ namespace rrllvm {
             :
             ownedDoc(nullptr),
             doc(nullptr),
+            mPiecewiseTriggers(),
             symbols(nullptr),
             options(options),
             random(nullptr),
@@ -161,6 +164,8 @@ namespace rrllvm {
 
             model = doc->getModel();
 
+            addAllPiecewiseTriggers(model);
+
             symbols = new LLVMModelDataSymbols(doc->getModel(), options);
 
             modelSymbols = std::make_unique<LLVMModelSymbols>(getModel(), *symbols);
@@ -207,6 +212,7 @@ namespace rrllvm {
     ModelGeneratorContext::ModelGeneratorContext() :
             ownedDoc(createEmptyDocument()),
             doc(ownedDoc),
+            mPiecewiseTriggers(),
             symbols(new LLVMModelDataSymbols(doc->getModel(), 0)),
             modelSymbols(new LLVMModelSymbols(getModel(), *symbols)),
             options(0)
@@ -216,16 +222,139 @@ namespace rrllvm {
         InitializeNativeTarget();
         InitializeNativeTargetAsmPrinter();
         InitializeNativeTargetAsmParser();
-
     }
 
     Random *ModelGeneratorContext::getRandom() const {
         return random;
     }
 
+    void ModelGeneratorContext::addAllPiecewiseTriggers(const libsbml::Model* model)
+    {
+        clearPiecewiseTriggers();
+
+        //If there are piecewise functions in function definitions, we need to convert the document to not have function definitions any more (sigh)
+        for (size_t fd = 0; fd < model->getNumFunctionDefinitions(); fd++) {
+            if (containsPiecewise(model->getFunctionDefinition(fd)->getMath())) {
+                libsbml::SBMLFunctionDefinitionConverter converter;
+                SBMLDocument doc(model->getLevel(), model->getVersion());
+                doc.setModel(model);
+                converter.setDocument(&doc);
+                if (converter.convert() == LIBSBML_OPERATION_SUCCESS) {
+                    return addAllPiecewiseTriggers(doc.getModel());
+                }
+                //Otherwise, I suppose we just continue?
+                rrLog(Logger::LOG_WARNING) << "A piecewise function was discovered in a function definition, but we were unable to convert the document to remove function definitions.  Any transitions in those piecewise functions may not be noticed by the simulator.";
+            }
+        }
+
+        //Only worry about piecewise functions in continuous contexts:  initial assignments and event assignments are fine, because we don't need to stop simulation to check things; the assignment is already happening when simulation is stopped.
+        for (size_t r = 0; r < model->getNumRules(); r++) {
+            //We don't care whether the rule is assignment, rate, or even algebraic; we're just looking for piecewise functions.
+            const libsbml::Rule* rule = model->getRule(r);
+            const ASTNode* node = rule->getMath();
+            addPiecewiseTriggersFrom(node);
+        }
+        for (size_t r = 0; r < model->getNumReactions(); r++) {
+            const libsbml::Reaction* rxn = model->getReaction(r);
+            if (rxn->isSetKineticLaw()) {
+                addPiecewiseTriggersFrom(rxn->getKineticLaw()->getMath());
+            }
+        }
+        //Event triggers themselves might have piecewise arguments in them:
+        for (size_t e = 0; e < model->getNumEvents(); e++) {
+            const libsbml::Event* event = model->getEvent(e);
+            if (event->isSetTrigger()) {
+                addPiecewiseTriggersFrom(event->getTrigger()->getMath());
+            }
+        }
+    }
+
+    void ModelGeneratorContext::addPiecewiseTriggersFrom(const libsbml::ASTNode* node)
+    {
+        if (node == NULL) {
+            return;
+        }
+        if (node->getType() == libsbml::AST_FUNCTION_PIECEWISE) {
+            // The format of the piecewise function is (val1, cond1, val2, cond2, ..., val_otherwise).  They're checked sequentially, so if cond1 is true, val1 is always returned, and if cond1 is false but cond2 is true, val2 is returned, etc.  This means the value returned is dependent on the following conditions:
+            // cond1
+            // cond2 && (!cond1)
+            // cond3 && (!cond1 && !cond2)
+            // ...
+            // !cond1 && !cond2 && !cond3  && ...
+
+            // None of the values need to be checked, just the conditions.  Hence:
+            std::vector<const libsbml::ASTNode*> conditions;
+            for (size_t c = 1; c < node->getNumChildren(); c += 2) {
+                conditions.push_back(node->getChild(c));
+            }
+            for (size_t c = 0; c < conditions.size(); c++) {
+                std::vector<const libsbml::ASTNode*> nots;
+                for (size_t n = 0; n < c; n++) {
+                    nots.push_back(conditions[n]);
+                }
+                if (nots.size() > 0) {
+                    libsbml::ASTNode* root = new libsbml::ASTNode(libsbml::AST_LOGICAL_AND);
+                    root->addChild(conditions[c]->deepCopy());
+                    for (size_t n = 0; n < nots.size(); n++) {
+                        libsbml::ASTNode* child_not = new libsbml::ASTNode(libsbml::AST_LOGICAL_NOT);
+                        child_not->addChild(nots[n]->deepCopy());
+                        root->addChild(child_not);
+                    }
+                    mPiecewiseTriggers.push_back(root);
+                }
+                else {
+                    mPiecewiseTriggers.push_back(conditions[c]->deepCopy());
+                }
+            }
+            //If there's an 'otherwise', we need an all-nots trigger:
+            if (node->getNumChildren() % 2 == 1) {
+                libsbml::ASTNode* root = new libsbml::ASTNode(libsbml::AST_LOGICAL_AND);
+                for (size_t c = 0; c < conditions.size(); c++) {
+                    libsbml::ASTNode* child_not = new libsbml::ASTNode(libsbml::AST_LOGICAL_NOT);
+                    child_not->addChild(conditions[c]->deepCopy());
+                    root->addChild(child_not);
+                }
+                mPiecewiseTriggers.push_back(root);
+            }
+        }
+
+        //Not 'else', since a piecewise function can have piecewise children.
+        for (size_t c = 0; c < node->getNumChildren(); c++) {
+            const ASTNode* child = node->getChild(c);
+            addPiecewiseTriggersFrom(child);
+        }
+    }
+
+    bool ModelGeneratorContext::containsPiecewise(const libsbml::ASTNode* node)
+    {
+        if (node == NULL) {
+            return false;
+        }
+        if (node->getType() == libsbml::AST_FUNCTION_PIECEWISE) {
+            return true;
+        }
+
+        for (size_t c = 0; c < node->getNumChildren(); c++) {
+            if (containsPiecewise(node->getChild(c))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    void ModelGeneratorContext::clearPiecewiseTriggers()
+    {
+        for (size_t pt = 0; pt < mPiecewiseTriggers.size(); pt++) {
+            delete mPiecewiseTriggers[pt];
+        }
+        mPiecewiseTriggers.clear();
+    }
+
     void ModelGeneratorContext::cleanup() {
         delete ownedDoc;
         ownedDoc = 0;
+        clearPiecewiseTriggers();
     }
 
     ModelGeneratorContext::~ModelGeneratorContext() {
@@ -246,6 +375,11 @@ namespace rrllvm {
 
     const libsbml::Model *ModelGeneratorContext::getModel() const {
         return doc->getModel();
+    }
+
+    const std::vector<libsbml::ASTNode*>* ModelGeneratorContext::getPiecewiseTriggers() const
+    {
+        return &mPiecewiseTriggers;
     }
 
     void ModelGeneratorContext::transferObjectsToResources(std::shared_ptr<rrllvm::ModelResources> modelResources) {

--- a/source/llvm/ModelGeneratorContext.cpp
+++ b/source/llvm/ModelGeneratorContext.cpp
@@ -210,29 +210,12 @@ namespace rrllvm {
             symbols(new LLVMModelDataSymbols(doc->getModel(), 0)),
             modelSymbols(new LLVMModelSymbols(getModel(), *symbols)),
             options(0)
-//        functionPassManager(0)
     {
         // initialize LLVM
         // TODO check result
         InitializeNativeTarget();
         InitializeNativeTargetAsmPrinter();
         InitializeNativeTargetAsmParser();
-
-//    context = std::unique_ptr<LLVMContext>();
-//    // Make the module, which holds all the code.
-//    module_owner = std::unique_ptr<Module>(new Module("LLVM Module", *context));
-//	module = module_owner.get();
-//
-//    builder = std::make_unique<IRBuilder<>>(*context);
-//
-//    errString = new std::string();
-//
-//	addGlobalMappings();
-//
-//    EngineBuilder engineBuilder(std::move(module_owner));
-//    //engineBuilder.setEngineKind(EngineKind::JIT);
-//    engineBuilder.setErrorStr(errString);
-//    executionEngine = std::unique_ptr<llvm::ExecutionEngine>(engineBuilder.create());
 
     }
 
@@ -243,23 +226,11 @@ namespace rrllvm {
     void ModelGeneratorContext::cleanup() {
         delete ownedDoc;
         ownedDoc = 0;
-//    delete errString; errString = 0;
     }
-
 
     ModelGeneratorContext::~ModelGeneratorContext() {
         cleanup();
     }
-
-//llvm::LLVMContext &ModelGeneratorContext::getContext() const
-//{
-//    return *context;
-//}
-//
-//llvm::ExecutionEngine &ModelGeneratorContext::getExecutionEngine() const
-//{
-//    return *executionEngine;
-//}
 
     const LLVMModelDataSymbols &ModelGeneratorContext::getModelDataSymbols() const {
         return *symbols;
@@ -269,26 +240,13 @@ namespace rrllvm {
         return doc;
     }
 
-
     Jit *ModelGeneratorContext::getJitNonOwning() const {
         return jit.get();
     }
 
-
     const libsbml::Model *ModelGeneratorContext::getModel() const {
         return doc->getModel();
     }
-
-
-//llvm::Module *ModelGeneratorContext::getModule() const
-//{
-//	return jit->getModuleNonOwning();
-//}
-//
-//llvm::IRBuilder<> &ModelGeneratorContext::getBuilder() const
-//{
-//    return *jit->getBuilderNonOwning();
-//}
 
     void ModelGeneratorContext::transferObjectsToResources(std::shared_ptr<rrllvm::ModelResources> modelResources) {
         modelResources->symbols = symbols;
@@ -299,14 +257,6 @@ namespace rrllvm {
 
         modelResources->random = random;
         random = nullptr;
-
-//    modelResources->context = std::move(context);
-//    context = nullptr;
-//    modelResources->executionEngine = std::move(executionEngine);
-//    executionEngine = nullptr;
-//
-//	modelResources->errStr = errString;
-//    errString = nullptr;
     }
 
     const LLVMModelSymbols &ModelGeneratorContext::getModelSymbols() const {
@@ -320,7 +270,6 @@ namespace rrllvm {
     bool ModelGeneratorContext::useSymbolCache() const {
         return (options & LoadSBMLOptions::LLVM_SYMBOL_CACHE) != 0;
     }
-
 
     static SBMLDocument *checkedReadSBMLFromString(const char *xml) {
         SBMLDocument *doc = readSBMLFromString(xml);

--- a/source/llvm/ModelGeneratorContext.cpp
+++ b/source/llvm/ModelGeneratorContext.cpp
@@ -382,6 +382,11 @@ namespace rrllvm {
         return &mPiecewiseTriggers;
     }
 
+    size_t ModelGeneratorContext::getNumPiecewiseTriggers() const
+    {
+        return mPiecewiseTriggers.size();
+    }
+
     void ModelGeneratorContext::transferObjectsToResources(std::shared_ptr<rrllvm::ModelResources> modelResources) {
         modelResources->symbols = symbols;
         symbols = nullptr;

--- a/source/llvm/ModelGeneratorContext.h
+++ b/source/llvm/ModelGeneratorContext.h
@@ -122,6 +122,8 @@ namespace rrllvm {
 
         const std::vector<libsbml::ASTNode*>* getPiecewiseTriggers() const;
 
+        size_t getNumPiecewiseTriggers() const;
+
         Jit *getJitNonOwning() const;
 
         /**
@@ -159,7 +161,7 @@ namespace rrllvm {
 
         /**
          * these point to the same location, ownedDoc is set if we create the doc,
-         * otherwise its nullptr, meaning we're borrowing the the doc.
+         * otherwise its nullptr, meaning we're borrowing the doc.
          */
         libsbml::SBMLDocument *ownedDoc;
 
@@ -245,7 +247,7 @@ namespace rrllvm {
     };
 
 
-    LLVMModelData *createModelData(const rrllvm::LLVMModelDataSymbols &symbols, const Random *random);
+    LLVMModelData *createModelData(const rrllvm::LLVMModelDataSymbols &symbols, const Random *random, uint numPiecewiseTriggers);
 
 
 } /* namespace rr */

--- a/source/llvm/ModelGeneratorContext.h
+++ b/source/llvm/ModelGeneratorContext.h
@@ -120,25 +120,9 @@ namespace rrllvm {
 
         const libsbml::Model *getModel() const;
 
+        const std::vector<libsbml::ASTNode*>* getPiecewiseTriggers() const;
+
         Jit *getJitNonOwning() const;
-
-        /**
-         * nearly all llvm functions expect a pointer to module, so we define this
-         * as a pointer type instead of reference, even though we gaurantee this to
-         * be non-null
-         */
-//        llvm::Module *getModule() const;
-
-        /**
-         * if optimization is enabled, this gets the function pass
-         * manager loaded with all the requested optimizers.
-         * NULL if no optimization is specified.
-         *
-         * @return a borrowed reference that is owned by ModelGeneratorContext
-         */
-//        llvm::legacy::FunctionPassManager* getFunctionPassManager() const;
-
-//        llvm::IRBuilder<> &getBuilder() const;
 
         /**
          * A lot can go wrong in the process of generating a model from  an sbml doc.
@@ -183,6 +167,8 @@ namespace rrllvm {
          * always references the sbml doc.
          */
         const libsbml::SBMLDocument *doc;
+
+        std::vector<libsbml::ASTNode*> mPiecewiseTriggers;
 
         const LLVMModelDataSymbols *symbols;
 
@@ -231,6 +217,26 @@ namespace rrllvm {
          * converted document.
          */
         std::unique_ptr<rr::conservation::ConservedMoietyConverter> moietyConverter;
+
+        /**
+         * Get all transitions from any piecewise equations in the model.
+         */
+        void addAllPiecewiseTriggers(const libsbml::Model* model);
+
+        /**
+         * Get all transitions from any piecewise equations in the model.
+         */
+        void addPiecewiseTriggersFrom(const libsbml::ASTNode* node);
+
+        /**
+         * Get all transitions from any piecewise equations in the model.
+         */
+        bool containsPiecewise(const libsbml::ASTNode* node);
+
+        /**
+         * Delete any piecewise trigger nodes (which we own)
+         */
+        void clearPiecewiseTriggers();
 
         /**
          * free any memory this class allocated.

--- a/source/llvm/ModelResources.h
+++ b/source/llvm/ModelResources.h
@@ -61,6 +61,7 @@ namespace rrllvm
         GetEventDelayCodeGen::FunctionPtr getEventDelayPtr;
         EventTriggerCodeGen::FunctionPtr eventTriggerPtr;
         EventAssignCodeGen::FunctionPtr eventAssignPtr;
+        GetPiecewiseTriggerCodeGen::FunctionPtr getPiecewiseTriggerPtr;
         EvalVolatileStoichCodeGen::FunctionPtr evalVolatileStoichPtr;
         EvalConversionFactorCodeGen::FunctionPtr evalConversionFactorPtr;
         SetBoundarySpeciesAmountCodeGen::FunctionPtr setBoundarySpeciesAmountPtr;

--- a/source/rrExecutableModel.h
+++ b/source/rrExecutableModel.h
@@ -853,6 +853,13 @@ namespace rr {
         virtual void resetEvents() = 0;
 
         /**
+         * We do root-finding for 'piecewise triggers': those times in a piecewise function that transition from one condition to the next.
+         */
+        virtual int getNumPiecewiseTriggers() = 0;
+
+
+
+        /**
          * need a virtual destructor as object implementing this interface
          * can be deleted directly, i.e.
          * ExecutableModel *p = createModel(...);

--- a/source/rrExecutableModel.h
+++ b/source/rrExecutableModel.h
@@ -846,6 +846,8 @@ namespace rr {
          */
         virtual void getEventRoots(double time, const double *y, double *gdot) = 0;
 
+        virtual void getPiecewiseTriggerRoots(double time, const double* y, double* gdot) = 0;
+
         virtual double getNextPendingEventTime(bool pop) = 0;
 
         virtual int getPendingEventSize() = 0;

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1511,7 +1511,7 @@ namespace rr {
     bool RoadRunner::clearModel() {
         // The model owns the shared library (if it exists), when the model is deleted,
         // its dtor unloads the shared lib.
-        impl->document.reset(new libsbml::SBMLDocument());
+        impl->document.reset(new libsbml::SBMLDocument(3, 2));
         impl->document->createModel();
         if (impl->model) {
             impl->model = nullptr;

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -128,7 +128,7 @@ namespace rr {
 /**
  * check if metabolic control analysis is valid for the model.
  *
- * In effect, this checks that the the model is a pure
+ * In effect, this checks that the model is a pure
  * reaction-kinetics model with no rate rules, no events.
  *
  * Throws an invaid arg exception if not valid.

--- a/test/llvm_tests/LLVMGeneratedFunctionTests.cpp
+++ b/test/llvm_tests/LLVMGeneratedFunctionTests.cpp
@@ -51,7 +51,7 @@ void LLVMGeneratedFunctionTests::checkInitialEvaluationSpecies(int options, int 
         // we need an instance of modelData to work with the functions.
         LLVMModelDataSymbols sym(m, options);
         std::unique_ptr<Random> r = std::make_unique<Random>();
-        LLVMModelData *modelData = createModelData(sym, r.get());
+        LLVMModelData *modelData = createModelData(sym, r.get(), 0);
 
         // Evaluate initial conditions
         evalInitConditions(modelData, options);

--- a/test/mockups/MockExecutableModel.h
+++ b/test/mockups/MockExecutableModel.h
@@ -101,6 +101,7 @@ public:
                 (double timeEnd, const unsigned char *previousEventStatus,const double *initialState, double *finalState),
                 (override));
     MOCK_METHOD(void, getEventRoots, (double time, const double *y, double *gdot), (override));
+    MOCK_METHOD(void, getPiecewiseTriggerRoots, (double time, const double* y, double* gdot), (override));
     MOCK_METHOD(double, getNextPendingEventTime, (bool pop), (override));
     MOCK_METHOD(int, getPendingEventSize, (), (override));
     MOCK_METHOD(void, resetEvents, (), (override));

--- a/test/mockups/MockExecutableModel.h
+++ b/test/mockups/MockExecutableModel.h
@@ -96,6 +96,7 @@ public:
     MOCK_METHOD(std::string, getInfo, (), (override));
     MOCK_METHOD(void, print, (std::ostream & stream), (override));
     MOCK_METHOD(int, getNumEvents, (), (override));
+    MOCK_METHOD(int, getNumPiecewiseTriggers, (), (override));
     MOCK_METHOD(int, getEventTriggers, (size_t len, const int *indx, unsigned char *values), (override));
     MOCK_METHOD(int, applyEvents,
                 (double timeEnd, const unsigned char *previousEventStatus,const double *initialState, double *finalState),

--- a/test/models/SBMLFeatures/need_piecewise_and_event_triggers.xml
+++ b/test/models/SBMLFeatures/need_piecewise_and_event_triggers.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.14.0 with libSBML version 5.20.2. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="X1" compartment="default_compartment" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="v" constant="false"/>
+      <parameter id="u" constant="false"/>
+      <parameter id="w" value="0" constant="false"/>
+      <parameter id="k" value="0.1" constant="true"/>
+    </listOfParameters>
+    <listOfRules>
+      <assignmentRule variable="v">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <piecewise>
+            <piece>
+              <cn type="integer"> 0 </cn>
+              <apply>
+                <lt/>
+                <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                <cn type="integer"> 2 </cn>
+              </apply>
+            </piece>
+            <otherwise>
+              <cn type="integer"> 3 </cn>
+            </otherwise>
+          </piecewise>
+        </math>
+      </assignmentRule>
+      <assignmentRule variable="u">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <plus/>
+            <ci> v </ci>
+            <ci> w </ci>
+          </apply>
+        </math>
+      </assignmentRule>
+    </listOfRules>
+    <listOfReactions>
+      <reaction id="J0" reversible="true" fast="false">
+        <listOfProducts>
+          <speciesReference species="X1" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <plus/>
+              <apply>
+                <times/>
+                <apply>
+                  <minus/>
+                  <ci> k </ci>
+                </apply>
+                <ci> X1 </ci>
+              </apply>
+              <ci> u </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+    <listOfEvents>
+      <event id="_E0" useValuesFromTriggerTime="true">
+        <trigger initialValue="true" persistent="true">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <and/>
+              <apply>
+                <gt/>
+                <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                <cn type="integer"> 1 </cn>
+              </apply>
+              <apply>
+                <lt/>
+                <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                <cn> 1.5 </cn>
+              </apply>
+            </apply>
+          </math>
+        </trigger>
+        <listOfEventAssignments>
+          <eventAssignment variable="w">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <cn type="integer"> 3 </cn>
+            </math>
+          </eventAssignment>
+        </listOfEventAssignments>
+      </event>
+    </listOfEvents>
+  </model>
+</sbml>

--- a/test/models/SBMLFeatures/need_piecewise_triggers.xml
+++ b/test/models/SBMLFeatures/need_piecewise_triggers.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.14.0 with libSBML version 5.20.2. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="X1" compartment="default_compartment" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="in_interval" constant="false"/>
+      <parameter id="u" constant="false"/>
+      <parameter id="k" value="0.1" constant="true"/>
+    </listOfParameters>
+    <listOfRules>
+      <assignmentRule variable="in_interval">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <and/>
+            <apply>
+              <geq/>
+              <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+              <cn type="integer"> 1 </cn>
+            </apply>
+            <apply>
+              <leq/>
+              <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+              <cn> 1.5 </cn>
+            </apply>
+          </apply>
+        </math>
+      </assignmentRule>
+      <assignmentRule variable="u">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <piecewise>
+            <piece>
+              <cn type="integer"> 3 </cn>
+              <ci> in_interval </ci>
+            </piece>
+            <otherwise>
+              <cn type="integer"> 0 </cn>
+            </otherwise>
+          </piecewise>
+        </math>
+      </assignmentRule>
+    </listOfRules>
+    <listOfReactions>
+      <reaction id="J0" reversible="true" fast="false">
+        <listOfProducts>
+          <speciesReference species="X1" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <plus/>
+              <apply>
+                <times/>
+                <apply>
+                  <minus/>
+                  <ci> k </ci>
+                </apply>
+                <ci> X1 </ci>
+              </apply>
+              <ci> u </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/models/SBMLFeatures/need_piecewise_triggers_3part.xml
+++ b/test/models/SBMLFeatures/need_piecewise_triggers_3part.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.14.0 with libSBML version 5.20.2. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="X1" compartment="default_compartment" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="u" constant="false"/>
+      <parameter id="k" value="0.1" constant="true"/>
+    </listOfParameters>
+    <listOfRules>
+      <assignmentRule variable="u">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <piecewise>
+            <piece>
+              <cn type="integer"> 0 </cn>
+              <apply>
+                <lt/>
+                <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </piece>
+            <piece>
+              <cn type="integer"> 0 </cn>
+              <apply>
+                <gt/>
+                <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                <cn> 1.5 </cn>
+              </apply>
+            </piece>
+            <otherwise>
+              <cn type="integer"> 3 </cn>
+            </otherwise>
+          </piecewise>
+        </math>
+      </assignmentRule>
+    </listOfRules>
+    <listOfReactions>
+      <reaction id="J0" reversible="true" fast="false">
+        <listOfProducts>
+          <speciesReference species="X1" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <plus/>
+              <apply>
+                <times/>
+                <apply>
+                  <minus/>
+                  <ci> k </ci>
+                </apply>
+                <ci> X1 </ci>
+              </apply>
+              <ci> u </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/models/SBMLFeatures/need_piecewise_triggers_rev.xml
+++ b/test/models/SBMLFeatures/need_piecewise_triggers_rev.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.14.0 with libSBML version 5.20.2. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="X1" compartment="default_compartment" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="u" constant="false"/>
+      <parameter id="k" value="0.1" constant="true"/>
+    </listOfParameters>
+    <listOfRules>
+      <assignmentRule variable="u">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <piecewise>
+            <piece>
+              <cn type="integer"> 0 </cn>
+              <apply>
+                <or/>
+                <apply>
+                  <lt/>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+                <apply>
+                  <gt/>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                  <cn> 1.5 </cn>
+                </apply>
+              </apply>
+            </piece>
+            <otherwise>
+              <cn type="integer"> 3 </cn>
+            </otherwise>
+          </piecewise>
+        </math>
+      </assignmentRule>
+    </listOfRules>
+    <listOfReactions>
+      <reaction id="J0" reversible="true" fast="false">
+        <listOfProducts>
+          <speciesReference species="X1" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <plus/>
+              <apply>
+                <times/>
+                <apply>
+                  <minus/>
+                  <ci> k </ci>
+                </apply>
+                <ci> X1 </ci>
+              </apply>
+              <ci> u </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/sbml_features/CMakeLists.txt
+++ b/test/sbml_features/CMakeLists.txt
@@ -2,10 +2,11 @@ add_test_executable(
         test_sbml_features test_targets
         ${SharedTestFiles}
         boolean_delay.cpp
-        invalid_sbml.cpp
-        valid_sbml.cpp
         events.cpp
+        invalid_sbml.cpp
+        piecewise_triggers.cpp
         unsupported_packages.cpp
+        valid_sbml.cpp
 )
 
 # make test_targets list global to all tests

--- a/test/sbml_features/piecewise_triggers.cpp
+++ b/test/sbml_features/piecewise_triggers.cpp
@@ -1,0 +1,51 @@
+#include "gtest/gtest.h"
+#include "rrRoadRunner.h"
+#include "rrException.h"
+#include "rrUtils.h"
+#include "rrTestSuiteModelSimulation.h"
+#include "sbml/SBMLTypes.h"
+#include "sbml/SBMLReader.h"
+#include "../test_util.h"
+#include <filesystem>
+#include "RoadRunnerTest.h"
+
+using namespace testing;
+using namespace rr;
+using namespace std;
+using std::filesystem::path;
+
+class SBMLFeatures : public RoadRunnerTest {
+public:
+    path SBMLFeaturesDir = rrTestModelsDir_ / "SBMLFeatures";
+    SBMLFeatures() = default;
+};
+
+TEST_F(SBMLFeatures, PIECEWISE_TRIGGERS_1)
+{
+    RoadRunner rri((SBMLFeaturesDir / "need_piecewise_triggers.xml").string());
+    const ls::DoubleMatrix* results = rri.simulate();
+    EXPECT_NEAR(rri.getValue(rri.createSelection("X1")), 1.0310384266045054, 0.0001);
+}
+
+TEST_F(SBMLFeatures, PIECEWISE_TRIGGERS_2)
+{
+    RoadRunner rri((SBMLFeaturesDir / "need_piecewise_triggers_rev.xml").string());
+    const ls::DoubleMatrix* results = rri.simulate();
+    EXPECT_NEAR(rri.getValue(rri.createSelection("X1")), 1.0310384266045054, 0.0001);
+}
+
+TEST_F(SBMLFeatures, PIECEWISE_TRIGGERS_3)
+{
+    RoadRunner rri((SBMLFeaturesDir / "need_piecewise_triggers_3part.xml").string());
+    const ls::DoubleMatrix* results = rri.simulate();
+    EXPECT_NEAR(rri.getValue(rri.createSelection("X1")), 1.0310384266045054, 0.0001);
+}
+
+TEST_F(SBMLFeatures, PIECEWISE_AND_EVENT_TRIGGERS)
+{
+    //This worked in rr 2.5, but failed with the new version because piecewise triggers overrode the events triggers.
+    RoadRunner rri((SBMLFeaturesDir / "need_piecewise_and_event_triggers.xml").string());
+    const ls::DoubleMatrix* results = rri.simulate();
+    EXPECT_NEAR(rri.getValue(rri.createSelection("X1")), 17.66586981819867, 0.0001);
+}
+

--- a/wrappers/C/rrc_api.h
+++ b/wrappers/C/rrc_api.h
@@ -3250,7 +3250,7 @@ C_DECL_SPEC RRStringArrayPtr rrcCallConv getListOfConfigKeys();
 
 /*!
  \brief Set the selection list for output from simulate(void) or simulateEx(void)
- Use setTimeCourseSelectionListEx(handle, length, list) to set the the simulate selection list.
+ Use setTimeCourseSelectionListEx(handle, length, list) to set the simulate selection list.
  Compared to setTimeCourseSelectionList, setTimeCourseSelectionListEx, expects a list of char* strings
  otherwise it has identical functionality.
  \param[in] handle Handle to a RoadRunner instance

--- a/wrappers/C/rrc_utilities.h
+++ b/wrappers/C/rrc_utilities.h
@@ -76,7 +76,7 @@ extern const char*  ALLOCATE_API_ERROR_MSG;
 extern const char*  INVALID_HANDLE_ERROR_MSG;
 
 /*!
- \brief Retrieves the the content of a file.
+ \brief Retrieves the content of a file.
  \param[in] fName Pointer to a string holding the name and optionla path to a file
  \return Content of file as a string, returns null if it fails
  \ingroup utilities


### PR DESCRIPTION
When a piecewise function condition changes from false to true, we need to find the root at which that happened.  We have the mechanics to do this for events, and if we create fake events with triggers set to the piecewise conditions, everything works.  This adds a separate system to do rootfinding for piecewise functions specifically.