### PR TITLE
fix: resolve memory leaks in auto2000 plugin

### DIFF
--- a/rrplugins/plugins/auto2000/telAutoWorker.cpp
+++ b/rrplugins/plugins/auto2000/telAutoWorker.cpp
@@ -124,6 +124,15 @@ void AutoWorker::run()
     rrc::RRStringArrayPtr temp = gHostInterface->getSteadyStateSelectionList(mTheHost.rrHandle);
     StringList selRecs (temp->String, temp->Count);
     StringList              selList = selRecs;
+    if (temp != NULL) {
+        if (temp->String != NULL) {
+            for (int i = 0; i < temp->Count; i++) {
+                delete[] temp->String[i];
+            }
+            delete[] temp->String;
+        }
+        delete temp;
+    }
 
     TelluriumData& data =  mTheHost.mBifurcationData.getValueReference();
 

--- a/rrplugins/plugins/levenberg_marquardt/lm.cpp
+++ b/rrplugins/plugins/levenberg_marquardt/lm.cpp
@@ -97,8 +97,10 @@ namespace lmfit
         mProperties.add(&mStatusMessage);
 
         //Allocate model and Residuals data
-        mResidualsData.setValue(new TelluriumData());
-        mModelData.setValue(new TelluriumData());
+        TelluriumData residualsData;
+        mResidualsData.setValue(&residualsData);
+        TelluriumData modelData;
+        mModelData.setValue(&modelData);
 
         mHint = "Parameter fitting using the Levenberg-Marquardt algorithm";
         mDescription = "The Levenberg-Marquardt plugin is used to fit a proposed \

--- a/rrplugins/plugins/nelder_mead/nmNelderMead.cpp
+++ b/rrplugins/plugins/nelder_mead/nmNelderMead.cpp
@@ -92,8 +92,10 @@ namespace nmfit
         mProperties.add(&mStatusMessage);
 
         //Allocate model and Residuals data
-        mResidualsData.setValue(new TelluriumData());
-        mModelData.setValue(new TelluriumData());
+        TelluriumData residualsData;
+        mResidualsData.setValue(&residualsData);
+        TelluriumData modelData;
+        mModelData.setValue(&modelData);
 
         mHint = "Parameter fitting using the Nelder-Mead algorithm";
         mDescription = "The Nelder-Mead plugin is used to fit a proposed \

--- a/wrappers/C/rrc_cpp_support.cpp
+++ b/wrappers/C/rrc_cpp_support.cpp
@@ -209,15 +209,15 @@ RRStringArrayPtr createList(const rrc::StringList& sList)
     RRStringArray* list = new RRStringArray;
     list->Count = sList.Count();
 
-    if (list->Count)
-        list->String = new char*[list->Count];
+    if (list->Count) {
+        list->String = new char *[list->Count];
+        for(int i = 0; i < list->Count; i++)
+        {
+            list->String[i] = rr::createText(sList[i]);
+        }
+    }
     else
         list->String = NULL;
-
-    for(int i = 0; i < list->Count; i++)
-    {
-        list->String[i] = rr::createText(sList[i]);
-    }
     return list;
 }
 


### PR DESCRIPTION
fix: resolve memory leaks in auto2000 plugin (plus lm and NelderMead plugins)
- Identified and corrected memory leaks in using RRStringArrayPtr, RRCDataPtr, and RRVectorPtr.
- Implemented unique_ptr for RRVector.
