### PR TITLE
Fix issue where large values were always being rejected.

### DIFF
--- a/source/rrConfig.h
+++ b/source/rrConfig.h
@@ -250,7 +250,7 @@ namespace rr {
             SIMULATEOPTIONS_MINIMUM_TIMESTEP,
 
             /**
-             * Specify The Maximum Time Step Size That The Internaal Integrator
+             * Specify The Maximum Time Step Size That The Internal Integrator
              * Will Use. Uses Integrator Estimated Value If <= 0.
              * see SimulateOptions::maximumTimeStep
              */
@@ -485,7 +485,7 @@ namespace rr {
 
 
             /**
-             * Relax SBML resrictions.
+             * Relax SBML restrictions.
              *
              * Allows some idiosyncrasies of e.g. JDesigner that libSBML does not
              * officially support. See:

--- a/test/cxx_api_tests/ConfigTests.cpp
+++ b/test/cxx_api_tests/ConfigTests.cpp
@@ -3,11 +3,12 @@
 //
 
 #include "gtest/gtest.h"
+#include "rrConfig.h"
+#include "Poco/Path.h" // for Poco::Path::home, which is used in rrConfig.cpp
 #include <filesystem>
 #include <fstream>
 #include <cstdlib>
-#include "rrConfig.h"
-#include "Poco/Path.h" // for Poco::Path::home, which is used in rrConfig.cpp
+#include <limits>
 
 using namespace rr;
 
@@ -154,11 +155,61 @@ TEST_F(ConfigTests, SetLLJitOptLevelToAggressive){
 TEST_F(ConfigTests, SetLLJitNumThreadsTo7){
     // only print out the default value, which will
     // be different on different machines ==> bad test
-    std::cout << Config::getValue(Config::LLJIT_NUM_THREADS).getAs<int>() << std::endl;
     Config::setValue(Config::LLJIT_NUM_THREADS, 7);
     int numThreads = Config::getValue(Config::LLJIT_NUM_THREADS);
     ASSERT_EQ(7, numThreads);
 }
 
+TEST_F(ConfigTests, SetSeedToNighMaxValues) {
+    uint64_t seedval = (std::numeric_limits<uint64_t>::max)() - 5;
+    Config::setValue(Config::RANDOM_SEED, seedval);
+    rr::Setting seed_as_setting = Config::getValue(Config::RANDOM_SEED);
+    uint64_t seed = seed_as_setting.getAs<uint64_t>();
+    ASSERT_EQ(seedval, seed);
 
+    ASSERT_THROW(seed_as_setting.getAs<int64_t>(), std::invalid_argument);
+    ASSERT_THROW(seed_as_setting.getAs<unsigned int>(), std::invalid_argument);
+    ASSERT_THROW(seed_as_setting.getAs<int>(), std::invalid_argument);
+    ASSERT_THROW(seed_as_setting.getAs<string>(), std::invalid_argument);
+    string seedstr = seed_as_setting.toString();
+
+    seedval = (std::numeric_limits<int64_t>::max)() - 5;
+    Config::setValue(Config::RANDOM_SEED, seedval);
+    seed_as_setting = Config::getValue(Config::RANDOM_SEED);
+    seed = seed_as_setting.getAs<uint64_t>();
+    ASSERT_EQ(seedval, seed);
+    seed = seed_as_setting.getAs<int64_t>();
+    ASSERT_EQ(seedval, seed);
+    ASSERT_THROW(seed_as_setting.getAs<unsigned int>(), std::invalid_argument);
+    ASSERT_THROW(seed_as_setting.getAs<int>(), std::invalid_argument);
+    ASSERT_THROW(seed_as_setting.getAs<string>(), std::invalid_argument);
+    seedstr = seed_as_setting.toString();
+
+    seedval = (std::numeric_limits<unsigned int>::max)() - 5;
+    Config::setValue(Config::RANDOM_SEED, seedval);
+    seed_as_setting = Config::getValue(Config::RANDOM_SEED);
+    seed = seed_as_setting.getAs<uint64_t>();
+    ASSERT_EQ(seedval, seed);
+    seed = seed_as_setting.getAs<int64_t>();
+    ASSERT_EQ(seedval, seed);
+    seed = seed_as_setting.getAs<unsigned int>();
+    ASSERT_EQ(seedval, seed);
+    ASSERT_THROW(seed_as_setting.getAs<int>(), std::invalid_argument);
+    ASSERT_THROW(seed_as_setting.getAs<string>(), std::invalid_argument);
+    seedstr = seed_as_setting.toString();
+
+    seedval = (std::numeric_limits<int>::max)() - 5;
+    Config::setValue(Config::RANDOM_SEED, seedval);
+    seed_as_setting = Config::getValue(Config::RANDOM_SEED);
+    seed = seed_as_setting.getAs<uint64_t>();
+    ASSERT_EQ(seedval, seed);
+    seed = seed_as_setting.getAs<int64_t>();
+    ASSERT_EQ(seedval, seed);
+    seed = seed_as_setting.getAs<unsigned int>();
+    ASSERT_EQ(seedval, seed);
+    seed = seed_as_setting.getAs<int>();
+    ASSERT_EQ(seedval, seed);
+    ASSERT_THROW(seed_as_setting.getAs<string>(), std::invalid_argument);
+    seedstr = seed_as_setting.toString();
+}
 

--- a/test/cxx_api_tests/SettingTests.cpp
+++ b/test/cxx_api_tests/SettingTests.cpp
@@ -201,7 +201,7 @@ TEST_F(SettingTests, ImplicitCastNegativeIntToUInt) {
     Setting setting(-4);
     ASSERT_THROW(
             unsigned int x = setting,
-            std::bad_variant_access
+            std::invalid_argument
     );
 }
 
@@ -210,7 +210,7 @@ TEST_F(SettingTests, ImplicitCastNegativeIntToULong) {
     Setting setting(-4);
     ASSERT_THROW(
             unsigned long x = setting,
-            std::bad_variant_access
+            std::invalid_argument
     );
 }
 
@@ -221,7 +221,18 @@ TEST_F(SettingTests, ImplicitCastLongToIntOutOfBounds) {
     Setting setting(out_of_range);
     ASSERT_THROW(
             int x = setting,
-            std::bad_variant_access
+            std::invalid_argument
+    );
+}
+
+TEST_F(SettingTests, ImplicitCastLongToNegIntOutOfBounds) {
+    // should raise error
+    std::int64_t biggest_int = std::numeric_limits<int>::max();
+    std::int64_t out_of_range = -biggest_int * 10;
+    Setting setting(out_of_range);
+    ASSERT_THROW(
+        int x = setting,
+        std::invalid_argument
     );
 }
 


### PR DESCRIPTION
maxint was the effective limit of the value of any integer, even uint64.