### PR TITLE
fix: compile error with gcc13

### DIFF
--- a/source/Setting.h
+++ b/source/Setting.h
@@ -5,6 +5,7 @@
 #ifndef ROADRUNNER_SETTING_H
 #define ROADRUNNER_SETTING_H
 
+#include <cstdint>
 #include <variant>
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
Without this i am getting `'uint32_t' is not a member of 'std'`. See also https://gcc.gnu.org/gcc-13/porting_to.html "Header dependency changes".