### PR TITLE
Random seed of the ExecutableModel can now be set through API functions

### DIFF
--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -1431,6 +1431,9 @@ double LLVMExecutableModel::getValue(const std::string& id)
     case SelectionRecord::TIME:
         result = getTime();
         break;
+    case SelectionRecord::SEED:
+        result = getRandomSeed();
+        break;
     case SelectionRecord::FLOATING_AMOUNT:
         getFloatingSpeciesAmounts(1, &index, &result);
         break;
@@ -1511,6 +1514,8 @@ const rr::SelectionRecord& LLVMExecutableModel::getSelection(const std::string& 
         switch(sel.selectionType)
         {
         case SelectionRecord::TIME:
+            break;
+        case SelectionRecord::SEED:
             break;
         case SelectionRecord::UNKNOWN_ELEMENT:
             // check for sbml element types
@@ -1659,6 +1664,9 @@ void LLVMExecutableModel::setValue(const std::string& id, double value)
     {
     case SelectionRecord::TIME:
         setTime(value);
+        break;
+    case SelectionRecord::SEED:
+        setRandomSeed(value);
         break;
     case SelectionRecord::FLOATING_AMOUNT:
         setFloatingSpeciesAmounts(1, &index, &value);

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1362,7 +1362,9 @@ namespace rr {
             case SelectionRecord::TIME:
                 dResult = getCurrentTime();
                 break;
-
+            case SelectionRecord::SEED:
+                dResult = impl->model->getRandomSeed();
+                break;
             default:
                 dResult = 0.0;
                 break;
@@ -4630,6 +4632,7 @@ namespace rr {
         // check to see that we have valid selection ids
         switch (sel.selectionType) {
             case SelectionRecord::TIME:
+            case SelectionRecord::SEED:
             case SelectionRecord::UNKNOWN_ELEMENT:
                 // check for sbml element types
 
@@ -4653,6 +4656,9 @@ namespace rr {
                     break;
                 } else if (sel.selectionType == SelectionRecord::TIME) {
                     //Need to put this here in case there's an actual SBML variable called 'time'
+                    break;
+                } else if (sel.selectionType == SelectionRecord::SEED) {
+                    //Need to put this here in case there's an actual SBML variable called 'seed'
                     break;
                 } else {
                     throw Exception("No sbml element exists for symbol '" + str + "'");
@@ -7185,7 +7191,6 @@ namespace rr {
             getSpeciesIdsFromAST(node->getChild(i), species, instanceSpeciesNames);
         }
     }
-
 
     void writeDoubleVectorListToStream(std::ostream &out, const DoubleVectorList &results) {
         for (const std::vector<double> &row: results) {

--- a/source/rrSelectionRecord.cpp
+++ b/source/rrSelectionRecord.cpp
@@ -21,6 +21,12 @@ static bool is_time(const std::string& str)
     return is_time_re.match(str);
 }
 
+static const Poco::RegularExpression is_seed_re("^\\s*seed\\s*$", RegularExpression::RE_CASELESS);
+static bool is_seed(const std::string& str)
+{
+    return is_seed_re.match(str);
+}
+
 static const Poco::RegularExpression is_uec_re("^\\s*uec\\s*\\(\\s*(\\w*)\\s*,\\s*(\\w*)\\s*\\)\\s*$", RegularExpression::RE_CASELESS);
 static bool is_uec(const std::string& str, std::string& p1, std::string& p2)
 {
@@ -325,7 +331,6 @@ rr::SelectionRecord::SelectionRecord(const std::string str) :
         index(-1), selectionType(UNKNOWN)
 {
     int complex;
-
     if (is_ec(str, p1, p2))
     {
         selectionType = ELASTICITY;
@@ -387,6 +392,10 @@ rr::SelectionRecord::SelectionRecord(const std::string str) :
         if (is_time(str))
         {
             selectionType = TIME;
+        }
+        else if (is_seed(str))
+        {
+            selectionType = SEED;
         }
         else
         {

--- a/source/rrSelectionRecord.h
+++ b/source/rrSelectionRecord.h
@@ -152,6 +152,8 @@ public:
          */
         EIGENVALUE_IMAG =                    (0x1 << 23),
 
+        SEED =                               (0x1 << 24),
+
         /**
         * SelectionType for everything.
         */


### PR DESCRIPTION
- SEED is added as a SelectionType to the list of SelectionRecords

- 'seed' is recognized as the id for SEED in the SelectionRecords

- the getValue function of API now returns the value of getRandomSeed function of the model if it is asked to return the 'seed' value

- the setValue function of API now sets the value of getRandomSeed function of the model if it is asked to set the 'seed' value