### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 # Summary
 
-libRoadRunner is a C/C++ library that supports simulation of SBML based models. It uses LLVM) to generate extremely high performance code and is the fastest SBML-based simulator currently available (ref). Its main purpose is for use as a reusable library that can be hosted by other applications, particularly on large compute clusters for doing parameter optimization where performance is critical. It also has a set of python bindings that allow it to be easily used from python. 
+libRoadRunner is a C/C++ library that supports simulation of SBML based models. It uses LLVM to generate extremely high performance code and is the fastest SBML-based simulator currently available (ref). Its main purpose is for use as a reusable library that can be hosted by other applications, particularly on large compute clusters for doing parameter optimization where performance is critical. It also has a set of python bindings that allow it to be easily used from python. 
 
 We provide C/C++, Python and Julia bindings.
 
@@ -133,7 +133,7 @@ Endre T. Somogyi, Jean-Marie Bouteiller, James A. Glazier, Matthias König, J. K
 
 This work is funded by NIGMS grant: GM081070
 
-## Licence
+## License
 
 Licensed under the Apache License, Version 2.0 (the License); you may not use this 
 file except in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
For some reason, @BenjaminRodenberg's patch failed to build on azure, *maybe* because it was looking in his repository for libroadrunner-deps instead of sys-bio's?  Trying here to reproduce his fixes to see if I get the same error.