### PR TITLE
Set initial values consistently

### DIFF
--- a/source/llvm/LLVMModelGenerator.cpp
+++ b/source/llvm/LLVMModelGenerator.cpp
@@ -282,7 +282,7 @@ namespace rrllvm {
     }
 
     ExecutableModel*
-        LLVMModelGenerator::regenerateModel(rr::ExecutableModel* oldModel, libsbml::SBMLDocument* doc, uint options) 
+        LLVMModelGenerator::regenerateModel(rr::ExecutableModel* oldModel, libsbml::SBMLDocument* doc, uint options)
     {
         SharedModelResourcesPtr modelResources = std::make_shared<ModelResources>();
 
@@ -305,9 +305,8 @@ namespace rrllvm {
         LLVMExecutableModel* newModel = new LLVMExecutableModel(modelResources, modelData);
 
         if (oldModel) {
-            // the stored SBML document will not keep updated, so we need to
-            // copy the old values (e.g, initial values, current values) to new model
-            // so that we can start from where we paused
+            // the stored SBML document only has initial values, not current values,
+            // so copy all current values to the new model.
 
             std::vector<std::string> newSymbols = newModel->getRateRuleSymbols();
 
@@ -315,45 +314,15 @@ namespace rrllvm {
                 std::string id = oldModel->getFloatingSpeciesId(i);
                 int index = newModel->getFloatingSpeciesIndex(id);
 
-                if (index >= 0 && index < newModel->modelData->numInitFloatingSpecies) {
+                if (index >= 0) {
                     // new model has this species
-
-                    if (!newModel->symbols->hasAssignmentRule(id) && !newModel->symbols->hasRateRule(id)) {
-                        if (!newModel->symbols->hasInitialAssignmentRule(id)) {
-                            double initValue = 0;
-                            oldModel->getFloatingSpeciesInitAmounts(1, &i, &initValue);
-                            newModel->modelData->initFloatingSpeciesAmountsAlias[index] = initValue;
-                            //newModel->setFloatingSpeciesInitAmounts(1, &index, &initValue);
-                        }
-                    }
-                }
-            }
-
-
-            for (int i = 0; i < oldModel->getNumFloatingSpecies(); i++) {
-                std::string id = oldModel->getFloatingSpeciesId(i);
-                int index = newModel->getFloatingSpeciesIndex(id);
-
-                if (index >= 0 && index < newModel->modelData->numIndFloatingSpecies) {
-                    // new model has this species
-
-                    // TODO: should we change the dirty flag when we call setters?
                     double value = 0;
                     oldModel->getFloatingSpeciesAmounts(1, &i, &value);
-
-                    if (!newModel->symbols->hasAssignmentRule(id) && !newModel->symbols->hasRateRule(id)) {
-                        newModel->modelData->floatingSpeciesAmountsAlias[index] = value;
-                        //newModel->setFloatingSpeciesAmounts(1, &index, &value);
+                    try {
+                        newModel->setValue(id, value);
                     }
-                    else if (newModel->symbols->hasRateRule(id)) {
-                        // copy to rate rule value data block
-                        std::vector<std::string>::iterator it = std::find(newSymbols.begin(), newSymbols.end(), id);
-                        if (it != newSymbols.end()) {
-                            // found it
-                            index = std::distance(newSymbols.begin(), it);
-                            newModel->modelData->rateRuleValuesAlias[index] = value;
-                        }
-
+                    catch (const exception&) {
+                        //Don't worry about it.
                     }
                 }
             }
@@ -363,33 +332,15 @@ namespace rrllvm {
                 std::string id = oldModel->getBoundarySpeciesId(i);
                 int index = newModel->getBoundarySpeciesIndex(id);
 
-                // TODO: set concentration or amount?
-
-                if (index >= 0 && index < newModel->modelData->numIndBoundarySpecies) {
+                if (index >= 0) {
                     // new model has this species
-
                     double value = 0;
                     oldModel->getBoundarySpeciesAmounts(1, &i, &value);
-
-                    if (!newModel->symbols->hasAssignmentRule(id) && !newModel->symbols->hasRateRule(id)) {
-                        newModel->modelData->boundarySpeciesAmountsAlias[index] = value;
-                        //newModel->setBoundarySpeciesAmounts(1, &index, &value);
+                    try {
+                        newModel->setValue(id, value);
                     }
-                    else if (newModel->symbols->hasRateRule(id)) {
-                        // copy to rate rule value data block
-                        std::vector<std::string>::iterator it = std::find(newSymbols.begin(), newSymbols.end(), id);
-                        if (it != newSymbols.end()) {
-                            // found it
-                            index = std::distance(newSymbols.begin(), it);
-                            newModel->modelData->rateRuleValuesAlias[index] = value;
-                        }
-                    }
-                    else {
-                        if (!newModel->symbols->hasInitialAssignmentRule(id)) {
-                            double initValue = 0;
-                            oldModel->getBoundarySpeciesInitAmounts(1, &i, &initValue);
-                            newModel->modelData->initBoundarySpeciesAmountsAlias[index] = initValue;
-                        }
+                    catch (const exception&) {
+                        //Don't worry about it.
                     }
                 }
 
@@ -400,48 +351,16 @@ namespace rrllvm {
                 std::string id = oldModel->getCompartmentId(i);
                 int index = newModel->getCompartmentIndex(id);
 
-                if (index >= 0 && index < newModel->modelData->numInitCompartments) {
-                    // new model has this compartment
-
-                    if (!newModel->symbols->hasAssignmentRule(id) && !newModel->symbols->hasRateRule(id)) {
-                        if (!newModel->symbols->hasInitialAssignmentRule(id)) {
-                            double initValue = 0;
-                            oldModel->getCompartmentInitVolumes(1, &i, &initValue);
-                            newModel->modelData->initCompartmentVolumesAlias[index] = initValue;
-                            //newModel->setCompartmentInitVolumes(1, &index, &initValue);
-                        }
-
-                    }
-
-                }
-
-            }
-
-
-            for (int i = 0; i < oldModel->getNumCompartments(); i++) {
-                std::string id = oldModel->getCompartmentId(i);
-                int index = newModel->getCompartmentIndex(id);
-
-                if (index >= 0 && index < newModel->modelData->numIndCompartments) {
+                if (index >= 0) {
                     // new model has this compartment
                     double value = 0;
                     oldModel->getCompartmentVolumes(1, &i, &value);
-
-                    if (!newModel->symbols->hasAssignmentRule(id) && !newModel->symbols->hasRateRule(id)) {
-                        newModel->modelData->compartmentVolumesAlias[index] = value;
-                        //newModel->setCompartmentVolumes(1, &index, &value);
+                    try {
+                        newModel->setValue(id, value);
                     }
-                    else if (newModel->symbols->hasRateRule(id)) {
-                        // copy to rate rule value data block
-                        std::vector<std::string>::iterator it = std::find(newSymbols.begin(), newSymbols.end(), id);
-                        if (it != newSymbols.end()) {
-                            // found it
-                            index = std::distance(newSymbols.begin(), it);
-                            newModel->modelData->rateRuleValuesAlias[index] = value;
-                        }
-
+                    catch (const exception&) {
+                        //Don't worry about it.
                     }
-
                 }
 
             }
@@ -452,41 +371,13 @@ namespace rrllvm {
 
                 if (index >= 0 && index < newModel->modelData->numInitGlobalParameters) {
                     // new model has this parameter
-
-                    if (!newModel->symbols->hasAssignmentRule(id) && !newModel->symbols->hasRateRule(id)) {
-                        if (!newModel->symbols->hasInitialAssignmentRule(id)) {
-                            double initValue = 0;
-                            oldModel->getGlobalParameterInitValues(1, &i, &initValue);
-                            newModel->modelData->initGlobalParametersAlias[index] = initValue;
-                            //newModel->setGlobalParameterInitValues(1, &index, &initValue);
-                        }
-                    }
-                }
-            }
-
-
-            for (int i = 0; i < oldModel->getNumGlobalParameters(); i++) {
-                std::string id = oldModel->getGlobalParameterId(i);
-                int index = newModel->getGlobalParameterIndex(id);
-
-                if (index >= 0 && index < newModel->modelData->numIndGlobalParameters) {
-                    // new model has this parameter
-
                     double value = 0;
                     oldModel->getGlobalParameterValues(1, &i, &value);
-
-                    if (!newModel->symbols->hasAssignmentRule(id) && !newModel->symbols->hasRateRule(id)) {
-                        newModel->modelData->globalParametersAlias[index] = value;
-                        //newModel->setGlobalParameterValues(1, &index, &value);
+                    try {
+                        newModel->setValue(id, value);
                     }
-                    else if (newModel->symbols->hasRateRule(id)) {
-                        // copy to rate rule value data block
-                        std::vector<std::string>::iterator it = std::find(newSymbols.begin(), newSymbols.end(), id);
-                        if (it != newSymbols.end()) {
-                            // found it
-                            index = std::distance(newSymbols.begin(), it);
-                            newModel->modelData->rateRuleValuesAlias[index] = value;
-                        }
+                    catch (const exception&) {
+                        //Don't worry about it.
                     }
                 }
             }

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -4656,22 +4656,28 @@ namespace rr {
 
         SelectionRecord sel(sId);
 
-        if (sel.selectionType & SelectionRecord::INITIAL) {
-            //Don't worry if it doesn't exist, and don't regenerate yet.
-            removeInitialAssignment(sel.p1, true, false);
+        if (sel.selectionType & SelectionRecord::INITIAL && sel.p2 == "") {
+            if (sel.selectionType & SelectionRecord::CONCENTRATION) {
+                setInitConcentration(sel.p1, dValue, false);
+            }
+            else {
+                setInitValue(sel.p1, dValue, false);
+            }
         }
         
-        impl->model->setValue(sId, dValue);
+        else {
+            impl->model->setValue(sId, dValue);
 
-        if (sel.selectionType & SelectionRecord::INITIAL) {
-            reset(
-                SelectionRecord::TIME |
-                SelectionRecord::RATE |
-                SelectionRecord::FLOATING |
-                SelectionRecord::BOUNDARY |
-                SelectionRecord::COMPARTMENT |
-                SelectionRecord::GLOBAL_PARAMETER |
-                SelectionRecord::STOICHIOMETRY);
+            if (sel.selectionType & SelectionRecord::INITIAL) {
+                reset(
+                    SelectionRecord::TIME |
+                    SelectionRecord::RATE |
+                    SelectionRecord::FLOATING |
+                    SelectionRecord::BOUNDARY |
+                    SelectionRecord::COMPARTMENT |
+                    SelectionRecord::GLOBAL_PARAMETER |
+                    SelectionRecord::STOICHIOMETRY);
+            }
         }
     }
 
@@ -6122,25 +6128,32 @@ namespace rr {
         species->unsetInitialConcentration();
         species->setInitialAmount(initAmount);
 
-        //This function returns NULL if there is no such initial assignment.
-        InitialAssignment* ia = sbmlModel->removeInitialAssignment(sid);
-        delete ia;
-
-        regenerateModel(forceRegenerate);
+        //Remove initial assignment and regenerate and reset if we do (regardless of forceRegenerate; the rest of this function won't work otherwise).
+        removeInitialAssignment(sid, true, false);
 
         // recover the updated init amount
-        if (species->getBoundaryCondition()) {
-            int index = impl->model->getBoundarySpeciesIndex(sid);
-            if (index >= 0 && index < impl->model->getNumBoundarySpecies()) {
-                impl->model->setBoundarySpeciesInitAmounts(1, &index, &initAmount);
-            }
-        }
-        else {
-            int index = impl->model->getFloatingSpeciesIndex(sid);
-            if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
-                impl->model->setFloatingSpeciesInitAmounts(1, &index, &initAmount);
-            }
-        }
+        impl->model->setValue("init(" + sid+ ")", initAmount);
+
+        regenerateModel(forceRegenerate);
+        reset(
+            SelectionRecord::TIME |
+            SelectionRecord::RATE |
+            SelectionRecord::FLOATING |
+            SelectionRecord::BOUNDARY |
+            SelectionRecord::COMPARTMENT |
+            SelectionRecord::GLOBAL_PARAMETER);
+        //if (species->getBoundaryCondition()) {
+        //    int index = impl->model->getBoundarySpeciesIndex(sid);
+        //    if (index >= 0 && index < impl->model->getNumBoundarySpecies()) {
+        //        impl->model->setBoundarySpeciesInitAmounts(1, &index, &initAmount);
+        //    }
+        //}
+        //else {
+        //    int index = impl->model->getFloatingSpeciesIndex(sid);
+        //    if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
+        //        impl->model->setFloatingSpeciesInitAmounts(1, &index, &initAmount);
+        //    }
+        //}
     }
 
     void RoadRunner::setInitConcentration(const std::string &sid, double initConcentration, bool forceRegenerate) {
@@ -6158,43 +6171,111 @@ namespace rr {
         species->unsetInitialAmount();
         species->setInitialConcentration(initConcentration);
 
-        //This function returns NULL if there is no such initial assignment.
-        InitialAssignment* ia = sbmlModel->removeInitialAssignment(sid);
-        delete ia;
+        //Remove initial assignment and regenerate and reset if we do (regardless of forceRegenerate; the rest of this function won't work otherwise).
+        removeInitialAssignment(sid, true, false);
 
-        regenerateModel(forceRegenerate);
 
         // recover the updated init concentration
-        if (species->getBoundaryCondition()) {
-            int index = impl->model->getBoundarySpeciesIndex(sid);
+        impl->model->setValue("init([" + sid + "])", initConcentration);
 
-            if (index >= 0 && index < impl->model->getNumBoundarySpecies()) {
+        regenerateModel(forceRegenerate);
+        reset(
+            SelectionRecord::TIME |
+            SelectionRecord::RATE |
+            SelectionRecord::FLOATING |
+            SelectionRecord::BOUNDARY |
+            SelectionRecord::COMPARTMENT |
+            SelectionRecord::GLOBAL_PARAMETER);
+        //if (species->getBoundaryCondition()) {
+        //    int index = impl->model->getBoundarySpeciesIndex(sid);
 
-                int compartment = impl->model->getCompartmentIndex(species->getCompartment());
-                double compartmentSize = 1;
-                impl->model->getCompartmentVolumes(1, &compartment, &compartmentSize);
+        //    if (index >= 0 && index < impl->model->getNumBoundarySpecies()) {
 
-                double initValue = initConcentration * compartmentSize;
-                impl->model->setBoundarySpeciesInitAmounts(1, &index, &initValue);
-            }
-        }
-        
-        else {
-            int index = impl->model->getFloatingSpeciesIndex(sid);
+        //        int compartment = impl->model->getCompartmentIndex(species->getCompartment());
+        //        double compartmentSize = 1;
+        //        impl->model->getCompartmentVolumes(1, &compartment, &compartmentSize);
 
-            if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
+        //        double initValue = initConcentration * compartmentSize;
+        //        //impl->model->setValue(sid, initValue);
+        //        impl->model->setBoundarySpeciesInitAmounts(1, &index, &initValue);
+        //    }
+        //}
+        //
+        //else {
+        //    int index = impl->model->getFloatingSpeciesIndex(sid);
 
-                int compartment = impl->model->getCompartmentIndex(species->getCompartment());
-                double compartmentSize = 1;
-                impl->model->getCompartmentVolumes(1, &compartment, &compartmentSize);
+        //    if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
 
-                double initValue = initConcentration * compartmentSize;
-                impl->model->setFloatingSpeciesInitAmounts(1, &index, &initValue);
-            }
-        }
+        //        int compartment = impl->model->getCompartmentIndex(species->getCompartment());
+        //        double compartmentSize = 1;
+        //        impl->model->getCompartmentVolumes(1, &compartment, &compartmentSize);
+
+        //        double initValue = initConcentration * compartmentSize;
+        //        //impl->model->setValue(sid, initValue);
+        //        impl->model->setFloatingSpeciesInitAmounts(1, &index, &initValue);
+        //    }
+        //}
     }
 
-    void RoadRunner::setConstant(const std::string &sid, bool constant, bool forceRegenerate) {
+    void RoadRunner::setInitValue(const std::string& sid, double initValue, bool forceRegenerate) {
+        using namespace libsbml;
+        Model* sbmlModel = impl->document->getModel();
+        if (sid[0] == '[' && sid[sid.size() - 1] == ']') {
+            string sub_sid = sid.substr(1, sid.size() - 1);
+            return setInitConcentration(sid, initValue, forceRegenerate);
+        }
+        Species* species = sbmlModel->getSpecies(sid);
+        if (species != NULL) {
+            return setInitAmount(sid, initValue, forceRegenerate);
+        }
+        //Remove initial assignment and regenerate and reset if we do (regardless of forceRegenerate; the rest of this function won't work otherwise).
+        removeInitialAssignment(sid, true, false);
+
+        bool found = false;
+        //If it's a compartment:
+        Compartment* compartment = sbmlModel->getCompartment(sid);
+        if (compartment != NULL) {
+            compartment->setSize(initValue);
+            found = true;
+        }
+
+        //or a Parameter:
+        Parameter* param = sbmlModel->getParameter(sid);
+        if (param != NULL) {
+            param->setValue(initValue);
+            found = true;
+        }
+
+        if (!found) {
+            SBase* element = sbmlModel->getElementBySId(sid);
+            if (element == NULL) {
+                throw std::invalid_argument(
+                    "Roadrunner::setInitValue failed, no element with ID " + sid + " existed in the model");
+            }
+            int type = element->getTypeCode();
+            if (type == SBML_SPECIES_REFERENCE) {
+                SpeciesReference* sr = static_cast<SpeciesReference*>(element);
+                sr->setStoichiometry(initValue);
+            }
+            else {
+                string package = element->getPackageName();
+                throw std::invalid_argument(
+                    "Cannot set the initial value of '" + sid + "':  cannot set the value of elements of type " + string(SBMLTypeCode_toString(type, package.c_str())) + ".");
+            }
+        }
+
+        impl->model->setValue("init(" + sid + ")", initValue);
+        regenerateModel(forceRegenerate);
+        reset(
+            SelectionRecord::TIME |
+            SelectionRecord::RATE |
+            SelectionRecord::FLOATING |
+            SelectionRecord::BOUNDARY |
+            SelectionRecord::COMPARTMENT |
+            SelectionRecord::GLOBAL_PARAMETER);
+    }
+
+    void RoadRunner::setConstant(const std::string& sid, bool constant, bool forceRegenerate) {
         using namespace libsbml;
         Model *sbmlModel = impl->document->getModel();
         Species *species = sbmlModel->getSpecies(sid);

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -6107,18 +6107,18 @@ namespace rr {
     }
 
 
-    void RoadRunner::setInitAmount(const std::string &sid, double initAmount, bool forceRegenerate) {
+    void RoadRunner::setInitAmount(const std::string& sid, double initAmount, bool forceRegenerate) {
         using namespace libsbml;
-        Model *sbmlModel = impl->document->getModel();
-        Species *species = sbmlModel->getSpecies(sid);
+        Model* sbmlModel = impl->document->getModel();
+        Species* species = sbmlModel->getSpecies(sid);
 
         if (species == NULL) {
             throw std::invalid_argument(
-                    "Roadrunner::setInitAmount failed, no species with ID " + sid + " existed in the model");
+                "Roadrunner::setInitAmount failed, no species with ID " + sid + " existed in the model");
         }
 
         rrLog(Logger::LOG_DEBUG) << "Setting initial amount for species " << sid << "..." << std::endl;
-        
+
         species->unsetInitialConcentration();
         species->setInitialAmount(initAmount);
 
@@ -6129,10 +6129,18 @@ namespace rr {
         regenerateModel(forceRegenerate);
 
         // recover the updated init amount
-        //int index = impl->model->getFloatingSpeciesIndex(sid);
-        //if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
-        //    impl->model->setFloatingSpeciesInitAmounts(1, &index, &initAmount);
-        //}
+        if (species->getBoundaryCondition()) {
+            int index = impl->model->getBoundarySpeciesIndex(sid);
+            if (index >= 0 && index < impl->model->getNumBoundarySpecies()) {
+                impl->model->setBoundarySpeciesInitAmounts(1, &index, &initAmount);
+            }
+        }
+        else {
+            int index = impl->model->getFloatingSpeciesIndex(sid);
+            if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
+                impl->model->setFloatingSpeciesInitAmounts(1, &index, &initAmount);
+            }
+        }
     }
 
     void RoadRunner::setInitConcentration(const std::string &sid, double initConcentration, bool forceRegenerate) {
@@ -6157,17 +6165,33 @@ namespace rr {
         regenerateModel(forceRegenerate);
 
         // recover the updated init concentration
-        //int index = impl->model->getFloatingSpeciesIndex(sid);
+        if (species->getBoundaryCondition()) {
+            int index = impl->model->getBoundarySpeciesIndex(sid);
 
-        //if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
+            if (index >= 0 && index < impl->model->getNumBoundarySpecies()) {
 
-        //    int compartment = impl->model->getCompartmentIndex(species->getCompartment());
-        //    double compartmentSize = 1;
-        //    impl->model->getCompartmentVolumes(1, &compartment, &compartmentSize);
+                int compartment = impl->model->getCompartmentIndex(species->getCompartment());
+                double compartmentSize = 1;
+                impl->model->getCompartmentVolumes(1, &compartment, &compartmentSize);
 
-        //    double initValue = initConcentration * compartmentSize;
-        //    impl->model->setFloatingSpeciesInitAmounts(1, &index, &initValue);
-        //}
+                double initValue = initConcentration * compartmentSize;
+                impl->model->setBoundarySpeciesInitAmounts(1, &index, &initValue);
+            }
+        }
+        
+        else {
+            int index = impl->model->getFloatingSpeciesIndex(sid);
+
+            if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
+
+                int compartment = impl->model->getCompartmentIndex(species->getCompartment());
+                double compartmentSize = 1;
+                impl->model->getCompartmentVolumes(1, &compartment, &compartmentSize);
+
+                double initValue = initConcentration * compartmentSize;
+                impl->model->setFloatingSpeciesInitAmounts(1, &index, &initValue);
+            }
+        }
     }
 
     void RoadRunner::setConstant(const std::string &sid, bool constant, bool forceRegenerate) {

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -6118,19 +6118,21 @@ namespace rr {
         }
 
         rrLog(Logger::LOG_DEBUG) << "Setting initial amount for species " << sid << "..." << std::endl;
-        if (species->isSetInitialAmount()) {
-            species->unsetInitialAmount();
-        }
-
+        
+        species->unsetInitialConcentration();
         species->setInitialAmount(initAmount);
+
+        //This function returns NULL if there is no such initial assignment.
+        InitialAssignment* ia = sbmlModel->removeInitialAssignment(sid);
+        delete ia;
 
         regenerateModel(forceRegenerate);
 
         // recover the updated init amount
-        int index = impl->model->getFloatingSpeciesIndex(sid);
-        if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
-            impl->model->setFloatingSpeciesInitAmounts(1, &index, &initAmount);
-        }
+        //int index = impl->model->getFloatingSpeciesIndex(sid);
+        //if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
+        //    impl->model->setFloatingSpeciesInitAmounts(1, &index, &initAmount);
+        //}
     }
 
     void RoadRunner::setInitConcentration(const std::string &sid, double initConcentration, bool forceRegenerate) {
@@ -6144,25 +6146,28 @@ namespace rr {
         }
 
         rrLog(Logger::LOG_DEBUG) << "Setting initial concentration for species " << sid << "..." << std::endl;
-        if (species->isSetInitialConcentration()) {
-            species->unsetInitialConcentration();
-        }
+
+        species->unsetInitialAmount();
         species->setInitialConcentration(initConcentration);
+
+        //This function returns NULL if there is no such initial assignment.
+        InitialAssignment* ia = sbmlModel->removeInitialAssignment(sid);
+        delete ia;
 
         regenerateModel(forceRegenerate);
 
         // recover the updated init concentration
-        int index = impl->model->getFloatingSpeciesIndex(sid);
+        //int index = impl->model->getFloatingSpeciesIndex(sid);
 
-        if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
+        //if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
 
-            int compartment = impl->model->getCompartmentIndex(species->getCompartment());
-            double compartmentSize = 1;
-            impl->model->getCompartmentVolumes(1, &compartment, &compartmentSize);
+        //    int compartment = impl->model->getCompartmentIndex(species->getCompartment());
+        //    double compartmentSize = 1;
+        //    impl->model->getCompartmentVolumes(1, &compartment, &compartmentSize);
 
-            double initValue = initConcentration * compartmentSize;
-            impl->model->setFloatingSpeciesInitAmounts(1, &index, &initValue);
-        }
+        //    double initValue = initConcentration * compartmentSize;
+        //    impl->model->setFloatingSpeciesInitAmounts(1, &index, &initValue);
+        //}
     }
 
     void RoadRunner::setConstant(const std::string &sid, bool constant, bool forceRegenerate) {

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -6848,7 +6848,7 @@ namespace rr {
 
         if (replaceInitVal) {
             double initValue = impl->model->getValue("init(" + vid + ")");
-            setSBMLValue(sbmlModel, vid, false, initValue);
+            setSBMLValue(sbmlModel, vid, initValue, false);
         }
 
         regenerateModel(forceRegenerate);

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -3465,18 +3465,27 @@ namespace rr {
     /**
     * find an symbol id in the model and set its value.
     */
-    static void setSBMLValue(libsbml::Model *model, const std::string &id, double value) {
+    static void setSBMLValue(libsbml::Model *model, const std::string &id, double value, bool isConcentration = false) {
         if (model == NULL) {
             throw Exception("You need to load the model first");
         }
 
         libsbml::Species *oSpecies = model->getSpecies(id);
         if (oSpecies != NULL) {
-            if (oSpecies->isSetInitialAmount())
-                oSpecies->setInitialAmount(value);
-            else
+            if (isConcentration) {
+                oSpecies->unsetInitialAmount();
                 oSpecies->setInitialConcentration(value);
+            }
+            else {
+                oSpecies->unsetInitialConcentration();
+                oSpecies->setInitialAmount(value);
+            }
             return;
+        }
+
+        if (isConcentration) {
+            throw std::invalid_argument(
+                "Unable to set initial value: no species with ID " + id + " exists in the model");
         }
 
         libsbml::Compartment *oCompartment = model->getCompartment(id);
@@ -3485,25 +3494,30 @@ namespace rr {
             return;
         }
 
-        for (int i = 0; i < model->getNumReactions(); i++) {
-            libsbml::Reaction *reaction = model->getReaction(i);
-            for (int j = 0; j < reaction->getNumReactants(); j++) {
-                libsbml::SpeciesReference *reference = reaction->getReactant(j);
-                if (reference->isSetId() && reference->getId() == id) {
-                    reference->setStoichiometry(value);
-                    return;
-                }
-            }
-            for (int j = 0; j < reaction->getNumProducts(); j++) {
-                libsbml::SpeciesReference *reference = reaction->getProduct(j);
-                if (reference->isSetId() && reference->getId() == id) {
-                    reference->setStoichiometry(value);
-                    return;
-                }
-            }
+        libsbml::Parameter* param = model->getParameter(id);
+        if (param != NULL) {
+            param->setValue(value);
+            return;
         }
 
-        throw Exception("Invalid std::string name. The id '" + id + "' does not exist in the model");
+        //If it's something else, it could be a stoichiometry:
+        // Don't call getElementBySId first; it's expensive, and very unlikely to not be a parameter, species, or compartment.
+        libsbml::SBase* element = model->getElementBySId(id);
+        if (element == NULL) {
+            throw std::invalid_argument(
+                "Unable to set initial value: no element with ID " + id + " exists in the model");
+        }
+        int type = element->getTypeCode();
+        if (type == libsbml::SBML_SPECIES_REFERENCE) {
+            libsbml::SpeciesReference* sr = static_cast<libsbml::SpeciesReference*>(element);
+            sr->setStoichiometry(value);
+            return;
+        }
+
+        string package = element->getPackageName();
+        throw std::invalid_argument(
+                "Cannot set the initial value of '" + id + "':  cannot set the value of elements of type " + string(libsbml::SBMLTypeCode_toString(type, package.c_str())) + ".");
+
     }
 
 
@@ -4581,15 +4595,27 @@ namespace rr {
         std::vector<std::string> array = getFloatingSpeciesIds();
         for (int i = 0; i < array.size(); i++) {
             double value = 0;
-            impl->model->getFloatingSpeciesAmounts(1, &i, &value);
-            setSpeciesAmount(model, array[i], value);
+            if (model->getSpecies(array[i])->isSetInitialConcentration()) {
+                impl->model->getFloatingSpeciesConcentrations(1, &i, &value);
+                setSBMLValue(model, array[i], value, true);
+            }
+            else {
+                impl->model->getFloatingSpeciesAmounts(1, &i, &value);
+                setSBMLValue(model, array[i], value, false);
+            }
         }
 
         array = getBoundarySpeciesIds();
         for (int i = 0; i < array.size(); i++) {
             double value = 0;
-            impl->model->getBoundarySpeciesConcentrations(1, &i, &value);
-            setSBMLValue(model, array[i], value);
+            if (model->getSpecies(array[i])->isSetInitialConcentration()) {
+                impl->model->getBoundarySpeciesConcentrations(1, &i, &value);
+                setSBMLValue(model, array[i], value, true);
+            }
+            else {
+                impl->model->getBoundarySpeciesAmounts(1, &i, &value);
+                setSBMLValue(model, array[i], value, false);
+            }
         }
 
         array = getCompartmentIds();
@@ -6144,7 +6170,6 @@ namespace rr {
         Model* sbmlModel = impl->document->getModel();
 
         bool isConcentration = false;
-        bool found = false;
         string origId = sid;
 
         if (sid[0] == '[' && sid[sid.size() - 1] == ']') {
@@ -6153,63 +6178,9 @@ namespace rr {
         }
 
         //Remove initial assignment and regenerate and reset if we do (regardless of forceRegenerate; the later 'setValue' won't work otherwise).
-        removeInitialAssignment(sid, true, false);
+        removeInitialAssignment(sid, true, false, false);
 
-        //If it's a species:
-        Species* species = sbmlModel->getSpecies(sid);
-        if (isConcentration && species == NULL) {
-            throw std::invalid_argument(
-                "RoadRunner::setInitValue failed, no species with ID " + sid + " existed in the model to have a concentration.");
-        }
-        if (species != NULL) {
-            if (isConcentration) {
-                species->unsetInitialAmount();
-                species->setInitialConcentration(initValue);
-            }
-            else {
-                species->unsetInitialConcentration();
-                species->setInitialAmount(initValue);
-            }
-            found = true;
-        }
-
-        //If it's a compartment:
-        if (!found) {
-            Compartment* compartment = sbmlModel->getCompartment(sid);
-            if (compartment != NULL) {
-                compartment->setSize(initValue);
-                found = true;
-            }
-        }
-
-        //If it's a Parameter:
-        if (!found) {
-            Parameter* param = sbmlModel->getParameter(sid);
-            if (param != NULL) {
-                param->setValue(initValue);
-                found = true;
-            }
-        }
-
-        //If it's something else; could be a stoichiometry:
-        // Don't call getElementBySId first; it's expensive, and very unlikely to not be a parameter, species, or compartment.
-        if (!found) {
-            SBase* element = sbmlModel->getElementBySId(sid);
-            if (element == NULL) {
-                throw std::invalid_argument(
-                    "Roadrunner::setInitValue failed, no element with ID " + sid + " existed in the model");
-            }
-            int type = element->getTypeCode();
-            if (type == SBML_SPECIES_REFERENCE) {
-                SpeciesReference* sr = static_cast<SpeciesReference*>(element);
-                sr->setStoichiometry(initValue);
-            }
-            else {
-                string package = element->getPackageName();
-                throw std::invalid_argument(
-                    "Cannot set the initial value of '" + sid + "':  cannot set the value of elements of type " + string(SBMLTypeCode_toString(type, package.c_str())) + ".");
-            }
-        }
+        setSBMLValue(sbmlModel, sid, initValue, isConcentration);
 
         impl->model->setValue("init(" + origId + ")", initValue);
         regenerateModel(true);
@@ -6858,7 +6829,7 @@ namespace rr {
         regenerateModel(forceRegenerate, true);
     }
 
-    void RoadRunner::removeInitialAssignment(const std::string &vid, bool forceRegenerate, bool errIfNotExist) {
+    void RoadRunner::removeInitialAssignment(const std::string &vid, bool forceRegenerate, bool errIfNotExist, bool replaceInitVal) {
         using namespace libsbml;
         Model *sbmlModel = impl->document->getModel();
 
@@ -6874,6 +6845,11 @@ namespace rr {
         }
         rrLog(Logger::LOG_DEBUG) << "Removing initial assignment for variable" << vid << "..." << std::endl;
         delete toDelete;
+
+        if (replaceInitVal) {
+            double initValue = impl->model->getValue("init(" + vid + ")");
+            setSBMLValue(sbmlModel, vid, false, initValue);
+        }
 
         regenerateModel(forceRegenerate);
         reset(

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -4658,10 +4658,10 @@ namespace rr {
 
         if (sel.selectionType & SelectionRecord::INITIAL && sel.p2 == "") {
             if (sel.selectionType & SelectionRecord::CONCENTRATION) {
-                setInitConcentration(sel.p1, dValue, false);
+                setInitConcentration(sel.p1, dValue);
             }
             else {
-                setInitValue(sel.p1, dValue, false);
+                setInitValue(sel.p1, dValue);
             }
         }
         
@@ -6113,139 +6113,86 @@ namespace rr {
     }
 
 
-    void RoadRunner::setInitAmount(const std::string& sid, double initAmount, bool forceRegenerate) {
+    void RoadRunner::setInitAmount(const std::string& sid, double initAmount) {
+        //Error check:
         using namespace libsbml;
         Model* sbmlModel = impl->document->getModel();
         Species* species = sbmlModel->getSpecies(sid);
-
         if (species == NULL) {
             throw std::invalid_argument(
-                "Roadrunner::setInitAmount failed, no species with ID " + sid + " existed in the model");
+                "RoadRunner::setInitAmount failed, no species with ID " + sid + " existed in the model");
         }
 
-        rrLog(Logger::LOG_DEBUG) << "Setting initial amount for species " << sid << "..." << std::endl;
-
-        species->unsetInitialConcentration();
-        species->setInitialAmount(initAmount);
-
-        //Remove initial assignment and regenerate and reset if we do (regardless of forceRegenerate; the rest of this function won't work otherwise).
-        removeInitialAssignment(sid, true, false);
-
-        // recover the updated init amount
-        impl->model->setValue("init(" + sid+ ")", initAmount);
-
-        regenerateModel(forceRegenerate);
-        reset(
-            SelectionRecord::TIME |
-            SelectionRecord::RATE |
-            SelectionRecord::FLOATING |
-            SelectionRecord::BOUNDARY |
-            SelectionRecord::COMPARTMENT |
-            SelectionRecord::GLOBAL_PARAMETER);
-        //if (species->getBoundaryCondition()) {
-        //    int index = impl->model->getBoundarySpeciesIndex(sid);
-        //    if (index >= 0 && index < impl->model->getNumBoundarySpecies()) {
-        //        impl->model->setBoundarySpeciesInitAmounts(1, &index, &initAmount);
-        //    }
-        //}
-        //else {
-        //    int index = impl->model->getFloatingSpeciesIndex(sid);
-        //    if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
-        //        impl->model->setFloatingSpeciesInitAmounts(1, &index, &initAmount);
-        //    }
-        //}
+        return setInitValue(sid, initAmount);
     }
 
-    void RoadRunner::setInitConcentration(const std::string &sid, double initConcentration, bool forceRegenerate) {
-        using namespace libsbml;
-        Model *sbmlModel = impl->document->getModel();
-        Species *species = sbmlModel->getSpecies(sid);
-
-        if (species == NULL) {
-            throw std::invalid_argument(
-                    "Roadrunner::setInitConcentration failed, no species with ID " + sid + " existed in the model");
-        }
-
-        rrLog(Logger::LOG_DEBUG) << "Setting initial concentration for species " << sid << "..." << std::endl;
-
-        species->unsetInitialAmount();
-        species->setInitialConcentration(initConcentration);
-
-        //Remove initial assignment and regenerate and reset if we do (regardless of forceRegenerate; the rest of this function won't work otherwise).
-        removeInitialAssignment(sid, true, false);
-
-
-        // recover the updated init concentration
-        impl->model->setValue("init([" + sid + "])", initConcentration);
-
-        regenerateModel(forceRegenerate);
-        reset(
-            SelectionRecord::TIME |
-            SelectionRecord::RATE |
-            SelectionRecord::FLOATING |
-            SelectionRecord::BOUNDARY |
-            SelectionRecord::COMPARTMENT |
-            SelectionRecord::GLOBAL_PARAMETER);
-        //if (species->getBoundaryCondition()) {
-        //    int index = impl->model->getBoundarySpeciesIndex(sid);
-
-        //    if (index >= 0 && index < impl->model->getNumBoundarySpecies()) {
-
-        //        int compartment = impl->model->getCompartmentIndex(species->getCompartment());
-        //        double compartmentSize = 1;
-        //        impl->model->getCompartmentVolumes(1, &compartment, &compartmentSize);
-
-        //        double initValue = initConcentration * compartmentSize;
-        //        //impl->model->setValue(sid, initValue);
-        //        impl->model->setBoundarySpeciesInitAmounts(1, &index, &initValue);
-        //    }
-        //}
-        //
-        //else {
-        //    int index = impl->model->getFloatingSpeciesIndex(sid);
-
-        //    if (index >= 0 && index < impl->model->getNumIndFloatingSpecies()) {
-
-        //        int compartment = impl->model->getCompartmentIndex(species->getCompartment());
-        //        double compartmentSize = 1;
-        //        impl->model->getCompartmentVolumes(1, &compartment, &compartmentSize);
-
-        //        double initValue = initConcentration * compartmentSize;
-        //        //impl->model->setValue(sid, initValue);
-        //        impl->model->setFloatingSpeciesInitAmounts(1, &index, &initValue);
-        //    }
-        //}
-    }
-
-    void RoadRunner::setInitValue(const std::string& sid, double initValue, bool forceRegenerate) {
+    void RoadRunner::setInitConcentration(const std::string &sid, double initConcentration) {
+        //Error check:
         using namespace libsbml;
         Model* sbmlModel = impl->document->getModel();
-        if (sid[0] == '[' && sid[sid.size() - 1] == ']') {
-            string sub_sid = sid.substr(1, sid.size() - 1);
-            return setInitConcentration(sid, initValue, forceRegenerate);
-        }
         Species* species = sbmlModel->getSpecies(sid);
-        if (species != NULL) {
-            return setInitAmount(sid, initValue, forceRegenerate);
+        if (species == NULL) {
+            throw std::invalid_argument(
+                    "RoadRunner::setInitConcentration failed, no species with ID " + sid + " existed in the model");
         }
-        //Remove initial assignment and regenerate and reset if we do (regardless of forceRegenerate; the rest of this function won't work otherwise).
-        removeInitialAssignment(sid, true, false);
 
+        return setInitValue("[" + sid + "]", initConcentration);
+    }
+
+    void RoadRunner::setInitValue(std::string sid, double initValue) {
+        using namespace libsbml;
+        Model* sbmlModel = impl->document->getModel();
+
+        bool isConcentration = false;
         bool found = false;
+        string origId = sid;
+
+        if (sid[0] == '[' && sid[sid.size() - 1] == ']') {
+            sid = sid.substr(1, sid.size() - 2);
+            isConcentration = true;
+        }
+
+        //Remove initial assignment and regenerate and reset if we do (regardless of forceRegenerate; the later 'setValue' won't work otherwise).
+        removeInitialAssignment(sid, true, false);
+
+        //If it's a species:
+        Species* species = sbmlModel->getSpecies(sid);
+        if (isConcentration && species == NULL) {
+            throw std::invalid_argument(
+                "RoadRunner::setInitValue failed, no species with ID " + sid + " existed in the model to have a concentration.");
+        }
+        if (species != NULL) {
+            if (isConcentration) {
+                species->unsetInitialAmount();
+                species->setInitialConcentration(initValue);
+            }
+            else {
+                species->unsetInitialConcentration();
+                species->setInitialAmount(initValue);
+            }
+            found = true;
+        }
+
         //If it's a compartment:
-        Compartment* compartment = sbmlModel->getCompartment(sid);
-        if (compartment != NULL) {
-            compartment->setSize(initValue);
-            found = true;
+        if (!found) {
+            Compartment* compartment = sbmlModel->getCompartment(sid);
+            if (compartment != NULL) {
+                compartment->setSize(initValue);
+                found = true;
+            }
         }
 
-        //or a Parameter:
-        Parameter* param = sbmlModel->getParameter(sid);
-        if (param != NULL) {
-            param->setValue(initValue);
-            found = true;
+        //If it's a Parameter:
+        if (!found) {
+            Parameter* param = sbmlModel->getParameter(sid);
+            if (param != NULL) {
+                param->setValue(initValue);
+                found = true;
+            }
         }
 
+        //If it's something else; could be a stoichiometry:
+        // Don't call getElementBySId first; it's expensive, and very unlikely to not be a parameter, species, or compartment.
         if (!found) {
             SBase* element = sbmlModel->getElementBySId(sid);
             if (element == NULL) {
@@ -6264,8 +6211,8 @@ namespace rr {
             }
         }
 
-        impl->model->setValue("init(" + sid + ")", initValue);
-        regenerateModel(forceRegenerate);
+        impl->model->setValue("init(" + origId + ")", initValue);
+        regenerateModel(true);
         reset(
             SelectionRecord::TIME |
             SelectionRecord::RATE |

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -1111,7 +1111,7 @@ namespace rr {
          *						   to save time for editing for multiple times, one could
          *					       set this flag to true only in the last call of editing
          */
-        void setInitAmount(const std::string &sid, double initAmount, bool forceRegenerate = true);
+        void setInitAmount(const std::string &sid, double initAmount);
 
 
         /**
@@ -1125,7 +1125,7 @@ namespace rr {
          *						   to save time for editing for multiple times, one could
          *					       set this flag to true only in the last call of editing
          */
-        void setInitConcentration(const std::string &sid, double initConcentration, bool forceRegenerate = true);
+        void setInitConcentration(const std::string &sid, double initConcentration);
 
         /**
          * Set initial value for any model element. Previous initial levels will be unset.
@@ -1138,7 +1138,7 @@ namespace rr {
          *						   to save time for editing for multiple times, one could
          *					       set this flag to true only in the last call of editing
          */
-        void setInitValue(const std::string& sid, double initValue, bool forceRegenerate);
+        void setInitValue(std::string sid, double initValue);
 
 
         /**

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -1355,7 +1355,7 @@ namespace rr {
          *						   to save time for editing for multiple times, one could
          *					       set this flag to true only in the last call of editing
          */
-        void removeInitialAssignment(const std::string &vid, bool forceRegenerate = true, bool errIfNotExist = true);
+        void removeInitialAssignment(const std::string& vid, bool forceRegenerate = true, bool errIfNotExist = true, bool replaceInitVal = true);
 
 
         /*

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -1127,6 +1127,19 @@ namespace rr {
          */
         void setInitConcentration(const std::string &sid, double initConcentration, bool forceRegenerate = true);
 
+        /**
+         * Set initial value for any model element. Previous initial levels will be unset.
+         * @param sid: the ID of a model element (if a species, use "S1" for amount or "[S1]" for concentration)
+         * @param initValue:       the initial value to be set
+         * @param forceRegenerate: a boolean value to indicate if the model is regenerated
+         *					       after this function call
+         *						   default value is true to regenerate model after each call
+         *                         of editing function
+         *						   to save time for editing for multiple times, one could
+         *					       set this flag to true only in the last call of editing
+         */
+        void setInitValue(const std::string& sid, double initValue, bool forceRegenerate);
+
 
         /**
          * Set the constant attribute for an existing species/ parameter/ compartment
@@ -1333,7 +1346,7 @@ namespace rr {
 
 
         /**
-         * Remove initial assignment for a symbol from the current model
+         * Remove initial assignment for a symbol from the current model.  Returns whether or not the model was regenerated.
          * @param vid: ID of the symbol
          * @param forceRegenerate: a boolean value to indicate if the model is regenerated
          *					       after this function call

--- a/test/c_api_core/model_editing.cpp
+++ b/test/c_api_core/model_editing.cpp
@@ -481,11 +481,11 @@ TEST_F(CAPIModelEditingTests, SET_HAS_ONLY_SUBSTANCE_UNITS_3) {
 TEST_F(CAPIModelEditingTests, SET_INITIAL_CONCENTRATION_1) {
     EXPECT_TRUE(RunTestWithModification([](RRHandle rri) {
         addSpeciesConcentrationNoRegen(rri, "S1", "C", 0.0, false, false);
-        setInitConcentrationNoRegen(rri, "S1", 0.0004);
+        setInitConcentration(rri, "S1", 0.0004);
         addSpeciesConcentrationNoRegen(rri, "S2", "C", 0.0, false, false);
-        setInitConcentrationNoRegen(rri, "S2", 0.00048);
+        setInitConcentration(rri, "S2", 0.00048);
         addSpeciesConcentrationNoRegen(rri, "S3", "C", 0.0, false, false);
-        setInitConcentrationNoRegen(rri, "S3", 0.0008);
+        setInitConcentration(rri, "S3", 0.0008);
         addSpeciesConcentrationNoRegen(rri, "S4", "C", 0.0, false, false);
         setInitConcentration(rri, "S4", 0.0004);
 
@@ -504,16 +504,16 @@ TEST_F(CAPIModelEditingTests, SET_INITIAL_CONCENTRATION_1) {
 
 TEST_F(CAPIModelEditingTests, SET_INITIAL_CONCENTRATION_2) {
     EXPECT_TRUE(RunTestWithModification([](RRHandle rri) {
-        setInitConcentrationNoRegen(rri, "S1", 0.0004);
-        setInitConcentrationNoRegen(rri, "S2", 0.00048);
-        setInitConcentrationNoRegen(rri, "S3", 0.0008);
+        setInitConcentration(rri, "S1", 0.0004);
+        setInitConcentration(rri, "S2", 0.00048);
+        setInitConcentration(rri, "S3", 0.0008);
         setInitConcentration(rri, "S4", 0.0004);
     }));
 }
 
 TEST_F(CAPIModelEditingTests, SET_INITIAL_AMOUNT_1) {
     EXPECT_TRUE(RunTestWithModification([](RRHandle rri) {
-        setInitAmountNoRegen(rri, "S1", 0.00015);
+        setInitAmount(rri, "S1", 0.00015);
         setInitAmount(rri, "S2", 0);
     }));
 }
@@ -521,7 +521,7 @@ TEST_F(CAPIModelEditingTests, SET_INITIAL_AMOUNT_1) {
 TEST_F(CAPIModelEditingTests, SET_INITIAL_AMOUNT_2) {
     EXPECT_TRUE(RunTestWithModification([](RRHandle rri) {
         addSpeciesConcentration(rri, "S1", "compartment", 0.0, false, false);
-        setInitAmountNoRegen(rri, "S1", 0.00015);
+        setInitAmount(rri, "S1", 0.00015);
         addSpeciesConcentration(rri, "S2", "compartment", 0.0, false, false);
         setInitAmount(rri, "S2", 0);
 

--- a/test/c_api_rrtests/RRTestFileTests.cpp
+++ b/test/c_api_rrtests/RRTestFileTests.cpp
@@ -988,13 +988,17 @@ public:
         double d_value_r;
 
         setValue(gRR, d, d_value);
-        setValue(gRR, d_init, d_value);
-
+        
         resetToOrigin(gRR);
-
         getValue(gRR, d, &d_value_r);
 
         EXPECT_NE(d_value, d_value_r);
+
+        setValue(gRR, d_init, d_value);
+        resetToOrigin(gRR);
+        getValue(gRR, d, &d_value_r);
+
+        EXPECT_NEAR(d_value, d_value_r, 1e-6);
     }
 
     void check_CHECK_RK4_OUTPUT(IniSection *aSection) {

--- a/test/cxx_api_tests/RoadRunnerAPITests.h
+++ b/test/cxx_api_tests/RoadRunnerAPITests.h
@@ -16,7 +16,7 @@
 #include "rrExecutableModel.h"
 #include "rrRoadRunner.h"
 #include "rrConfig.h"
-#include "sbml/sbmlDocument.h"
+#include "sbml/SBMLDocument.h"
 
 using namespace rr;
 

--- a/test/cxx_api_tests/RoadRunnerAPITests.h
+++ b/test/cxx_api_tests/RoadRunnerAPITests.h
@@ -1191,6 +1191,21 @@ public:
         checkMatrixEqual(expected2, actual);
     }
 
+    void setInitAmountWithSetValue() {
+        RoadRunner rr(SimpleFlux().str());
+        rr.setValue("init(S1)", 1234.5);
+        //std::cout << rr.getFloatingSpeciesAmountsNamedArray() << std::endl;
+        ls::DoubleMatrix expected({ {1234.5, 1} });
+        auto actual = rr.getFloatingSpeciesAmountsNamedArray();
+        checkMatrixEqual(expected, actual);
+
+        RoadRunner rr2(Brown2004().str());
+        rr2.setValue("init(PP2AActive)", 1234.5);
+        ls::DoubleMatrix expected2({ {120000, 120000, 1234.5, 120000} });
+        actual = rr2.getBoundarySpeciesAmountsNamedArray();
+        checkMatrixEqual(expected2, actual);
+    }
+
     void setInitConcentration() {
         RoadRunner rr(SimpleFlux().str());
         rr.setInitConcentration("S1", 1234.5);
@@ -1200,7 +1215,7 @@ public:
         checkMatrixEqual(expected, actual);
 
         RoadRunner rr2(Brown2004().str());
-        rr2.setValue("init(cell)", 2);
+        rr2.setInitValue("cell", 2);
         EXPECT_NEAR(rr2.getValue("cell"), 2.0, 0.0001);
         EXPECT_NEAR(rr2.getValue("init(cell)"), 2.0, 0.0001);
         rr2.setInitConcentration("PP2AActive", 1234.5);
@@ -1208,6 +1223,41 @@ public:
         actual = rr2.getBoundarySpeciesConcentrationsNamedArray();
         checkMatrixEqual(expected2, actual);
         ls::DoubleMatrix expected3({ {120000*2, 120000*2, 1234.5*2, 120000*2} });
+        actual = rr2.getBoundarySpeciesAmountsNamedArray();
+        checkMatrixEqual(expected3, actual);
+
+        string sbml = rr2.getSBML();
+        libsbml::SBMLDocument* doc = libsbml::readSBMLFromString(sbml.c_str());
+        libsbml::Model* mod = doc->getModel();
+        EXPECT_NEAR(mod->getCompartment("cell")->getSize(), 2.0, 0.00001);
+        EXPECT_NEAR(mod->getSpecies("PP2AActive")->getInitialConcentration(), 1234.5, 0.00001);
+        EXPECT_NEAR(mod->getSpecies("Raf1Inactive")->getInitialConcentration(), 120000, 0.00001);
+        delete doc;
+    }
+
+    void setInitConcentrationWithSetValue() {
+        RoadRunner rr(SimpleFlux().str());
+        rr.setValue("init([S1])", 1234.5);
+        //std::cout << rr.getFloatingSpeciesAmountsNamedArray() << std::endl;
+        ls::DoubleMatrix expected({ {1234.5, 1} });
+        auto actual = rr.getFloatingSpeciesConcentrationsNamedArray();
+        checkMatrixEqual(expected, actual);
+
+        rr.setInitConcentration("S1", 234.56);
+        //std::cout << rr.getFloatingSpeciesAmountsNamedArray() << std::endl;
+        expected[0][0] = 234.56;
+        actual = rr.getFloatingSpeciesConcentrationsNamedArray();
+        checkMatrixEqual(expected, actual);
+
+        RoadRunner rr2(Brown2004().str());
+        rr2.setValue("init(cell)", 2);
+        EXPECT_NEAR(rr2.getValue("cell"), 2.0, 0.0001);
+        EXPECT_NEAR(rr2.getValue("init(cell)"), 2.0, 0.0001);
+        rr2.setValue("init([PP2AActive])", 1234.5);
+        ls::DoubleMatrix expected2({ {120000, 120000, 1234.5, 120000} });
+        actual = rr2.getBoundarySpeciesConcentrationsNamedArray();
+        checkMatrixEqual(expected2, actual);
+        ls::DoubleMatrix expected3({ {120000 * 2, 120000 * 2, 1234.5 * 2, 120000 * 2} });
         actual = rr2.getBoundarySpeciesAmountsNamedArray();
         checkMatrixEqual(expected3, actual);
 

--- a/test/cxx_api_tests/RoadRunnerAPITests.h
+++ b/test/cxx_api_tests/RoadRunnerAPITests.h
@@ -16,6 +16,7 @@
 #include "rrExecutableModel.h"
 #include "rrRoadRunner.h"
 #include "rrConfig.h"
+#include "sbml/sbmlDocument.h"
 
 using namespace rr;
 
@@ -1200,13 +1201,23 @@ public:
 
         RoadRunner rr2(Brown2004().str());
         rr2.setValue("init(cell)", 2);
+        EXPECT_NEAR(rr2.getValue("cell"), 2.0, 0.0001);
+        EXPECT_NEAR(rr2.getValue("init(cell)"), 2.0, 0.0001);
         rr2.setInitConcentration("PP2AActive", 1234.5);
-        ls::DoubleMatrix expected2({ {120000/2, 120000/2, 1234.5, 120000/2} });
+        ls::DoubleMatrix expected2({ {120000, 120000, 1234.5, 120000} });
         actual = rr2.getBoundarySpeciesConcentrationsNamedArray();
         checkMatrixEqual(expected2, actual);
-        ls::DoubleMatrix expected3({ {120000, 120000, 1234.5*2, 120000} });
+        ls::DoubleMatrix expected3({ {120000*2, 120000*2, 1234.5*2, 120000*2} });
         actual = rr2.getBoundarySpeciesAmountsNamedArray();
         checkMatrixEqual(expected3, actual);
+
+        string sbml = rr2.getSBML();
+        libsbml::SBMLDocument* doc = libsbml::readSBMLFromString(sbml.c_str());
+        libsbml::Model* mod = doc->getModel();
+        EXPECT_NEAR(mod->getCompartment("cell")->getSize(), 2.0, 0.00001);
+        EXPECT_NEAR(mod->getSpecies("PP2AActive")->getInitialConcentration(), 1234.5, 0.00001);
+        EXPECT_NEAR(mod->getSpecies("Raf1Inactive")->getInitialConcentration(), 120000, 0.00001);
+        delete doc;
     }
 
     /**

--- a/test/cxx_api_tests/RoadRunnerAPITests.h
+++ b/test/cxx_api_tests/RoadRunnerAPITests.h
@@ -186,28 +186,28 @@ public:
     void RoadRunnerConstructorVersion() {
         RoadRunner rr(1, 2);
         rr.addCompartment("C1", 1.0);
-        std::cout << rr.getSBML() << std::endl;
+        //std::cout << rr.getSBML() << std::endl;
         rr = RoadRunner(2, 1);
         rr.addCompartment("C1", 1.0);
-        std::cout << rr.getSBML() << std::endl;
+        //std::cout << rr.getSBML() << std::endl;
         rr = RoadRunner(2, 2);
         rr.addCompartment("C1", 1.0);
-        std::cout << rr.getSBML() << std::endl;
+        //std::cout << rr.getSBML() << std::endl;
         rr = RoadRunner(2, 3);
         rr.addCompartment("C1", 1.0);
-        std::cout << rr.getSBML() << std::endl;
+        //std::cout << rr.getSBML() << std::endl;
         rr = RoadRunner(2, 4);
         rr.addCompartment("C1", 1.0);
-        std::cout << rr.getSBML() << std::endl;
+        //std::cout << rr.getSBML() << std::endl;
         rr = RoadRunner(2, 5);
         rr.addCompartment("C1", 1.0);
-        std::cout << rr.getSBML() << std::endl;
+        //std::cout << rr.getSBML() << std::endl;
         rr = RoadRunner(3, 1);
         rr.addCompartment("C1", 1.0);
-        std::cout << rr.getSBML() << std::endl;
+        //std::cout << rr.getSBML() << std::endl;
         rr = RoadRunner(3, 2);
         rr.addCompartment("C1", 1.0);
-        std::cout << rr.getSBML() << std::endl;
+        //std::cout << rr.getSBML() << std::endl;
     }
 
     /**
@@ -790,6 +790,9 @@ public:
         //std::cout << x << std::endl;
         ls::DoubleMatrix expected({{10}});
         checkMatrixEqual(expected, x);
+        x = rr.getFloatingSpeciesAmountsNamedArray();
+        ls::DoubleMatrix expected2({ {1} });
+        checkMatrixEqual(expected2, x);
         delete testModel;
     }
 
@@ -1179,6 +1182,12 @@ public:
         ls::DoubleMatrix expected({{1234.5, 1}});
         auto actual = rr.getFloatingSpeciesAmountsNamedArray();
         checkMatrixEqual(expected, actual);
+
+        RoadRunner rr2(Brown2004().str());
+        rr2.setInitAmount("PP2AActive", 1234.5);
+        ls::DoubleMatrix expected2({ {120000, 120000, 1234.5, 120000} });
+        actual = rr2.getBoundarySpeciesAmountsNamedArray();
+        checkMatrixEqual(expected2, actual);
     }
 
     void setInitConcentration() {
@@ -1188,6 +1197,16 @@ public:
         ls::DoubleMatrix expected({{1234.5, 1}});
         auto actual = rr.getFloatingSpeciesConcentrationsNamedArray();
         checkMatrixEqual(expected, actual);
+
+        RoadRunner rr2(Brown2004().str());
+        rr2.setValue("init(cell)", 2);
+        rr2.setInitConcentration("PP2AActive", 1234.5);
+        ls::DoubleMatrix expected2({ {120000/2, 120000/2, 1234.5, 120000/2} });
+        actual = rr2.getBoundarySpeciesConcentrationsNamedArray();
+        checkMatrixEqual(expected2, actual);
+        ls::DoubleMatrix expected3({ {120000, 120000, 1234.5*2, 120000} });
+        actual = rr2.getBoundarySpeciesAmountsNamedArray();
+        checkMatrixEqual(expected3, actual);
     }
 
     /**

--- a/test/cxx_api_tests/RoadRunnerAPITestsWithLLJit.cpp
+++ b/test/cxx_api_tests/RoadRunnerAPITestsWithLLJit.cpp
@@ -438,8 +438,16 @@ TEST_F(RoadRunnerAPITestsWithLLJit, setInitAmount){
     setInitAmount();
 }
 
+TEST_F(RoadRunnerAPITestsWithLLJit, setInitAmountWithSetValue) {
+    setInitAmountWithSetValue();
+}
+
 TEST_F(RoadRunnerAPITestsWithLLJit, setInitConcentration){
     setInitConcentration();
+}
+
+TEST_F(RoadRunnerAPITestsWithLLJit, setInitConcentrationWithSetValue) {
+    setInitConcentrationWithSetValue();
 }
 
 TEST_F(RoadRunnerAPITestsWithLLJit, DISABLED_setConstant){

--- a/test/cxx_api_tests/RoadRunnerAPITestsWithMCJit.cpp
+++ b/test/cxx_api_tests/RoadRunnerAPITestsWithMCJit.cpp
@@ -438,8 +438,16 @@ TEST_F(RoadRunnerAPITestsWithMCJit, setInitAmount){
     setInitAmount();
 }
 
+TEST_F(RoadRunnerAPITestsWithMCJit, setInitAmountWithSetValue) {
+    setInitAmountWithSetValue();
+}
+
 TEST_F(RoadRunnerAPITestsWithMCJit, setInitConcentration){
     setInitConcentration();
+}
+
+TEST_F(RoadRunnerAPITestsWithMCJit, setInitConcentrationWithSetValue) {
+    setInitConcentrationWithSetValue();
 }
 
 TEST_F(RoadRunnerAPITestsWithMCJit, DISABLED_setConstant){

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -22,6 +22,24 @@ public:
 };
 
 
+TEST_F(ModelAnalysisTests, RegenerateOddModel) {
+    //This model has both an independent and a dependent floating species, so
+    // the original version of regenerateModel got things wrong when transferring
+    // data from one to the other.  This checks to ensure this was fixed.
+    RoadRunner rr((modelAnalysisModelsDir / "floating_change_rate.xml").string());
+    rr.simulate();
+    double S1 = rr.getValue("init(S1)");
+    EXPECT_EQ(S1, 3);
+    S1 = rr.getValue("S1");
+    EXPECT_EQ(S1, 23);
+    rr.regenerateModel(true, false);
+    S1 = rr.getValue("init(S1)");
+    EXPECT_EQ(S1, 3);
+    S1 = rr.getValue("S1");
+    EXPECT_EQ(S1, 23);
+}
+
+
 TEST_F(ModelAnalysisTests, SimulateWithSameTimes) {
     RoadRunner rr((modelAnalysisModelsDir / "BIOMD0000000035_url.xml").string());
     std::vector<double> times;
@@ -1113,6 +1131,10 @@ TEST_F(ModelAnalysisTests, ResetFloatingSpeciesRate) {
     rr.reset();
     S1 = rr.getValue("S1");
     EXPECT_EQ(S1, 10);
+
+    rr.setValue("init(S2)", 15);
+    EXPECT_EQ(rr.getValue("S2"), 15);
+
 }
 
 

--- a/test/model_editing/model_editing.cpp
+++ b/test/model_editing/model_editing.cpp
@@ -1449,11 +1449,11 @@ TEST_F(ModelEditingTests, SET_HAS_ONLY_SUBSTANCE_UNITS_3) {
 TEST_F(ModelEditingTests, SET_INITIAL_CONCENTRATION_1) {
     ASSERT_TRUE(RunModelEditingTest([](RoadRunner *rri) {
         rri->addSpeciesConcentration("S1", "C", 0.0);
-        rri->setInitConcentration("S1", 0.0004, false);
+        rri->setInitConcentration("S1", 0.0004);
         rri->addSpeciesConcentration("S2", "C", 0.0);
-        rri->setInitConcentration("S2", 0.00048, false);
+        rri->setInitConcentration("S2", 0.00048);
         rri->addSpeciesConcentration("S3", "C", 0.0);
-        rri->setInitConcentration("S3", 0.0008, false);
+        rri->setInitConcentration("S3", 0.0008);
         rri->addSpeciesConcentration("S4", "C", 0.0);
         rri->setInitConcentration("S4", 0.0004);
 
@@ -1468,16 +1468,16 @@ TEST_F(ModelEditingTests, SET_INITIAL_CONCENTRATION_1) {
 
 TEST_F(ModelEditingTests, SET_INITIAL_CONCENTRATION_2) {
     ASSERT_TRUE(RunModelEditingTest([](RoadRunner *rri) {
-        rri->setInitConcentration("S1", 0.0004, false);
-        rri->setInitConcentration("S2", 0.00048, false);
-        rri->setInitConcentration("S3", 0.0008, false);
+        rri->setInitConcentration("S1", 0.0004);
+        rri->setInitConcentration("S2", 0.00048);
+        rri->setInitConcentration("S3", 0.0008);
         rri->setInitConcentration("S4", 0.0004);
     }));
 }
 
 TEST_F(ModelEditingTests, SET_INITIAL_AMOUNT_1) {
     ASSERT_TRUE(RunModelEditingTest([](RoadRunner *rri) {
-        rri->setInitAmount("S1", 0.00015, false);
+        rri->setInitAmount("S1", 0.00015);
         rri->setInitAmount("S2", 0);
     }));
 }
@@ -1485,7 +1485,7 @@ TEST_F(ModelEditingTests, SET_INITIAL_AMOUNT_1) {
 TEST_F(ModelEditingTests, SET_INITIAL_AMOUNT_2) {
     ASSERT_TRUE(RunModelEditingTest([](RoadRunner *rri) {
         rri->addSpeciesConcentration("S1", "compartment", 1.0, false, false);
-        rri->setInitAmount("S1", 0.00015, false);
+        rri->setInitAmount("S1", 0.00015);
         rri->addSpeciesConcentration("S2", "compartment", 1.0, false, false);
         rri->setInitAmount("S2", 0);
 

--- a/test/model_editing/model_editing.cpp
+++ b/test/model_editing/model_editing.cpp
@@ -8,6 +8,7 @@
 #include "../test_util.h"
 #include <filesystem>
 #include "RoadRunnerTest.h"
+#include "TestModelFactory.h"
 
 using namespace testing;
 using namespace rr;
@@ -501,6 +502,14 @@ void ModelEditingTests::removeAndReaddAllCompartments(RoadRunner *rri, libsbml::
     readdAllEvents(rri, doc);
 }
 
+TEST_F(ModelEditingTests, SET_INITIAL_VALUE_WITH_INITIAL_ASSIGNMENT) {
+    TestModel* testModel = TestModelFactory("SimpleFlux");
+    //TestModel* testModel = TestModelFactory("SimpleFluxManuallyReduced");
+    RoadRunner rr(testModel->str());
+    rr.addInitialAssignment("S1", "5/3", true);
+    rr.setValue("init(S1)", 3);
+    //Logger::setLevel(Logger::LOG_DEBUG);
+}
 
 TEST_F(ModelEditingTests, SET_INITIAL_ASSIGNMENT_INIT) {
     RoadRunner rri;

--- a/test/python/test_rrtests.py
+++ b/test/python/test_rrtests.py
@@ -953,7 +953,6 @@ def rtestResetToOrigin(rrInstance, testId):
     errorFlag = False
     words = divide(readLine())
     rrInstance.setValue(words[0], float(words[1]))
-    rrInstance.setValue("init(" + words[0] + ")", float(words[1]))
     rrInstance.resetToOrigin()
     d = rrInstance.getValue(words[0])
     rrInstance.reset()

--- a/test/rrtest_files/Add_Reactions2.rrtest
+++ b/test/rrtest_files/Add_Reactions2.rrtest
@@ -349,7 +349,7 @@ rates=0.101 -0.08 -1.071
 "k1 1.0 X1 1.0"
 
 [Test ResetToOrigin]
-"X1 1.0"
+"X1 5.5"
 
 [Test SetValues]
 "S1 S2 S3 1.0 2.0 3.0"

--- a/test/rrtest_files/Remove_Compartment1.rrtest
+++ b/test/rrtest_files/Remove_Compartment1.rrtest
@@ -467,7 +467,7 @@ rates=0.101 -0.08 -1.071
 "k1 1.0 X1 1.0"
 
 [Test ResetToOrigin]
-"X1 1.0"
+"X1 5.5"
 
 [Test SetValues]
 "S1 S2 S3 1.0 2.0 3.0"

--- a/test/rrtest_files/Remove_Parameter1.rrtest
+++ b/test/rrtest_files/Remove_Parameter1.rrtest
@@ -401,7 +401,7 @@ rates=0.101 -0.08 -1.071
 "k1 1.0 X1 1.0"
 
 [Test ResetToOrigin]
-"X1 1.0"
+"X1 5.5"
 
 [Test SetValues]
 "S1 S2 S3 1.0 2.0 3.0"

--- a/test/rrtest_files/Remove_Rules1.rrtest
+++ b/test/rrtest_files/Remove_Rules1.rrtest
@@ -399,7 +399,7 @@ rates=0.101 -0.08 -1.071
 "k1 1.0 X1 1.0"
 
 [Test ResetToOrigin]
-"X1 1.0"
+"X1 5.5"
 
 [Test SetValues]
 "S1 S2 S3 1.0 2.0 3.0"

--- a/test/rrtest_files/Remove_Species1.rrtest
+++ b/test/rrtest_files/Remove_Species1.rrtest
@@ -464,7 +464,7 @@ rates=0.101 -0.08 -1.071
 "k1 1.0 X1 1.0"
 
 [Test ResetToOrigin]
-"X1 1.0"
+"X1 5.5"
 
 [Test SetValues]
 "S1 S2 S3 1.0 2.0 3.0"

--- a/test/rrtest_files/Set_Kinetic_Law1.rrtest
+++ b/test/rrtest_files/Set_Kinetic_Law1.rrtest
@@ -354,7 +354,7 @@ rates=0.101 -0.08 -1.071
 "k1 1.0 X1 1.0"
 
 [Test ResetToOrigin]
-"X1 1.0"
+"X1 5.5"
 
 [Test SetValues]
 "S1 S2 S3 1.0 2.0 3.0"

--- a/test/rrtest_files/Test_1.rrtest
+++ b/test/rrtest_files/Test_1.rrtest
@@ -382,7 +382,7 @@ rates=0.101 -0.08 -1.071
 "k1 1.0 X1 1.0"
 
 [Test ResetToOrigin]
-"X1 1.0"
+"X1 5.5"
 
 [Test SetValues]
 "S1 S2 S3 1.0 2.0 3.0"

--- a/wrappers/C/rrc_api.cpp
+++ b/wrappers/C/rrc_api.cpp
@@ -1911,29 +1911,11 @@ bool rrcCallConv setInitAmount(RRHandle handle, const char* sid, double initAmou
 	catch_bool_macro
 }
 
-bool rrcCallConv setInitAmountNoRegen(RRHandle handle, const char* sid, double initAmount)
-{
-	start_try
-		RoadRunner* rri = castToRoadRunner(handle);
-		rri->setInitAmount(sid, initAmount, false);
-		return true;
-	catch_bool_macro
-}
-
 bool rrcCallConv setInitConcentration(RRHandle handle, const char* sid, double initConcentration)
 {
 	start_try
 		RoadRunner* rri = castToRoadRunner(handle);
 		rri->setInitConcentration(sid, initConcentration);
-		return true;
-	catch_bool_macro
-}
-
-bool rrcCallConv setInitConcentrationNoRegen(RRHandle handle, const char* sid, double initConcentration)
-{
-	start_try
-		RoadRunner* rri = castToRoadRunner(handle);
-		rri->setInitConcentration(sid, initConcentration, false);
 		return true;
 	catch_bool_macro
 }

--- a/wrappers/C/rrc_api.h
+++ b/wrappers/C/rrc_api.h
@@ -573,17 +573,6 @@ C_DECL_SPEC bool rrcCallConv setHasOnlySubstanceUnitsNoRegen(RRHandle handle, co
 C_DECL_SPEC bool rrcCallConv setInitAmount(RRHandle handle, const char* sid, double initAmount);
 
 /*!
- \brief Set initial amount for an existing species, without regenerating it
-		The last modification must regenerate for the modifications to take effect
- \param[in] handle Handle to a RoadRunner instance
- \param[in] sid ID of the species
- \param[in] initAmount Initial amount to be set
- \return Returns false if the call fails, otherwise returns a true
- \ingroup edit
-*/
-C_DECL_SPEC bool rrcCallConv setInitAmountNoRegen(RRHandle handle, const char* sid, double initAmount);
-
-/*!
  \brief Set initial concentration for an existing species. Initial amount/concentration set before will be unset.
  \param[in] handle Handle to a RoadRunner instance
  \param[in] sid ID of the species
@@ -592,18 +581,6 @@ C_DECL_SPEC bool rrcCallConv setInitAmountNoRegen(RRHandle handle, const char* s
  \ingroup edit
 */
 C_DECL_SPEC bool rrcCallConv setInitConcentration(RRHandle handle, const char* sid, double initConcentration);
-
-/*!
- \brief Set initial concentration for an existing species, without regenerating it
-		The last modification must regenerate for the modifications to take effect
- \param[in] handle Handle to a RoadRunner instance
- \param[in] sid ID of the species
- \param[in] initConcentration Initial concentration to be set
- \return Returns false if the call fails, otherwise returns a true
- \ingroup edit
-*/
-C_DECL_SPEC bool rrcCallConv setInitConcentrationNoRegen(RRHandle handle, const char* sid, double initConcentration);
-
 
 /*!
  \brief Set the constant attribute for an existing species/ parameter/ compartment.


### PR DESCRIPTION
Make setInitAmount, setInitConcentration, and setValue("init(..)", val) work consistently.

Make sure:
* Initial assignments are properly dropped when necessary.
* getSBML() behaves as expected.
* resetToOrigin() behaves as expected.