### PR TITLE
Fix steady state solver decorators handing out dead model pointers.

### DIFF
--- a/source/ApproxSteadyStateDecorator.cpp
+++ b/source/ApproxSteadyStateDecorator.cpp
@@ -28,18 +28,23 @@ namespace rr {
             //  step_size * num_steps = duration
             const double stepSize = end / steps;
 
-            const int &numVariables = mModel->getStateVector(nullptr);
-            CVODEIntegrator integrator(solver_->getModel());
+            rr::ExecutableModel* model = getModel();
+            model->reset();
+            const int &numVariables = model->getStateVector(nullptr);
+            CVODEIntegrator integrator(model);
 
             // integrate and collect the sundials N_Vector
-            integrator.integrate(end - (2*stepSize), stepSize);
-            solver_->syncWithModel(solver_->getModel());
-            N_Vector stateVectorAtTMinus2 = integrator.getStateVector();
-            double* stateVectorAtTMinus2ArrPtr = stateVectorAtTMinus2->ops->nvgetarraypointer(stateVectorAtTMinus2);
+            integrator.integrate(end - stepSize, stepSize);
+            solver_->syncWithModel(model);
+            N_Vector svtm1 = integrator.getStateVector();
+            std::vector<double> stateVectorAtTMinus1;
+            for (int i = 0; i < svtm1->ops->nvgetlength(svtm1); i++) {
+              stateVectorAtTMinus1.push_back(svtm1->ops->nvgetarraypointer(svtm1)[i]);
+            }
 
             // integrate collect the new sundials N_Vector
-            integrator.integrate(end - stepSize, stepSize);
-            solver_->syncWithModel(solver_->getModel());
+            integrator.integrate(end, stepSize);
+            solver_->syncWithModel(model);
             N_Vector stateVectorAtT = integrator.getStateVector();
             double *stateVectorAtTArrPtr = stateVectorAtT->ops->nvgetarraypointer(stateVectorAtT);
 
@@ -47,7 +52,7 @@ namespace rr {
             for (int i = 0; i < stateVectorAtT->ops->nvgetlength(stateVectorAtT); i++) {
                 tol += sqrt(
                         pow(
-                                (stateVectorAtTMinus2ArrPtr[i] - stateVectorAtTArrPtr[i]) / stepSize,
+                                (stateVectorAtTMinus1[i] - stateVectorAtTArrPtr[i]) / stepSize,
                                 2)
                 );
             }
@@ -76,6 +81,11 @@ namespace rr {
 
     Solver *ApproxSteadyStateDecorator::construct(ExecutableModel *executableModel) const {
         return new ApproxSteadyStateDecorator(executableModel);
+    }
+
+    bool ApproxSteadyStateDecorator::hasApproxSetup()
+    {
+      return true;
     }
 
     /** @endcond PRIVATE */

--- a/source/ApproxSteadyStateDecorator.cpp
+++ b/source/ApproxSteadyStateDecorator.cpp
@@ -34,7 +34,7 @@ namespace rr {
             CVODEIntegrator integrator(model);
 
             // integrate and collect the sundials N_Vector
-            integrator.integrate(end - stepSize, stepSize);
+            integrator.integrate(end - (2*stepSize), stepSize);
             solver_->syncWithModel(model);
             N_Vector svtm1 = integrator.getStateVector();
             std::vector<double> stateVectorAtTMinus1;
@@ -43,7 +43,7 @@ namespace rr {
             }
 
             // integrate collect the new sundials N_Vector
-            integrator.integrate(end, stepSize);
+            integrator.integrate(end-stepSize, stepSize);
             solver_->syncWithModel(model);
             N_Vector stateVectorAtT = integrator.getStateVector();
             double *stateVectorAtTArrPtr = stateVectorAtT->ops->nvgetarraypointer(stateVectorAtT);

--- a/source/ApproxSteadyStateDecorator.h
+++ b/source/ApproxSteadyStateDecorator.h
@@ -22,6 +22,8 @@ namespace rr {
 
         Solver* construct(ExecutableModel* executableModel) const override;
 
+        virtual bool hasApproxSetup() override;
+
     private:
         std::string decoratorName() const override;
 

--- a/source/PresimulationProgramDecorator.cpp
+++ b/source/PresimulationProgramDecorator.cpp
@@ -26,16 +26,17 @@ namespace rr {
             std::vector<double> times = presimulationTimesVariant.get<std::vector<double>>();
             for (const auto &timePoint: times) {
                 solver_->getModel()->reset();
-                CVODEIntegrator integrator(solver_->getModel());
-                // integrate one interval between 0 and presimulation_time.
-                integrator.integrate(0, timePoint);
-                solver_->syncWithModel(solver_->getModel());
-
+                if (timePoint != 0) {
+                  CVODEIntegrator integrator(solver_->getModel());
+                  // integrate one interval between 0 and presimulation_time.
+                  integrator.integrate(0, timePoint);
+                  solver_->syncWithModel(solver_->getModel());
+                }
                 try {
                     return solver_->solve();
                 } catch (std::exception &err) {
                     if (timePoint == times.back())
-                        throw CoreException("SteadyStateSolver failed to solve presimulation program: ", err.what());
+                        throw std::runtime_error(string("SteadyStateSolver failed to solve presimulation program: ") + err.what());
                 }
             }
         }
@@ -48,5 +49,9 @@ namespace rr {
 
     Solver *PresimulationProgramDecorator::construct(ExecutableModel *executableModel) const {
         return new PresimulationProgramDecorator(executableModel);
+    }
+    bool PresimulationProgramDecorator::hasPresimSetup()
+    {
+      return true;
     }
 }

--- a/source/PresimulationProgramDecorator.h
+++ b/source/PresimulationProgramDecorator.h
@@ -35,6 +35,8 @@ namespace rr {
 
         Solver* construct(ExecutableModel* executableModel) const override;
 
+        virtual bool hasPresimSetup() override;
+
     private:
         std::string decoratorName() const override;
     };

--- a/source/Solver.cpp
+++ b/source/Solver.cpp
@@ -37,6 +37,16 @@ namespace rr
         }
     }
 
+    bool Solver::hasPresimSetup()
+    {
+      return false;
+    }
+
+    bool Solver::hasApproxSetup()
+    {
+      return false;
+    }
+
     void Solver::updateSettings(Dictionary * inputSettings)
     {
         if (!inputSettings)

--- a/source/Solver.h
+++ b/source/Solver.h
@@ -188,6 +188,9 @@ namespace rr
          */
         virtual ExecutableModel *getModel() const;
 
+        virtual bool hasPresimSetup();
+        virtual bool hasApproxSetup();
+
 
         using SettingsList     =  std::vector<std::string> ;
         using SettingsMap      =  std::unordered_map<std::string, Setting> ;

--- a/source/SteadyStateSolverDecorator.cpp
+++ b/source/SteadyStateSolverDecorator.cpp
@@ -15,8 +15,10 @@ namespace rr {
     }
 
     SteadyStateSolverDecorator::SteadyStateSolverDecorator(SteadyStateSolver *solver)
-        : SteadyStateSolver(solver->getModel()), solver_(solver){
+        : SteadyStateSolver(solver->getModel()), solver_(solver)
+    {
         settings = solver_->getSettingsMap();
+        mModel = nullptr;
     }
 
     std::string SteadyStateSolverDecorator::getName() const {
@@ -33,6 +35,21 @@ namespace rr {
 
     void SteadyStateSolverDecorator::resetSettings()  {
         return solver_->resetSettings();
+    }
+
+    ExecutableModel* SteadyStateSolverDecorator::getModel() const
+    {
+        return solver_->getModel();
+    }
+
+    bool SteadyStateSolverDecorator::hasPresimSetup()
+    {
+      return solver_->hasPresimSetup();
+    }
+
+    bool SteadyStateSolverDecorator::hasApproxSetup()
+    {
+      return solver_->hasApproxSetup();
     }
 
     std::string SteadyStateSolverDecorator::decoratorName() const {

--- a/source/SteadyStateSolverDecorator.h
+++ b/source/SteadyStateSolverDecorator.h
@@ -44,6 +44,15 @@ namespace rr {
 
         void resetSettings() override;
 
+        /**
+         * @brief returns the pointer to the ExecutableModel
+         */
+        virtual ExecutableModel* getModel() const override;
+
+        virtual bool hasPresimSetup() override;
+        virtual bool hasApproxSetup() override;
+
+
     protected:
         SteadyStateSolver *solver_;
 

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1650,18 +1650,42 @@ namespace rr {
 //    SteadyStateSolver* copyOfSSSolverPtr;
 
         // apply presimulation decorator if requested by user
-        if (impl->steady_state_solver->getValue("allow_presimulation")) {
+        if (impl->steady_state_solver->getValue("allow_presimulation") &&
+          !impl->steady_state_solver->hasPresimSetup()) {
             presimDec = new PresimulationProgramDecorator(impl->steady_state_solver);
             impl->steady_state_solver = presimDec;
         }
 
         // apply approximation decorator if requested by user
-        if (impl->steady_state_solver->getValue("allow_approx")) {
+        if (impl->steady_state_solver->getValue("allow_approx") &&
+          !impl->steady_state_solver->hasApproxSetup()) {
             approxDec = new ApproxSteadyStateDecorator(impl->steady_state_solver);
             impl->steady_state_solver = approxDec;
         }
 
-        double ss = impl->steady_state_solver->solve();
+        double ss = 0;
+        try {
+          ss = impl->steady_state_solver->solve();
+        }
+        catch (exception& e) {
+          if (presimDec) {
+            delete presimDec;
+            presimDec = nullptr;
+          }
+
+          if (approxDec) {
+            delete approxDec;
+            approxDec = nullptr;
+          }
+
+          // put back to original type before return
+          // so the next call to steadyState starts
+          // without any decorators.
+          setSteadyStateSolver(solverName);
+          if (!currentConservedMoietyAnalysisStatus)
+            setConservedMoietyAnalysis(currentConservedMoietyAnalysisStatus);
+          throw;
+        }
 
         if (presimDec) {
             delete presimDec;

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -22,6 +22,19 @@ public:
 };
 
 
+TEST_F(ModelAnalysisTests, issue1259) {
+  BasicDictionary opt;
+  opt.setItem("allow_approx", true);
+  opt.setItem("allow_presimulation", true);
+
+  rr::RoadRunner rr((modelAnalysisModelsDir / "no_steady_state.xml").string());
+  EXPECT_THROW(rr.steadyState(&opt), CoreException);
+
+  rr.load((modelAnalysisModelsDir / "no_steady_state.xml").string());
+  EXPECT_THROW(rr.steadyState(&opt), CoreException);
+}
+
+
 TEST_F(ModelAnalysisTests, RegenerateOddModel) {
     //This model has both an independent and a dependent floating species, so
     // the original version of regenerateModel got things wrong when transferring

--- a/test/models/ModelAnalysis/no_steady_state.xml
+++ b/test/models/ModelAnalysis/no_steady_state.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v3.1.0 with libSBML version 5.20.5. -->
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4">
+  <model metaid="__main" id="__main">
+    <listOfParameters>
+      <parameter id="a" value="0.3" constant="false"/>
+    </listOfParameters>
+    <listOfRules>
+      <rateRule variable="a">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <cn type="integer"> 1 </cn>
+        </math>
+      </rateRule>
+    </listOfRules>
+  </model>
+</sbml>

--- a/test/models/PLUGINS/BIOMD0000000648_url.xml
+++ b/test/models/PLUGINS/BIOMD0000000648_url.xml
@@ -1,0 +1,7130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" metaid="c2a1c769-46af-47fc-8b03-716ece003433" level="2" version="4">
+  <model metaid="COPASI0" id="Padala2017__ERK__PI3K_Akt_and_Wnt_signalling_network__normal" name="Padala2017- ERK, PI3K/Akt and Wnt signalling network (normal)">
+    <notes>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+        <div class="dc:title">Padala2017- ERK, PI3K/Akt and Wnt signalling
+network (normal)</div>
+        <div class="dc:description">Crosstalk model of the ERK, Wnt and Akt
+signalling pathways under normal condition.</div>
+        <div class="dc:bibliographicCitation">
+          <p>This model is described in the article:</p>
+          <div class="bibo:title">
+            <a href="http://identifiers.org/pubmed/28367561" title="Access to this publication">Cancerous perturbations
+    within the ERK, PI3K/Akt, and Wnt/?-catenin signaling network
+    constitutively activate inter-pathway positive feedback
+    loops.</a>
+          </div>
+          <div class="bibo:authorList">Padala RR, Karnawat R, Viswanathan
+  SB, Thakkar AV, Das AB.</div>
+          <div class="bibo:Journal">Mol Biosyst 2017 May; 13(5):
+  830-840</div>
+          <p>Abstract:</p>
+          <div class="bibo:abstract">
+            <p>Perturbations in molecular signaling pathways are a result
+    of genetic or epigenetic alterations, which may lead to
+    malignant transformation of cells. Despite cellular robustness,
+    specific genetic or epigenetic changes of any gene can trigger
+    a cascade of failures, which result in the malfunctioning of
+    cell signaling pathways and lead to cancer phenotypes. The
+    extent of cellular robustness has a link with the architecture
+    of the network such as feedback and feedforward loops.
+    Perturbation in components within feedback loops causes a
+    transition from a regulated to a persistently activated state
+    and results in uncontrolled cell growth. This work represents
+    the mathematical and quantitative modeling of ERK, PI3K/Akt,
+    and Wnt/?-catenin signaling crosstalk to show the dynamics of
+    signaling responses during genetic and epigenetic changes in
+    cancer. ERK, PI3K/Akt, and Wnt/?-catenin signaling crosstalk
+    networks include both intra and inter-pathway feedback loops
+    which function in a controlled fashion in a healthy cell. Our
+    results show that cancerous perturbations of components such as
+    EGFR, Ras, B-Raf, PTEN, and components of the destruction
+    complex cause extreme fragility in the network and
+    constitutively activate inter-pathway positive feedback loops.
+    We observed that the aberrant signaling response due to the
+    failure of specific network components is transmitted
+    throughout the network via crosstalk, generating an additive
+    effect on cancer growth and proliferation.</p>
+          </div>
+        </div>
+        <div class="dc:publisher">
+          <p>This model is hosted on 
+  <a href="http://www.ebi.ac.uk/biomodels/">BioModels Database</a>
+  and identified by: 
+  <a href="http://identifiers.org/biomodels.db/BIOMD0000000648">BIOMD0000000648</a>.</p>
+          <p>To cite BioModels Database, please use: 
+  <a href="http://identifiers.org/pubmed/25414348" target="_blank">Chelliah V et al. BioModels: ten-year
+  anniversary. Nucl. Acids Res. 2015, 43(Database
+  issue):D542-8</a>.</p>
+        </div>
+        <div class="dc:license">
+          <p>To the extent possible under law, all copyright and related or
+  neighbouring rights to this encoded model have been dedicated to
+  the public domain worldwide. Please refer to 
+  <a href="http://creativecommons.org/publicdomain/zero/1.0/" title="Access to: CC0 1.0 Universal (CC0 1.0), Public Domain Dedication">CC0
+  Public Domain Dedication</a> for more information.</p>
+        </div>
+      </body>
+    </notes>
+    <annotation>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+        <rdf:Description rdf:about="#COPASI0">
+          <dc:creator>
+            <rdf:Bag>
+              <rdf:li rdf:parseType="Resource">
+                <vCard:N rdf:parseType="Resource">
+                  <vCard:Family>Sheriff</vCard:Family>
+                  <vCard:Given>Rahuman</vCard:Given>
+                </vCard:N>
+                <vCard:EMAIL>sheriff@ebi.ac.uk</vCard:EMAIL>
+                <vCard:ORG rdf:parseType="Resource">
+                  <vCard:Orgname>EMBL-EBI</vCard:Orgname>
+                </vCard:ORG>
+              </rdf:li>
+              <rdf:li rdf:parseType="Resource">
+                <vCard:N rdf:parseType="Resource">
+                  <vCard:Family>Fairbanks</vCard:Family>
+                  <vCard:Given>Emma</vCard:Given>
+                </vCard:N>
+                <vCard:EMAIL>emmafairbanks93@gmail.com</vCard:EMAIL>
+                <vCard:ORG rdf:parseType="Resource">
+                  <vCard:Orgname>University of Nottingham</vCard:Orgname>
+                </vCard:ORG>
+              </rdf:li>
+            </rdf:Bag>
+          </dc:creator>
+          <dcterms:created rdf:parseType="Resource">
+            <dcterms:W3CDTF>2017-08-14T10:34:00Z</dcterms:W3CDTF>
+          </dcterms:created>
+          <dcterms:modified rdf:parseType="Resource">
+            <dcterms:W3CDTF>2017-09-20T14:26:44Z</dcterms:W3CDTF>
+          </dcterms:modified>
+          <bqmodel:is>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/biomodels.db/MODEL1708290005"/>
+            </rdf:Bag>
+          </bqmodel:is>
+          <bqmodel:is>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/biomodels.db/BIOMD0000000648"/>
+            </rdf:Bag>
+          </bqmodel:is>
+          <bqmodel:isDescribedBy>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/pubmed/28367561"/>
+            </rdf:Bag>
+          </bqmodel:isDescribedBy>
+          <bqmodel:isDerivedFrom>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/biomodels.db/BIOMD0000000149"/>
+              <rdf:li rdf:resource="http://identifiers.org/biomodels.db/BIOMD0000000033"/>
+              <rdf:li rdf:resource="http://identifiers.org/biomodels.db/BIOMD0000000623"/>
+            </rdf:Bag>
+          </bqmodel:isDerivedFrom>
+          <bqbiol:hasProperty>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/mamo/MAMO_0000046"/>
+            </rdf:Bag>
+          </bqbiol:hasProperty>
+          <bqbiol:isDescribedBy>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/pubmed/21391741"/>
+            </rdf:Bag>
+          </bqbiol:isDescribedBy>
+          <bqbiol:hasProperty>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/go/GO:0043408"/>
+              <rdf:li rdf:resource="http://identifiers.org/go/GO:0060828"/>
+              <rdf:li rdf:resource="http://identifiers.org/go/GO:0051896"/>
+            </rdf:Bag>
+          </bqbiol:hasProperty>
+          <bqbiol:hasPart>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/kegg.pathway/map04010"/>
+              <rdf:li rdf:resource="http://identifiers.org/kegg.pathway/map04151"/>
+              <rdf:li rdf:resource="http://identifiers.org/kegg.pathway/map04310"/>
+              <rdf:li rdf:resource="http://identifiers.org/go/GO:0000165"/>
+            </rdf:Bag>
+          </bqbiol:hasPart>
+          <bqbiol:hasTaxon>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/taxonomy/9606"/>
+            </rdf:Bag>
+          </bqbiol:hasTaxon>
+        </rdf:Description>
+      </rdf:RDF>
+      <COPASI xmlns="http://www.copasi.org/static/sbml">
+        <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">
+          <rdf:Description rdf:about="#COPASI0">
+            <dcterms:bibliographicCitation>
+              <rdf:Description>
+                <CopasiMT:isDescribedBy rdf:resource="urn:miriam:pubmed:21391741"/>
+              </rdf:Description>
+            </dcterms:bibliographicCitation>
+            <dcterms:created>
+              <rdf:Description>
+                <dcterms:W3CDTF>2017-08-14T10:34:00Z</dcterms:W3CDTF>
+              </rdf:Description>
+            </dcterms:created>
+            <dcterms:creator>
+              <rdf:Description>
+                <vCard:EMAIL>efairbanks@ebi.ac.uk</vCard:EMAIL>
+                <vCard:N>
+                  <rdf:Description>
+                    <vCard:Family>Fairbanks</vCard:Family>
+                    <vCard:Given>Emma</vCard:Given>
+                  </rdf:Description>
+                </vCard:N>
+                <vCard:ORG>
+                  <rdf:Description>
+                    <vCard:Orgname>EMBL-EBI</vCard:Orgname>
+                  </rdf:Description>
+                </vCard:ORG>
+              </rdf:Description>
+            </dcterms:creator>
+            <CopasiMT:hasProperty rdf:resource="urn:miriam:go:GO:0043408"/>
+            <CopasiMT:hasProperty rdf:resource="urn:miriam:go:GO:0051896"/>
+            <CopasiMT:hasProperty rdf:resource="urn:miriam:go:GO:0060828"/>
+            <CopasiMT:hasProperty rdf:resource="urn:miriam:pw:PW:0000605"/>
+            <CopasiMT:hasPart rdf:resource="urn:miriam:go:GO:0000165"/>
+            <CopasiMT:hasPart rdf:resource="urn:miriam:kegg.pathway:map04010"/>
+            <CopasiMT:hasPart rdf:resource="urn:miriam:kegg.pathway:map04151"/>
+            <CopasiMT:hasPart rdf:resource="urn:miriam:kegg.pathway:map04310"/>
+            <CopasiMT:hasPart rdf:resource="urn:miriam:ncit:NCIT_C38981"/>
+            <CopasiMT:hasPart rdf:resource="urn:miriam:go:GO:0060070"/>
+          </rdf:Description>
+        </rdf:RDF>
+      </COPASI>
+    </annotation>
+    <listOfFunctionDefinitions>
+      <functionDefinition metaid="COPASI119" id="Function_for_EGFR_dephosphorylation" name="Function for EGFR dephosphorylation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI119">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:43:30Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> V1 </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <ci> V1 </ci>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI120" id="Function_for_Raf1_dephosphorylation__RafPPtase_modifier" name="Function for Raf1 dephosphorylation (RafPPtase modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI120">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:43:31Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat10a </ci>
+            </bvar>
+            <bvar>
+              <ci> Km10a </ci>
+            </bvar>
+            <bvar>
+              <ci> RafPPtase </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pRaf1 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat10a </ci>
+                  <ci> RafPPtase </ci>
+                  <ci> pRaf1 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> pRaf1 </ci>
+                  <ci> Km10a </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI121" id="Function_for_Raf1_dephosphorylation__pAkt_modifier" name="Function for Raf1 dephosphorylation (pAkt modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI121">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:51:13Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat10b </ci>
+            </bvar>
+            <bvar>
+              <ci> Km10b </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pAkt </ci>
+            </bvar>
+            <bvar>
+              <ci> pRaf1 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat10b </ci>
+                  <ci> pAkt </ci>
+                  <ci> pRaf1 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> pRaf1 </ci>
+                  <ci> Km10b </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI122" id="Function_for_MEK_phosphorylation__pbRaf_modifier" name="Function for MEK phosphorylation (pbRaf modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI122">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:55:20Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat11a </ci>
+            </bvar>
+            <bvar>
+              <ci> Km11a </ci>
+            </bvar>
+            <bvar>
+              <ci> MEK </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pBRaf </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat11a </ci>
+                  <ci> pBRaf </ci>
+                  <ci> MEK </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> MEK </ci>
+                  <ci> Km11a </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI123" id="Function_for_MEK_phosphorylation__pRaf1__pRKIP_and_RKIP_modifiers" name="Function for MEK phosphorylation (pRaf1, pRKIP and RKIP modifiers)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI123">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:54:39Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> MEK </ci>
+            </bvar>
+            <bvar>
+              <ci> RKIP </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k11b1 </ci>
+            </bvar>
+            <bvar>
+              <ci> k11b2 </ci>
+            </bvar>
+            <bvar>
+              <ci> pRKIP </ci>
+            </bvar>
+            <bvar>
+              <ci> pRaf1 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> k11b1 </ci>
+                  <ci> pRaf1 </ci>
+                  <ci> MEK </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <cn> 1 </cn>
+                  <apply>
+                    <power/>
+                    <apply>
+                      <divide/>
+                      <apply>
+                        <minus/>
+                        <ci> RKIP </ci>
+                        <ci> pRKIP </ci>
+                      </apply>
+                      <ci> k11b2 </ci>
+                    </apply>
+                    <cn> 2 </cn>
+                  </apply>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI124" id="Function_for_MEK_dephosphorylation__PP2A_modifer" name="Function for MEK dephosphorylation (PP2A modifer)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI124">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:55:31Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat12 </ci>
+            </bvar>
+            <bvar>
+              <ci> Km12 </ci>
+            </bvar>
+            <bvar>
+              <ci> PP2A </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pMEK </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat12 </ci>
+                  <ci> PP2A </ci>
+                  <ci> pMEK </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> pMEK </ci>
+                  <ci> Km12 </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI125" id="Function_for_ERK_phosphorylation__pMEK_modifier" name="Function for ERK phosphorylation (pMEK modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI125">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:57:03Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> ERK </ci>
+            </bvar>
+            <bvar>
+              <ci> Kcat13 </ci>
+            </bvar>
+            <bvar>
+              <ci> Km13 </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pMEK </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat13 </ci>
+                  <ci> pMEK </ci>
+                  <ci> ERK </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> ERK </ci>
+                  <ci> Km13 </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI126" id="Function_for_ERK_dephosphorylation__PP2A_modifer" name="Function for ERK dephosphorylation (PP2A modifer)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI126">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:57:17Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat14 </ci>
+            </bvar>
+            <bvar>
+              <ci> Km14 </ci>
+            </bvar>
+            <bvar>
+              <ci> PP2A </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pERK </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat14 </ci>
+                  <ci> PP2A </ci>
+                  <ci> pERK </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> pERK </ci>
+                  <ci> Km14 </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI127" id="Function_for_RKIP_phosphorylation__pERK_modifier" name="Function for RKIP phosphorylation (pERK modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI127">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T11:03:58Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> RKIP </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k15a </ci>
+            </bvar>
+            <bvar>
+              <ci> pERK </ci>
+            </bvar>
+            <bvar>
+              <ci> pRKIP </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k15a </ci>
+                <ci> pERK </ci>
+                <apply>
+                  <minus/>
+                  <ci> RKIP </ci>
+                  <ci> pRKIP </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI128" id="Function_for_RKIP_dephosphorylation" name="Function for RKIP dephosphorylation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI128">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:48:00Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> V15b </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pRKIP </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> V15b </ci>
+                <ci> pRKIP </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI129" id="Function_for_RKIP_degradation" name="Function for RKIP degradation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI129">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:48:12Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> RKIP </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k15c </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k15c </ci>
+                <ci> RKIP </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI130" id="Function_for_bRaf_phosphorylation__pRas_modifier" name="Function for bRaf phosphorylation (pRas modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI130">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T11:00:03Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> BRaf </ci>
+            </bvar>
+            <bvar>
+              <ci> Kcat16a </ci>
+            </bvar>
+            <bvar>
+              <ci> Km16a </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pRas </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat16a </ci>
+                  <ci> pRas </ci>
+                  <ci> BRaf </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> BRaf </ci>
+                  <ci> Km16a </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI131" id="Function_for_bRaf_phosphorylation__pRap1_modifier" name="Function for bRaf phosphorylation (pRap1 modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI131">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T11:00:15Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> BRaf </ci>
+            </bvar>
+            <bvar>
+              <ci> Kcat16b </ci>
+            </bvar>
+            <bvar>
+              <ci> Km16b </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pRap1 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat16b </ci>
+                  <ci> pRap1 </ci>
+                  <ci> BRaf </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> BRaf </ci>
+                  <ci> Km16b </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI132" id="Function_for_P90Rsk_dephosphorylation" name="Function for P90Rsk dephosphorylation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI132">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:49:09Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k18a </ci>
+            </bvar>
+            <bvar>
+              <ci> pP90Rsk </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k18a </ci>
+                <ci> pP90Rsk </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI133" id="Function_for_P90Rsk_phosphorylation__pERK_modifier" name="Function for P90Rsk phosphorylation (pERK modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI133">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:54:08Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat18b </ci>
+            </bvar>
+            <bvar>
+              <ci> Km18b </ci>
+            </bvar>
+            <bvar>
+              <ci> P90Rsk </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pERK </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat18b </ci>
+                  <ci> pERK </ci>
+                  <ci> P90Rsk </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> P90Rsk </ci>
+                  <ci> Km18b </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI134" id="Function_for_PI3K_phosphorylation__boundEGFR_modifier" name="Function for PI3K phosphorylation (boundEGFR modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI134">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:52:49Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat19a </ci>
+            </bvar>
+            <bvar>
+              <ci> Km19a </ci>
+            </bvar>
+            <bvar>
+              <ci> PI3K </ci>
+            </bvar>
+            <bvar>
+              <ci> bEGFR </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat19a </ci>
+                  <ci> bEGFR </ci>
+                  <ci> PI3K </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> PI3K </ci>
+                  <ci> Km19a </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI135" id="Function_for_PI3K_phosphorylation__pRas_modifier" name="Function for PI3K phosphorylation (pRas modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI135">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:52:33Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat19b </ci>
+            </bvar>
+            <bvar>
+              <ci> Km19b </ci>
+            </bvar>
+            <bvar>
+              <ci> PI3K </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pRas </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat19b </ci>
+                  <ci> pRas </ci>
+                  <ci> PI3K </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> PI3K </ci>
+                  <ci> Km19b </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI136" id="Function_for_PI3K_dephosphorylation" name="Function for PI3K dephosphorylation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI136">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:53:02Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k19c </ci>
+            </bvar>
+            <bvar>
+              <ci> pPI3K </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k19c </ci>
+                <ci> pPI3K </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI137" id="Function_for_EGFR_binding" name="Function for EGFR binding">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI137">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:58:25Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> EGF </ci>
+            </bvar>
+            <bvar>
+              <ci> bEGFR </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> fEGFR </ci>
+            </bvar>
+            <bvar>
+              <ci> k21 </ci>
+            </bvar>
+            <bvar>
+              <ci> k22 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> k21 </ci>
+                  <ci> EGF </ci>
+                  <ci> fEGFR </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> k22 </ci>
+                  <ci> bEGFR </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI138" id="Function_for_PIP2_phosphorylated_to_PIP3" name="Function for PIP2 phosphorylated to PIP3">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI138">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:52:13Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat20 </ci>
+            </bvar>
+            <bvar>
+              <ci> Km20 </ci>
+            </bvar>
+            <bvar>
+              <ci> PIP2 </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pPI3K </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat20 </ci>
+                  <ci> pPI3K </ci>
+                  <ci> PIP2 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> PIP2 </ci>
+                  <ci> Km20 </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI139" id="Function_for_PIP3_dephosphorylated_to_PIP2" name="Function for PIP3 dephosphorylated to PIP2">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI139">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:51:56Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat21 </ci>
+            </bvar>
+            <bvar>
+              <ci> Km21 </ci>
+            </bvar>
+            <bvar>
+              <ci> PIP3 </ci>
+            </bvar>
+            <bvar>
+              <ci> PTEN </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat21 </ci>
+                  <ci> PTEN </ci>
+                  <ci> PIP3 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> PIP3 </ci>
+                  <ci> Km21 </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI140" id="Function_for_Akt_phosphorylation__PIP3_modifier" name="Function for Akt phosphorylation (PIP3 modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI140">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:42:05Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Akt </ci>
+            </bvar>
+            <bvar>
+              <ci> Kcat22a </ci>
+            </bvar>
+            <bvar>
+              <ci> Km22a </ci>
+            </bvar>
+            <bvar>
+              <ci> PIP3 </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat22a </ci>
+                  <ci> PIP3 </ci>
+                  <ci> Akt </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> Akt </ci>
+                  <ci> Km22a </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI141" id="Function_for_Akt_dephosphorylation" name="Function for Akt dephosphorylation ">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI141">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:41:40Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat22b </ci>
+            </bvar>
+            <bvar>
+              <ci> Km22b </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pAkt </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat22b </ci>
+                  <ci> pAkt </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> Km22b </ci>
+                  <ci> pAkt </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI142" id="Function_for_C3G_phosphorylation__boundEGFR_modifier" name="Function for C3G phosphorylation (boundEGFR modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI142">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:59:22Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> C3G </ci>
+            </bvar>
+            <bvar>
+              <ci> Kcat23a </ci>
+            </bvar>
+            <bvar>
+              <ci> Km23a </ci>
+            </bvar>
+            <bvar>
+              <ci> bEGFR </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat23a </ci>
+                  <ci> bEGFR </ci>
+                  <ci> C3G </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> C3G </ci>
+                  <ci> Km23a </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI143" id="Function_for_C3G_dephosphorylation" name="Function for C3G dephosphorylation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI143">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:59:49Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k23b </ci>
+            </bvar>
+            <bvar>
+              <ci> pC3G </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k23b </ci>
+                <ci> pC3G </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI144" id="Function_for_Rap1_phosphorylation__pC3G_modifier" name="Function for Rap1 phosphorylation (pC3G modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI144">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:49:22Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat24 </ci>
+            </bvar>
+            <bvar>
+              <ci> Km24 </ci>
+            </bvar>
+            <bvar>
+              <ci> Rap1 </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pC3G </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat24 </ci>
+                  <ci> pC3G </ci>
+                  <ci> Rap1 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> Rap1 </ci>
+                  <ci> Km24 </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI145" id="Function_for_Rap1_dephosphorylation__Rap1_GAP_modifer" name="Function for Rap1 dephosphorylation (Rap1_GAP modifer)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI145">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:49:46Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat25 </ci>
+            </bvar>
+            <bvar>
+              <ci> Km25 </ci>
+            </bvar>
+            <bvar>
+              <ci> Rap1Gap </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pRap1 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat25 </ci>
+                  <ci> Rap1Gap </ci>
+                  <ci> pRap1 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> pRap1 </ci>
+                  <ci> Km25 </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI146" id="Function_for_PKCD_synthesis" name="Function for PKCD synthesis">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI146">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:51:26Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> GSK3B </ci>
+            </bvar>
+            <bvar>
+              <ci> V26a </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k26a </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <ci> V26a </ci>
+                <apply>
+                  <plus/>
+                  <cn> 1 </cn>
+                  <apply>
+                    <power/>
+                    <apply>
+                      <divide/>
+                      <ci> GSK3B </ci>
+                      <ci> k26a </ci>
+                    </apply>
+                    <cn> 2.5 </cn>
+                  </apply>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI147" id="Function_for_PKCD_degradation" name="Function for PKCD degradation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI147">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:51:41Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> PKCD </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k26b </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k26b </ci>
+                <ci> PKCD </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI148" id="Function_for_GSK3b_phosphorylation__pERK_modifier" name="Function for GSK3b phosphorylation (pERK modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI148">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:55:44Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> GSK3B </ci>
+            </bvar>
+            <bvar>
+              <ci> Kcat27a </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pERK </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Kcat27a </ci>
+                <ci> GSK3B </ci>
+                <ci> pERK </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI149" id="Function_for_GSK3b_phosphorylation__pAkt_modifier" name="Function for GSK3b phosphorylation (pAkt modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI149">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:56:06Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> GSK3B </ci>
+            </bvar>
+            <bvar>
+              <ci> Kcat27b </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pAkt </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Kcat27b </ci>
+                <ci> GSK3B </ci>
+                <ci> pAkt </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI150" id="Function_for_GSK3b_synthesis" name="Function for GSK3b synthesis">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI150">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T11:04:56Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> RKIP </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k27c </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k27c </ci>
+                <ci> RKIP </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI151" id="Function_for_GSK3b_dephosphorylation" name="Function for GSK3b dephosphorylation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI151">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:56:24Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat27d </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pGSK3B </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> Kcat27d </ci>
+                <ci> pGSK3B </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI152" id="Function_for_Dsh_activation" name="Function for Dsh activation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI152">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:58:59Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Dshi </ci>
+            </bvar>
+            <bvar>
+              <ci> W </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k28 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k28 </ci>
+                <ci> Dshi </ci>
+                <ci> W </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI153" id="Function_for_Dsh_deactivation" name="Function for Dsh deactivation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI153">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:58:36Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Dsha </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k29 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k29 </ci>
+                <ci> Dsha </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI154" id="Function_for_freeEGFR_degradation" name="Function for freeEGFR degradation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI154">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:56:45Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> fEGFR </ci>
+            </bvar>
+            <bvar>
+              <ci> k3 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k3 </ci>
+                <ci> fEGFR </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI155" id="Function_for_APC_Axin_GSK3b_complex_disassembly__Dsha_modifier" name="Function for APC_Axin_GSK3b complex disassembly (Dsha modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI155">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:44:54Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> APCAxinGSK3B </ci>
+            </bvar>
+            <bvar>
+              <ci> Dsha </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k30 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k30 </ci>
+                <ci> Dsha </ci>
+                <ci> APCAxinGSK3B </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI156" id="Function_for_APC_Axin_GSK3b_complex_formation" name="Function for APC_Axin_GSK3b complex formation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI156">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:45:02Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> APCAxin </ci>
+            </bvar>
+            <bvar>
+              <ci> APCAxinGSK3B </ci>
+            </bvar>
+            <bvar>
+              <ci> GSK3B </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k311 </ci>
+            </bvar>
+            <bvar>
+              <ci> k312 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> k311 </ci>
+                  <ci> GSK3B </ci>
+                  <ci> APCAxin </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> k312 </ci>
+                  <ci> APCAxinGSK3B </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI157" id="Function_for_APC_and_Axin_phosphorylation__in_compound" name="Function for APC and Axin phosphorylation (in compound)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI157">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:43:48Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> APCAxinGSK3B </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k32a </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k32a </ci>
+                <ci> APCAxinGSK3B </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI158" id="Function_for_APC_and_Axin_dephosphorylation__in_compound" name="Function for APC and Axin dephosphorylation (in compound)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI158">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:42:34Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k32b </ci>
+            </bvar>
+            <bvar>
+              <ci> pAPCpAxinGSK3B </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k32b </ci>
+                <ci> pAPCpAxinGSK3B </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI159" id="APC_Axin_complex_formation" name="APC_Axin complex formation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI159">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:44:23Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> APC </ci>
+            </bvar>
+            <bvar>
+              <ci> APCAxin </ci>
+            </bvar>
+            <bvar>
+              <ci> Axin </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k33a1 </ci>
+            </bvar>
+            <bvar>
+              <ci> k33a2 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> k33a1 </ci>
+                  <ci> Axin </ci>
+                  <ci> APC </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> k33a2 </ci>
+                  <ci> APCAxin </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI160" id="Function_for_Axin_degradation" name="Function for Axin degradation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI160">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T11:02:36Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Axin </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k33b </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k33b </ci>
+                <ci> Axin </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI161" id="Function_for_Axin_synthesis" name="Function for Axin synthesis">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI161">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T11:02:16Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> BCatenin </ci>
+            </bvar>
+            <bvar>
+              <ci> TCFBCatenin </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k33c1 </ci>
+            </bvar>
+            <bvar>
+              <ci> k33c2 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <plus/>
+                <ci> k33c1 </ci>
+                <apply>
+                  <times/>
+                  <ci> k33c2 </ci>
+                  <apply>
+                    <plus/>
+                    <ci> TCFBCatenin </ci>
+                    <ci> BCatenin </ci>
+                  </apply>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI162" id="Function_for_pAPC_pAxin_GSK3b_bCatenin_complex_formation" name="Function for pAPC_pAxin_GSK3b_bCatenin complex formation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI162">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:53:50Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> BCatenin </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k341 </ci>
+            </bvar>
+            <bvar>
+              <ci> k342 </ci>
+            </bvar>
+            <bvar>
+              <ci> pAPCpAxinGSK3B </ci>
+            </bvar>
+            <bvar>
+              <ci> pAPCpAxinGSK3BBCatenin </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> k341 </ci>
+                  <ci> pAPCpAxinGSK3B </ci>
+                  <ci> BCatenin </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> k342 </ci>
+                  <ci> pAPCpAxinGSK3BBCatenin </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI163" id="Function_for_bCatenin_phosphorylation__in_compound" name="Function for bCatenin phosphorylation (in compound)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI163">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:46:25Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k35 </ci>
+            </bvar>
+            <bvar>
+              <ci> pAPCpAxinGSK3BBCatenin </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k35 </ci>
+                <ci> pAPCpAxinGSK3BBCatenin </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI164" id="Function_for_pAPC_pAxin_GSK3b_pbCatenin_complex_disassembly" name="Function for pAPC_pAxin_GSK3b_pbCatenin complex disassembly">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI164">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:53:37Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k36 </ci>
+            </bvar>
+            <bvar>
+              <ci> pAPCpAxinGSK3BpBCatenin </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k36 </ci>
+                <ci> pAPCpAxinGSK3BpBCatenin </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI165" id="Function_for_APC_bCatenin_complex_formation" name="Function for APC_bCatenin complex formation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI165">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T11:02:49Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> APC </ci>
+            </bvar>
+            <bvar>
+              <ci> APCBCatenin </ci>
+            </bvar>
+            <bvar>
+              <ci> BCatenin </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k37a1 </ci>
+            </bvar>
+            <bvar>
+              <ci> k37a2 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> k37a1 </ci>
+                  <ci> APC </ci>
+                  <ci> BCatenin </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> k37a2 </ci>
+                  <ci> APCBCatenin </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI166" id="Function_for_bCatenin_synthesis" name="Function for bCatenin synthesis">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI166">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T11:01:42Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> V37b </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <ci> V37b </ci>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI167" id="Function_for_bCatenin_degradation" name="Function for bCatenin degradation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI167">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T11:02:03Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> BCatenin </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k37c </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k37c </ci>
+                <ci> BCatenin </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI168" id="Function_for_bCatenin_TCF_complex_binding" name="Function for bCatenin_TCF complex binding">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI168">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:45:24Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> BCatenin </ci>
+            </bvar>
+            <bvar>
+              <ci> TCF </ci>
+            </bvar>
+            <bvar>
+              <ci> TCFBCatenin </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k381 </ci>
+            </bvar>
+            <bvar>
+              <ci> k382 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> k381 </ci>
+                  <ci> BCatenin </ci>
+                  <ci> TCF </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> k382 </ci>
+                  <ci> TCFBCatenin </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI169" id="Function_for_X_synthesis" name="Function for X synthesis">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI169">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:45:18Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Km39 </ci>
+            </bvar>
+            <bvar>
+              <ci> TCFBCatenin </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k39 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> k39 </ci>
+                  <apply>
+                    <power/>
+                    <ci> TCFBCatenin </ci>
+                    <cn> 2 </cn>
+                  </apply>
+                </apply>
+                <apply>
+                  <plus/>
+                  <apply>
+                    <power/>
+                    <ci> Km39 </ci>
+                    <cn> 2 </cn>
+                  </apply>
+                  <apply>
+                    <power/>
+                    <ci> TCFBCatenin </ci>
+                    <cn> 2 </cn>
+                  </apply>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI170" id="Function_for_boundEGFR_degradation" name="Function for boundEGFR degradation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI170">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T11:01:02Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> bEGFR </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k4 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k4 </ci>
+                <ci> bEGFR </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI171" id="Function_for_X_degradation" name="Function for X degradation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI171">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:45:34Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> X </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k40 </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k40 </ci>
+                <ci> X </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI172" id="Function_for_pbCatenin_degradation" name="Function for pbCatenin degradation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI172">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:53:15Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k41 </ci>
+            </bvar>
+            <bvar>
+              <ci> pBCatenin </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k41 </ci>
+                <ci> pBCatenin </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI173" id="Function_for_SOS_phosphorylation__PKCD__pERK_and_boundEGFR_modifiers_" name="Function for SOS phosphorylation (PKCD. pERK and boundEGFR modifiers) ">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI173">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:46:48Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> PKCD </ci>
+            </bvar>
+            <bvar>
+              <ci> bEGFR </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k51 </ci>
+            </bvar>
+            <bvar>
+              <ci> k52 </ci>
+            </bvar>
+            <bvar>
+              <ci> k53 </ci>
+            </bvar>
+            <bvar>
+              <ci> k54 </ci>
+            </bvar>
+            <bvar>
+              <ci> pERK </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <plus/>
+                  <apply>
+                    <times/>
+                    <ci> k51 </ci>
+                    <ci> bEGFR </ci>
+                  </apply>
+                  <ci> k52 </ci>
+                  <apply>
+                    <times/>
+                    <ci> k53 </ci>
+                    <ci> PKCD </ci>
+                  </apply>
+                </apply>
+                <apply>
+                  <plus/>
+                  <cn> 1 </cn>
+                  <apply>
+                    <divide/>
+                    <ci> pERK </ci>
+                    <ci> k54 </ci>
+                  </apply>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI174" id="Function_for_SOS_dephosphorylation" name="Function for SOS dephosphorylation">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI174">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:47:28Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k6a </ci>
+            </bvar>
+            <bvar>
+              <ci> pSOS </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> k6a </ci>
+                <ci> pSOS </ci>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI175" id="Function_for_SOS_dephosphorylation__pP90Rsk_modifier" name="Function for SOS dephosphorylation (pP90Rsk modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI175">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:47:05Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat6b </ci>
+            </bvar>
+            <bvar>
+              <ci> Km6b </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pP90Rsk </ci>
+            </bvar>
+            <bvar>
+              <ci> pSOS </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat6b </ci>
+                  <ci> pP90Rsk </ci>
+                  <ci> pSOS </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> pSOS </ci>
+                  <ci> Km6b </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI176" id="Function_for_Ras_phosphorylation__pSOS_modifier" name="Function for Ras phosphorylation (pSOS modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI176">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:48:49Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat7 </ci>
+            </bvar>
+            <bvar>
+              <ci> Km7 </ci>
+            </bvar>
+            <bvar>
+              <ci> Ras </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pSOS </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat7 </ci>
+                  <ci> pSOS </ci>
+                  <ci> Ras </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> Ras </ci>
+                  <ci> Km7 </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI177" id="Function_for_Ras_synthesis" name="Function for Ras synthesis">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI177">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:48:34Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> V8a </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <ci> V8a </ci>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI178" id="Function_for_Ras_dephosphorylation__Ras_Gap_modifier" name="Function for Ras dephosphorylation (Ras_Gap modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI178">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:49:04Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat8b </ci>
+            </bvar>
+            <bvar>
+              <ci> Km8b </ci>
+            </bvar>
+            <bvar>
+              <ci> RasGap </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pRas </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat8b </ci>
+                  <ci> RasGap </ci>
+                  <ci> pRas </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> pRas </ci>
+                  <ci> Km8b </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI179" id="Function_for_Raf1_phosphorylation__pRas_modifier" name="Function for Raf1 phosphorylation (pRas modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI179">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:50:17Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat9a </ci>
+            </bvar>
+            <bvar>
+              <ci> Km9a </ci>
+            </bvar>
+            <bvar>
+              <ci> Raf1 </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> pRas </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat9a </ci>
+                  <ci> pRas </ci>
+                  <ci> Raf1 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> Raf1 </ci>
+                  <ci> Km9a </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI180" id="Function_for_Raf1_phosphorylation__X_modifier" name="Function for Raf1 phosphorylation (X modifier)">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI180">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:50:02Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Km9b </ci>
+            </bvar>
+            <bvar>
+              <ci> Raf1 </ci>
+            </bvar>
+            <bvar>
+              <ci> W </ci>
+            </bvar>
+            <bvar>
+              <ci> X </ci>
+            </bvar>
+            <bvar>
+              <ci> Cell </ci>
+            </bvar>
+            <bvar>
+              <ci> k9b </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> k9b </ci>
+                  <ci> W </ci>
+                  <ci> X </ci>
+                  <ci> Raf1 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> Km9b </ci>
+                  <ci> Raf1 </ci>
+                </apply>
+              </apply>
+              <ci> Cell </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="COPASI181" id="function_for_bRaf_dephosphorylation" name="function for bRaf dephosphorylation ">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI181">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:26:17Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> Kcat17a </ci>
+            </bvar>
+            <bvar>
+              <ci> pbRaf </ci>
+            </bvar>
+            <bvar>
+              <ci> RafPPase </ci>
+            </bvar>
+            <bvar>
+              <ci> Km17a </ci>
+            </bvar>
+            <bvar>
+              <ci> volume </ci>
+            </bvar>
+            <apply>
+              <divide/>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> Kcat17a </ci>
+                  <ci> pbRaf </ci>
+                  <ci> RafPPase </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> Km17a </ci>
+                  <ci> pbRaf </ci>
+                </apply>
+              </apply>
+              <ci> volume </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+    </listOfFunctionDefinitions>
+    <listOfCompartments>
+      <compartment metaid="COPASI1" id="Cell" name="Cell" spatialDimensions="3" size="1" constant="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI1">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0005623"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI1">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T10:39:18Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0005623"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+      </compartment>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species metaid="COPASI2" id="APC" name="APC" compartment="Cell" initialConcentration="96.602" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI2">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P25054"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI3" id="APCAxin" name="APC_Axin" compartment="Cell" initialConcentration="0.0015" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI3">
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P25054"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/O15169"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI4" id="APCAxinGSK3B" name="APC_Axin_GSK3b" compartment="Cell" initialConcentration="0.0076" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI4">
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P49841"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P25054"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/O15169"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI5" id="APCBCatenin" name="APC_bCatenin" compartment="Cell" initialConcentration="3.4392" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI5">
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P25054"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P35222"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI6" id="Akt" name="Akt" compartment="Cell" initialConcentration="200" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI6">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P31749"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI7" id="Axin" name="Axin" compartment="Cell" initialConcentration="0.0008" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI7">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/O15169"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI8" id="BCatenin" name="bCatenin" compartment="Cell" initialConcentration="42.722" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI8">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P35222"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI9" id="BRaf" name="bRaf" compartment="Cell" initialConcentration="200" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI9">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P15056"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI10" id="C3G" name="C3G" compartment="Cell" initialConcentration="500" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI10">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q13905"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI11" id="Dsha" name="Dsha" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI11">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/O14640"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI12" id="Dshi" name="Dshi" compartment="Cell" initialConcentration="100" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI12">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/O14640"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI13" id="EGF" name="EGF" compartment="Cell" initialConcentration="600" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI13">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P01133"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI14" id="ERK" name="ERK" compartment="Cell" initialConcentration="260" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI14">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P27361"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI15" id="GSK3B" name="GSK3b" compartment="Cell" initialConcentration="49.137" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI15">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P49841"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI16" id="MEK" name="MEK" compartment="Cell" initialConcentration="680" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI16">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q02750"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI17" id="P90Rsk" name="P90Rsk" compartment="Cell" initialConcentration="60" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI17">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q15418"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI18" id="PI3K" name="PI3K" compartment="Cell" initialConcentration="100" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI18">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:omit:0027264"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI19" id="PIP2" name="PIP2" compartment="Cell" initialConcentration="700" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI19">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:chebi:0018348"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI20" id="PIP3" name="PIP3" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI20">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:chebi:0016618"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI21" id="PKCD" name="PKCD" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI21">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q05655"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI22" id="PP2A" name="PP2A" compartment="Cell" initialConcentration="240" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI22">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P67775"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI23" id="PTEN" name="PTEN" compartment="Cell" initialConcentration="270" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI23">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P60484"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI24" id="RKIP" name="RKIP" compartment="Cell" initialConcentration="20.909" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI24">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P30086"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI25" id="Raf1" name="Raf1" compartment="Cell" initialConcentration="100" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI25">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P04049"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI26" id="RafPPtase" name="RafPPtase" compartment="Cell" initialConcentration="60" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI26">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P67775"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI27" id="Rap1" name="Rap1" compartment="Cell" initialConcentration="200" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI27">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P62834"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI28" id="Rap1Gap" name="Rap1_Gap" compartment="Cell" initialConcentration="12" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI28">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P47736"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI29" id="Ras" name="Ras" compartment="Cell" initialConcentration="100" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI29">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P01112"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI30" id="RasGap" name="Ras_Gap" compartment="Cell" initialConcentration="100" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI30">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P20936"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI31" id="SOS" name="SOS" compartment="Cell" initialConcentration="100" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI31">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q07889"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI32" id="TCF" name="TCF" compartment="Cell" initialConcentration="6.1879" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI32">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q9UJU2"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI33" id="TCFBCatenin" name="bCatenin_TCF" compartment="Cell" initialConcentration="8.8121" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI33">
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P35222"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q9UJU2"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI34" id="X" name="X" compartment="Cell" initialConcentration="10.263" boundaryCondition="false" constant="false">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI34">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T10:57:07Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+      </species>
+      <species metaid="COPASI35" id="bEGFR" name="boundEGFR" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI35">
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P01133"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P00533"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI36" id="fEGFR" name="freeEGFR" compartment="Cell" initialConcentration="300" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI36">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P00533"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI37" id="pAPCpAxinGSK3B" name="pAPC_pAxin_GSK3b" compartment="Cell" initialConcentration="0.0153" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI37">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P49841"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/O15169"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P25054"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI38" id="pAPCpAxinGSK3BBCatenin" name="pAPC_pAxin_GSK3b_bCatenin" compartment="Cell" initialConcentration="0.002" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI38">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P25054"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P49841"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P35222"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/O15169"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI39" id="pAPCpAxinGSK3BpBCatenin" name="pAPC_pAxin_GSK3b_pbCatenin" compartment="Cell" initialConcentration="0.002" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI39">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P25054"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P49841"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/O15169"/>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P35222"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI40" id="pAkt" name="pAkt" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI40">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P31749"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI41" id="pBCatenin" name="pbCatenin" compartment="Cell" initialConcentration="0.9881" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI41">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P35222"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI42" id="pBRaf" name="pbRaf" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI42">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P15056"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI43" id="pC3G" name="pC3G" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI43">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P01024"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI44" id="pEGFR" name="pEGFR" compartment="Cell" initialConcentration="0.05" boundaryCondition="true" constant="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI44">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P00533"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI45" id="pERK" name="pERK" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI45">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P28482"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI46" id="pGSK3B" name="pGSK3b" compartment="Cell" initialConcentration="0.85544" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI46">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P49841"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI47" id="pMEK" name="pMEK" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI47">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q02750"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI48" id="pP90Rsk" name="pP90Rsk" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI48">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q15418"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI49" id="pPI3K" name="pPI3K" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI49">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:omit:0027264"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI50" id="pRKIP" name="pRKIP" compartment="Cell" initialConcentration="0.8619" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI50">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P30086"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI51" id="pRaf1" name="pRaf1" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI51">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P04049"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI52" id="pRap1" name="pRap1" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI52">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P62834"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI53" id="pRas" name="pRas" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI53">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P62070"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="COPASI54" id="pSOS" name="pSOS" compartment="Cell" initialConcentration="0" boundaryCondition="false" constant="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI54">
+              <bqbiol:hasProperty>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:bao:0002007"/>
+                </rdf:Bag>
+              </bqbiol:hasProperty>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q07889"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="de33bc45-a778-4110-b709-ab2983b7778e" id="null" name="null" compartment="Cell" initialConcentration="1" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter metaid="_507745a4-9b95-44fe-978e-0f08295603aa" id="Kcat10a" name="Kcat10a" value="0.12633" constant="true"/>
+      <parameter metaid="_2488923f-4c73-4e22-b8de-3c1e38d593d4" id="Kcat10b" name="Kcat10b" value="15.1212" constant="true"/>
+      <parameter metaid="_05070fa0-892f-4478-ac77-dec1a4482895" id="Kcat11a" name="Kcat11a" value="185.76" constant="true"/>
+      <parameter metaid="b4e88dc9-8be7-4709-937a-7ac0b13de8b3" id="Kcat12" name="Kcat12" value="2.8324" constant="true"/>
+      <parameter metaid="dd942eae-e2fa-4578-977f-5de1d9ec33ac" id="Kcat13" name="Kcat13" value="9.8537" constant="true"/>
+      <parameter metaid="_144fa5ac-95dd-4538-b8cf-9b7d4731d5cc" id="Kcat14" name="Kcat14" value="8.8912" constant="true"/>
+      <parameter metaid="f7fe71ee-bf3f-4d04-8115-9a96c88e18f8" id="Kcat16a" name="Kcat16a" value="0.8841" constant="true"/>
+      <parameter metaid="cb92ea51-c64c-4b81-8b4c-271e56dd831a" id="Kcat16b" name="Kcat16b" value="0.8841" constant="true"/>
+      <parameter metaid="d0679118-fe5c-4678-9307-5a3f251e89ab" id="Kcat17a" name="Kcat17a" value="0.12633" constant="true"/>
+      <parameter metaid="_6be98071-9cee-4270-b2d0-4028fc1ef1c3" id="Kcat17b" name="Kcat17b" value="15.1212" constant="true"/>
+      <parameter metaid="_8e042f85-4ce0-405b-b515-1dded4abd7d9" id="Kcat18b" name="Kcat18b" value="0.02137" constant="true"/>
+      <parameter metaid="_15a0157f-25c2-4a7e-9a1b-a3db9f375ed4" id="Kcat19a" name="Kcat19a" value="10.6737" constant="true"/>
+      <parameter metaid="_8b38f125-de29-4d97-904f-053533f02b99" id="Kcat19b" name="Kcat19b" value="0.07711" constant="true"/>
+      <parameter metaid="cf578b47-b06e-437f-9f0e-dc10375ed486" id="Kcat20" name="Kcat20" value="4" constant="true"/>
+      <parameter metaid="a4371e65-554a-450c-a3d4-7ec453011c20" id="Kcat21" name="Kcat21" value="5.5" constant="true"/>
+      <parameter metaid="_86865aed-ce91-4a07-b03b-96fa7dd013b7" id="Kcat22a" name="Kcat22a" value="0.33" constant="true"/>
+      <parameter metaid="e72d1901-59d9-48ee-9f94-035578acd752" id="Kcat22b" name="Kcat22b" value="48.667" constant="true"/>
+      <parameter metaid="_39ce3277-c2ef-4d87-b631-379d6d77944d" id="Kcat23a" name="Kcat23a" value="694.73" constant="true"/>
+      <parameter metaid="_02147721-e508-4df3-8429-d4ba91ed1fd3" id="Kcat24" name="Kcat24" value="32.344" constant="true"/>
+      <parameter metaid="ea9de28e-63b7-4c8e-87b3-31f93ddbecc7" id="Kcat25" name="Kcat25" value="1509.4" constant="true"/>
+      <parameter metaid="_95eaa6fd-daab-4bec-830f-ce166875d952" id="Kcat27a" name="Kcat27a" value="0.002" constant="true"/>
+      <parameter metaid="f753316b-d9fb-45b0-adaf-ee9741b0ab93" id="Kcat27b" name="Kcat27b" value="0.04596" constant="true"/>
+      <parameter metaid="_9fb1afb0-4af6-4818-8cf0-4997c9140bd3" id="Kcat27d" name="Kcat27d" value="0.01541" constant="true"/>
+      <parameter metaid="_0890a338-e065-4862-8723-2e554bd51f2c" id="Kcat6b" name="Kcat6b" value="1611.97" constant="true"/>
+      <parameter metaid="_641a07b7-2f15-42f4-b6af-5d6ae1fefb66" id="Kcat7" name="Kcat7" value="32.644" constant="true"/>
+      <parameter metaid="a33981ae-0ccb-47a4-bea9-8814c5f2addc" id="Kcat8b" name="Kcat8b" value="1509.36" constant="true"/>
+      <parameter metaid="_4e585a99-ac99-4455-93fa-3fbeeb8d292b" id="Kcat9a" name="Kcat9a" value="0.884096" constant="true"/>
+      <parameter metaid="e1286007-54a3-4d2e-8230-768aeffabcbf" id="Km10a" name="Km10a" value="1061.7" constant="true"/>
+      <parameter metaid="c12fc0a7-bd4e-4604-a048-0953295e27f5" id="Km10b" name="Km10b" value="119355" constant="true"/>
+      <parameter metaid="_27579f8b-69d8-423d-bebf-cb6efeee34e4" id="Km11a" name="Km11a" value="4768400" constant="true"/>
+      <parameter metaid="bb917bd3-fe33-42a6-a583-6f60963ff913" id="Km12" name="Km12" value="518750" constant="true"/>
+      <parameter metaid="_6915820e-89b3-4bbb-bf24-5d0c5d214a43" id="Km13" name="Km13" value="1007300" constant="true"/>
+      <parameter metaid="a2c2c340-9beb-419e-877d-74e8cbfeb5c0" id="Km14" name="Km14" value="3496500" constant="true"/>
+      <parameter metaid="_081c7199-5e77-4bd1-a6bb-1c82d3554e38" id="Km16a" name="Km16a" value="62645" constant="true"/>
+      <parameter metaid="_204a8e03-36a0-402b-89e3-d2dd41646fe0" id="Km16b" name="Km16b" value="62464.6" constant="true"/>
+      <parameter metaid="_6828eb77-ede3-446f-911a-7719e166fd93" id="Km17a" name="Km17a" value="1061.71" constant="true"/>
+      <parameter metaid="_645a94a7-3648-4484-98b8-b3b2e8716975" id="Km17b" name="Km17b" value="119355" constant="true"/>
+      <parameter metaid="be546670-36a4-4aad-88c7-5cfe8717cd6c" id="Km18b" name="Km18b" value="763523" constant="true"/>
+      <parameter metaid="_7f8294b8-3fd5-407e-a810-626ec7042e6e" id="Km19a" name="Km19a" value="184912" constant="true"/>
+      <parameter metaid="c77b618d-aefd-43be-8ee0-d1e2f2b8017b" id="Km19b" name="Km19b" value="272056" constant="true"/>
+      <parameter metaid="c8dc6d1d-41f0-4723-aa02-3a77de948409" id="Km20" name="Km20" value="4" constant="true"/>
+      <parameter metaid="_8a699e65-4dc0-4723-90ee-66e781dafedc" id="Km21" name="Km21" value="0.08" constant="true"/>
+      <parameter metaid="_59309543-0756-4fc4-8b80-e31b304768db" id="Km22a" name="Km22a" value="100" constant="true"/>
+      <parameter metaid="af86abc3-3a4b-41c3-9ece-92efa7f62622" id="Km22b" name="Km22b" value="100" constant="true"/>
+      <parameter metaid="_17c03a05-f8be-4e40-82f5-4677abdd017c" id="Km23a" name="Km23a" value="6086100" constant="true"/>
+      <parameter metaid="_938f0e01-222e-4f0f-b7f7-c5a6600c4433" id="Km24" name="Km24" value="35954.3" constant="true"/>
+      <parameter metaid="f2b21017-77a0-4c3d-b570-9f4b23718e59" id="Km25" name="Km25" value="1432400" constant="true"/>
+      <parameter metaid="_96e02259-6340-4344-8788-391d18639eb0" id="Km39" name="Km39" value="15" constant="true"/>
+      <parameter metaid="d666a4aa-ac50-4dce-9756-cbb85dc28ab7" id="Km6b" name="Km6b" value="896896" constant="true"/>
+      <parameter metaid="_763e59c5-3ac1-430d-9d3b-ef21d0a34c28" id="Km7" name="Km7" value="35954.3" constant="true"/>
+      <parameter metaid="_53adcc67-03a3-4f03-a6c8-5c3201ec64ee" id="Km8b" name="Km8b" value="1432410" constant="true"/>
+      <parameter metaid="_0afef9e4-e394-4a51-8fc8-9d31fb02e7a2" id="Km9a" name="Km9a" value="62464.6" constant="true"/>
+      <parameter metaid="ddec4894-748a-40f1-adf5-11844da4e067" id="Km9b" name="Km9b" value="15" constant="true"/>
+      <parameter metaid="_819d8ae7-f7f0-4fec-932d-bae3d5cc4474" id="V1" name="V1" value="100" constant="true"/>
+      <parameter metaid="_881a2c35-4d06-4905-9207-d28b92fe5369" id="V15b" name="V15b" value="4" constant="true"/>
+      <parameter metaid="dde641d2-7118-47f4-b38f-4e0ad772774c" id="V26a" name="V26a" value="0.00154" constant="true"/>
+      <parameter metaid="_5a6bdf72-f5ab-41eb-a26d-95250da1a65f" id="V37b" name="V37b" value="0.00705" constant="true"/>
+      <parameter metaid="e0fde29b-7bb1-4352-a56a-d50021fe07fd" id="V8a" name="V8a" value="0.0717" constant="true"/>
+      <parameter metaid="_4157d9fe-16e4-46d5-ae8a-87c7a70f6dc8" id="W" name="W" value="0" constant="true"/>
+      <parameter metaid="_34ac0e94-ab64-4763-863a-30225e2bc1d4" id="k11b1" name="k11b1" value="1.1167e-05" constant="true"/>
+      <parameter metaid="_176e2912-e61a-41cf-984a-a27b36ade340" id="k11b2" name="k11b2" value="120" constant="true"/>
+      <parameter metaid="_67031070-c178-45b9-b7d2-47d40a92fbec" id="k15a" name="k15a" value="1.3" constant="true"/>
+      <parameter metaid="efb8fd8a-4542-40cf-a346-4b2383d99f0b" id="k15c" name="k15c" value="0.00193" constant="true"/>
+      <parameter metaid="f9c2855e-7539-4480-9116-4aa9e0142fde" id="k18a" name="k18a" value="0.005" constant="true"/>
+      <parameter metaid="_21bed2b5-2570-49f3-93b8-ffe18f45dba0" id="k19c" name="k19c" value="0.005" constant="true"/>
+      <parameter metaid="_63835c45-ca43-4326-8812-8c8132d59844" id="k21" name="k21" value="2.18503e-05" constant="true"/>
+      <parameter metaid="b474fb13-efbb-4168-9f1b-ed8ed35b48e4" id="k22" name="k22" value="0.121008" constant="true"/>
+      <parameter metaid="_2b62ee90-5d08-409c-b6bc-2f9d122d3e0f" id="k23b" name="k23b" value="2.5" constant="true"/>
+      <parameter metaid="bd08885f-9576-4a3d-9f07-db3ea4bef01c" id="k26a" name="k26a" value="20" constant="true"/>
+      <parameter metaid="b486a393-05f9-4496-a0ce-75616e4c0b43" id="k26b" name="k26b" value="0.000385" constant="true"/>
+      <parameter metaid="_6b75bbb1-7d8e-417c-9043-caa481bee749" id="k27c" name="k27c" value="0.00015" constant="true"/>
+      <parameter metaid="_8471ddcc-0041-424f-932e-aa05d01d4774" id="k28" name="k28" value="0.003" constant="true"/>
+      <parameter metaid="_46bec0e1-4830-441d-b979-086443e71854" id="k29" name="k29" value="0.003" constant="true"/>
+      <parameter metaid="_6ffe05fe-81f3-491d-aefa-9b465ad5d2fc" id="k3" name="k3" value="0.00125" constant="true"/>
+      <parameter metaid="_5baf66e3-65f5-4d6a-a136-9c835a1bad49" id="k30" name="k30" value="0.000833" constant="true"/>
+      <parameter metaid="_2dee7497-6909-40a9-8333-b23289d05595" id="k311" name="k311" value="0.001515" constant="true"/>
+      <parameter metaid="_1a0be1ac-817d-48ea-96e9-b246bc15e15f" id="k312" name="k312" value="0.01515" constant="true"/>
+      <parameter metaid="_609e05c3-7d3e-4fdf-8288-b044693a6b07" id="k32a" name="k32a" value="0.00445" constant="true"/>
+      <parameter metaid="eb973b66-c317-4bc6-a4ab-ad882d189e0c" id="k32b" name="k32b" value="0.002217" constant="true"/>
+      <parameter metaid="c192a37d-c3b1-47d9-823f-5e96fda5d8ff" id="k33a1" name="k33a1" value="0.01667" constant="true"/>
+      <parameter metaid="ff131b93-5066-42e1-b14a-fb5208fbe16a" id="k33a2" name="k33a2" value="0.8333" constant="true"/>
+      <parameter metaid="_1e6c54db-ffe7-4648-82e0-66ca61909b3e" id="k33b" name="k33b" value="0.002783" constant="true"/>
+      <parameter metaid="c17fc4bb-a727-45b5-810f-cdc51b31d7a0" id="k33c1" name="k33c1" value="1.37e-06" constant="true"/>
+      <parameter metaid="_4fccf0fd-1022-4ec3-9dac-0492a4bb1df6" id="k33c2" name="k33c2" value="1.667e-08" constant="true"/>
+      <parameter metaid="afa8d96a-a84a-434f-b97c-21edea1161d6" id="k341" name="k341" value="0.01667" constant="true"/>
+      <parameter metaid="_8390fed4-391b-4c5d-bbaf-b470be2002aa" id="k342" name="k342" value="2" constant="true"/>
+      <parameter metaid="be71dcc1-8ef2-4a0b-b6a1-04f8c37fafbf" id="k35" name="k35" value="3.433" constant="true"/>
+      <parameter metaid="_0930520d-6dcf-41a9-9186-615fdc78ea6d" id="k36" name="k36" value="3.433" constant="true"/>
+      <parameter metaid="_76a89e65-f5a8-4eb6-b996-6918b8781305" id="k37a1" name="k37a1" value="0.01667" constant="true"/>
+      <parameter metaid="_9fad9e81-ddc5-4475-94c4-c546381aa4af" id="k37a2" name="k37a2" value="20" constant="true"/>
+      <parameter metaid="a2a68f95-9ede-4caa-a580-1fd9edaf25b2" id="k37c" name="k37c" value="4.283e-06" constant="true"/>
+      <parameter metaid="_0c781be5-01b0-49f3-a6cb-e3839ea9a386" id="k381" name="k381" value="0.01667" constant="true"/>
+      <parameter metaid="a7b79e5f-56c6-47ee-8f91-6af1f816f410" id="k382" name="k382" value="0.5" constant="true"/>
+      <parameter metaid="_91e4010d-ad8c-449d-badf-a354ad731f9f" id="k39" name="k39" value="0.01" constant="true"/>
+      <parameter metaid="_18afb064-e023-4a79-97ae-23326c780042" id="k4" name="k4" value="0.2" constant="true"/>
+      <parameter metaid="d02aa7aa-a4d1-4972-ba9f-d630988c6e80" id="k40" name="k40" value="0.00025" constant="true"/>
+      <parameter metaid="_1625ea9d-b63f-4ad5-9006-c54406c5873e" id="k41" name="k41" value="0.00695" constant="true"/>
+      <parameter metaid="ece37b84-a187-4fc6-9da0-a9c8ecad1dc6" id="k51" name="k51" value="0.003465" constant="true"/>
+      <parameter metaid="_878d9ed4-70c7-4171-9247-2756f33fdcdc" id="k52" name="k52" value="3.85e-05" constant="true"/>
+      <parameter metaid="_09735697-389b-41df-bde8-05f956636d49" id="k53" name="k53" value="0.00028833" constant="true"/>
+      <parameter metaid="_7df4a306-6239-4ddb-9007-53ec0865bba7" id="k54" name="k54" value="1.5" constant="true"/>
+      <parameter metaid="_761440a0-e738-4e37-8d89-211ffa15fe53" id="k6a" name="k6a" value="2.5" constant="true"/>
+      <parameter metaid="_08c3ab3f-30a4-466a-8682-28367b976b70" id="k9b" name="k9b" value="0.025" constant="true"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction metaid="COPASI55" id="v1" name="EGFR dephosphorylation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI55">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0038004"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI55">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T10:57:15Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0038004"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_0269469d-57ae-49c1-8a79-a7965b50623b" species="pEGFR" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="ed89e5ba-24a5-4245-a92c-127bfb7e232d" species="fEGFR" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_2886a1d6-cfc3-429b-87ae-879359b97831">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_EGFR_dephosphorylation </ci>
+                <ci> V1 </ci>
+                <ci> Cell </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI56" id="v10a" name="Raf1 dephosphorylation (RafPPtase modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI56">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0000185"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI56">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T10:57:32Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0000185"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="e0f465f3-ec34-4f90-81e5-b29f453fa106" species="RafPPtase" stoichiometry="1"/>
+          <speciesReference metaid="d1b8a5ac-a88c-4778-ba8f-ee145dab0287" species="pRaf1" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035b2274-3c36-4951-9039-3803bd878e26" species="RafPPtase" stoichiometry="1"/>
+          <speciesReference metaid="_5927c869-aad8-4876-b009-80d917d34973" species="Raf1" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="bfe523fa-dcad-40f4-accf-191cea270dde">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Raf1_dephosphorylation__RafPPtase_modifier </ci>
+                <ci> Kcat10a </ci>
+                <ci> Km10a </ci>
+                <ci> RafPPtase </ci>
+                <ci> Cell </ci>
+                <ci> pRaf1 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI57" id="v10b" name="Raf1 dephosphorylation (pAkt modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI57">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0051390"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI57">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T10:57:42Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0051390"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="e888e3ab-44a3-4fe6-920b-0e5d69a92a77" species="pAkt" stoichiometry="1"/>
+          <speciesReference metaid="f3d905ae-4a13-44eb-b52d-ca9d2559bb23" species="pRaf1" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_4c15df5a-80e6-4a19-b5f9-7022af6ac621" species="pAkt" stoichiometry="1"/>
+          <speciesReference metaid="f29b9c35-ae6a-4621-90ae-dfaf35de8f9e" species="Raf1" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="c96dbc69-7095-4723-bd10-f0e3449f2254">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Raf1_dephosphorylation__pAkt_modifier </ci>
+                <ci> Kcat10b </ci>
+                <ci> Km10b </ci>
+                <ci> Cell </ci>
+                <ci> pAkt </ci>
+                <ci> pRaf1 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI58" id="v11a" name="MEK phosphorylation (pbRaf modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI58">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.11.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="urn:miriam:go:GI%3A0004709"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0000186"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI58">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T10:57:53Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ec-code:2.7.11.1"/>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GI:0004709"/>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0000186"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="e1526ac9-d8c5-4693-bb86-d8f853a6d485" species="pBRaf" stoichiometry="1"/>
+          <speciesReference metaid="_1f61ebbf-e851-482b-898d-f348fa5b5292" species="MEK" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_807fb346-8532-4b68-8349-0a4e2f0ec3e5" species="pBRaf" stoichiometry="1"/>
+          <speciesReference metaid="_74654cd8-d8c7-4c67-a4f2-c8aecf2385a9" species="pMEK" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="d901d693-7a34-49c4-9325-77acb3226b8f">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_MEK_phosphorylation__pbRaf_modifier </ci>
+                <ci> Kcat11a </ci>
+                <ci> Km11a </ci>
+                <ci> MEK </ci>
+                <ci> Cell </ci>
+                <ci> pBRaf </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI59" id="v11b" name="MEK phosphorylation (pRaf1, pRKIP and RKIP modifiers)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI59">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0000186"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.11.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0004709"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI59">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T10:58:30Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ec-code:2.7.11.1"/>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0000186"/>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0004709"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="ca67e5eb-abde-4805-aa5e-b2ac037701ba" species="pRKIP" stoichiometry="1"/>
+          <speciesReference metaid="_09927d05-cfab-4d68-bc0b-dc79a94780e4" species="pRaf1" stoichiometry="1"/>
+          <speciesReference metaid="_318bcfe6-ee05-4ca7-b1ed-25e77f49734c" species="MEK" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="a2e4fc55-6f8c-453c-b2f3-73c99addcd90" species="pRKIP" stoichiometry="1"/>
+          <speciesReference metaid="_56abffcf-7733-438c-afb1-fc27299e8535" species="pRaf1" stoichiometry="1"/>
+          <speciesReference metaid="_2ac5d08c-3684-433b-bbcd-7ef2ef8c2006" species="pMEK" stoichiometry="1"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_729c80f9-f3dd-4893-a74a-cdcc11b74345" species="RKIP"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_6cec7f56-9207-4f01-b793-b51a611149c2">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_MEK_phosphorylation__pRaf1__pRKIP_and_RKIP_modifiers </ci>
+                <ci> MEK </ci>
+                <ci> RKIP </ci>
+                <ci> Cell </ci>
+                <ci> k11b1 </ci>
+                <ci> k11b2 </ci>
+                <ci> pRKIP </ci>
+                <ci> pRaf1 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI60" id="v12" name="MEK dephosphorylation (PP2A modifer)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI60">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0051389"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI60">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T10:59:11Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0051389"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_7c108d4c-0c75-4c8c-8a51-b2017a018f4d" species="pMEK" stoichiometry="1"/>
+          <speciesReference metaid="_563f0a01-3245-4586-9143-c9ff2fdd91bb" species="PP2A" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_19eb2cb4-c00c-4b58-95c8-3cdfef5d7652" species="MEK" stoichiometry="1"/>
+          <speciesReference metaid="_896cbba7-7bf2-4723-ac43-37debcdd00df" species="PP2A" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_15d6270e-5ab7-4615-9a43-dfb301689ab0">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_MEK_dephosphorylation__PP2A_modifer </ci>
+                <ci> Kcat12 </ci>
+                <ci> Km12 </ci>
+                <ci> PP2A </ci>
+                <ci> Cell </ci>
+                <ci> pMEK </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI61" id="v13" name="ERK phosphorylation (pMEK modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI61">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0004708"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.12.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0000187"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI61">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T10:59:23Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ec-code:2.7.12.2"/>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0000187"/>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0004708"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_0e6e7cea-29bd-4b31-b053-aadd7f1ad932" species="pMEK" stoichiometry="1"/>
+          <speciesReference metaid="a51306e7-c9ec-4861-8ec6-f40d659ce3a2" species="ERK" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_0620dff8-df48-4ef1-8a77-64823cc5d1cc" species="pMEK" stoichiometry="1"/>
+          <speciesReference metaid="e62200ef-a83b-463a-b5d5-3dbd13bdd1d5" species="pERK" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_4047ef48-85e7-46d7-a6ad-f0036d221fd7">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_ERK_phosphorylation__pMEK_modifier </ci>
+                <ci> ERK </ci>
+                <ci> Kcat13 </ci>
+                <ci> Km13 </ci>
+                <ci> Cell </ci>
+                <ci> pMEK </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI62" id="v14" name="ERK dephosphorylation (PP2A modifer)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI62">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0000188"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI62">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:00:03Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0000188"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_533f1173-7ecb-4c17-81d7-bd24b9a8b985" species="pERK" stoichiometry="1"/>
+          <speciesReference metaid="_86d42d39-0621-4694-8ccc-9bca1cb42d2e" species="PP2A" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_5c0b0401-7434-414b-a90b-11d1c79b6231" species="ERK" stoichiometry="1"/>
+          <speciesReference metaid="_9917c12d-f70d-4684-ac8a-46a5bb72bd1a" species="PP2A" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="cff3c342-53ae-4089-9965-83d52cd711cd">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_ERK_dephosphorylation__PP2A_modifer </ci>
+                <ci> Kcat14 </ci>
+                <ci> Km14 </ci>
+                <ci> PP2A </ci>
+                <ci> Cell </ci>
+                <ci> pERK </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI63" id="v15a" name="RKIP phosphorylation (pERK modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI63">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI63">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:56:20Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_5b270813-e4a3-4ac9-bb89-91945556d188" species="pERK" stoichiometry="1"/>
+          <speciesReference metaid="b71093ed-935e-4b29-b444-34175f8e0426" species="RKIP" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_71b11c61-5d86-4812-9974-658e885496e3" species="pERK" stoichiometry="1"/>
+          <speciesReference metaid="_079e6ff7-f8e6-43ea-8328-d1f8d139570b" species="pRKIP" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_2348cd81-9bfa-4554-8154-1426dc5351e0">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_RKIP_phosphorylation__pERK_modifier </ci>
+                <ci> RKIP </ci>
+                <ci> Cell </ci>
+                <ci> k15a </ci>
+                <ci> pERK </ci>
+                <ci> pRKIP </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI64" id="v15b" name="RKIP dephosphorylation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI64">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI64">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:56:33Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="e4e483d6-279d-4509-9565-0140100becb5" species="pRKIP" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="cc45f000-9c37-46fa-be32-8eed2957a8d9" species="RKIP" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="e7fbc2f4-b92a-4740-bdb5-22de8bf3a1d2">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_RKIP_dephosphorylation </ci>
+                <ci> V15b </ci>
+                <ci> Cell </ci>
+                <ci> pRKIP </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI65" id="v15c" name="RKIP degradation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI65">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI65">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:56:45Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0030163"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_17dc8f21-7074-4458-a695-680579b5f213" species="RKIP" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="d8272982-130d-499a-aca6-27b478f7259c" species="null" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_52cf24c1-0ef8-408d-ae54-f96b7510e7eb">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_RKIP_degradation </ci>
+                <ci> RKIP </ci>
+                <ci> Cell </ci>
+                <ci> k15c </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI66" id="v16a" name="bRaf phosphorylation (pRas modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI66">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI66">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:56:58Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="b19e6fd4-ba24-4073-ba76-605dc719c16f" species="pRas" stoichiometry="1"/>
+          <speciesReference metaid="a373940a-3ffc-4124-be4a-76984dd8d076" species="BRaf" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_2295296e-af6a-412b-bb59-d959751da163" species="pRas" stoichiometry="1"/>
+          <speciesReference metaid="_68365e81-ad44-4a01-80e9-43c2d0cfdb7d" species="pBRaf" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_11a83cfe-9fc6-475d-b012-eecae190cad0">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_bRaf_phosphorylation__pRas_modifier </ci>
+                <ci> BRaf </ci>
+                <ci> Kcat16a </ci>
+                <ci> Km16a </ci>
+                <ci> Cell </ci>
+                <ci> pRas </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI67" id="v16b" name="bRaf phosphorylation (pRap1 modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI67">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI67">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:57:11Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_6afb5bd3-2600-4a0f-839c-26dc3e8b6fe6" species="pRap1" stoichiometry="1"/>
+          <speciesReference metaid="f34077c0-65ec-492d-8244-ca8f5d095356" species="BRaf" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="bafb302c-af03-4f7e-8a9f-3fadb6785e37" species="pRap1" stoichiometry="1"/>
+          <speciesReference metaid="_1f3e0829-1fbd-4fb2-b253-7bbb9d64596f" species="pBRaf" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="f9d84d48-1ab5-424d-ab64-0308a052b12f">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_bRaf_phosphorylation__pRap1_modifier </ci>
+                <ci> BRaf </ci>
+                <ci> Kcat16b </ci>
+                <ci> Km16b </ci>
+                <ci> Cell </ci>
+                <ci> pRap1 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI68" id="v18a" name="P90Rsk dephosphorylation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI68">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI68">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:57:47Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_3011070f-5057-46c4-af7f-8756a0056e6e" species="pP90Rsk" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_1f490af6-3e9e-4ebc-9699-0c2befe37cc2" species="P90Rsk" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_76d8034a-f6d1-42ed-84b5-be0451b6fe4a">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_P90Rsk_dephosphorylation </ci>
+                <ci> Cell </ci>
+                <ci> k18a </ci>
+                <ci> pP90Rsk </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI69" id="v18b" name="P90Rsk phosphorylation (pERK modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI69">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI69">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:58:02Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_209d480f-e046-469c-83a2-99ba7273c237" species="pERK" stoichiometry="1"/>
+          <speciesReference metaid="d54fb02f-8276-4c17-81b3-efb1ef5da34c" species="P90Rsk" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="a1e6207b-bb81-4d01-b396-fdd4710eeb3b" species="pERK" stoichiometry="1"/>
+          <speciesReference metaid="b3ab8c9d-7f79-4e5a-bd59-aac183e981da" species="pP90Rsk" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_03fe8b69-bf13-4053-aac2-58e0dc7ae6ce">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_P90Rsk_phosphorylation__pERK_modifier </ci>
+                <ci> Kcat18b </ci>
+                <ci> Km18b </ci>
+                <ci> P90Rsk </ci>
+                <ci> Cell </ci>
+                <ci> pERK </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI70" id="v19a" name="PI3K phosphorylation (boundEGFR modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI70">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI70">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:58:15Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_67ae0e3c-d18c-4194-a4d9-07045cccf7c0" species="bEGFR" stoichiometry="1"/>
+          <speciesReference metaid="_674976fa-6f9d-481b-bd6a-6db591713f93" species="PI3K" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="ee41e20f-f4e5-48dd-b290-83f34ea883a2" species="bEGFR" stoichiometry="1"/>
+          <speciesReference metaid="d803627d-191a-4802-a9df-3e7a21f3d6b8" species="pPI3K" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="d2cdc7d6-f53f-4c52-85b6-305bec9e35ad">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_PI3K_phosphorylation__boundEGFR_modifier </ci>
+                <ci> Kcat19a </ci>
+                <ci> Km19a </ci>
+                <ci> PI3K </ci>
+                <ci> bEGFR </ci>
+                <ci> Cell </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI71" id="v19b" name="PI3K phosphorylation (pRas modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI71">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI71">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:58:27Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="bbea2b59-5558-4730-a559-72c971bedbb0" species="PI3K" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_3ba1eb49-4910-44d8-a79d-4f5464103e20" species="pPI3K" stoichiometry="1"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_449ed87a-94e5-400e-806c-6a753cddcc2f" species="pRas"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_6bdb35a0-f691-4005-acae-9c586682bb64">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_PI3K_phosphorylation__pRas_modifier </ci>
+                <ci> Kcat19b </ci>
+                <ci> Km19b </ci>
+                <ci> PI3K </ci>
+                <ci> Cell </ci>
+                <ci> pRas </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI72" id="v19c" name="PI3K dephosphorylation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI72">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI72">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:58:39Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_7cc055d2-8a2e-49cc-bbbd-4dcd9f5e79d4" species="pPI3K" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_721b9bd1-e11c-47b2-8bd8-88fcd03d54f2" species="PI3K" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_8e1ddbc8-748c-436b-9bef-e1eb832508a2">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_PI3K_dephosphorylation </ci>
+                <ci> Cell </ci>
+                <ci> k19c </ci>
+                <ci> pPI3K </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI73" id="v2" name="EGFR binding" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI73">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0070851"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI73">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:58:51Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0070851"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="d6fe612a-8f68-4737-808f-518236ea561a" species="fEGFR" stoichiometry="1"/>
+          <speciesReference metaid="e1b91d9b-4263-4fee-9845-82ca93c1816b" species="EGF" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_5b7be85f-4efa-4029-86e8-dc8381d428ac" species="bEGFR" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_7d720f90-2618-472f-881c-7890af47f256">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_EGFR_binding </ci>
+                <ci> EGF </ci>
+                <ci> bEGFR </ci>
+                <ci> Cell </ci>
+                <ci> fEGFR </ci>
+                <ci> k21 </ci>
+                <ci> k22 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI74" id="v20" name="PIP2 phosphorylated to PIP3" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI74">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI74">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:59:01Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="f7cdb3f4-a865-448a-a520-7666e8545809" species="pPI3K" stoichiometry="1"/>
+          <speciesReference metaid="_525c1fcf-4edc-4ab8-8498-bcca3d28d6c5" species="PIP2" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="b7dd0eef-df26-4950-8b8d-e8a54fc0df3b" species="pPI3K" stoichiometry="1"/>
+          <speciesReference metaid="_43b1de68-2792-4d68-8fc9-b46f29c11e34" species="PIP3" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="c27ff93f-57d2-4dc5-9bdf-bd9470d35938">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_PIP2_phosphorylated_to_PIP3 </ci>
+                <ci> Kcat20 </ci>
+                <ci> Km20 </ci>
+                <ci> PIP2 </ci>
+                <ci> Cell </ci>
+                <ci> pPI3K </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI75" id="v21" name="PIP3 dephosphorylated to PIP2" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI75">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI75">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:59:14Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="acda03ac-ac3b-45ef-b862-be78728113cb" species="PTEN" stoichiometry="1"/>
+          <speciesReference metaid="_9a21c2b1-a850-4b0e-88ae-ae6cb6e63eb1" species="PIP3" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_4fc1ad47-225f-4b9b-90d2-58bf1abfcd46" species="PTEN" stoichiometry="1"/>
+          <speciesReference metaid="_2fd9a73a-dbe6-43da-8cdf-db75019f2a8c" species="PIP2" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="a6a66be0-e17d-49f1-9019-e40dade48171">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_PIP3_dephosphorylated_to_PIP2 </ci>
+                <ci> Kcat21 </ci>
+                <ci> Km21 </ci>
+                <ci> PIP3 </ci>
+                <ci> PTEN </ci>
+                <ci> Cell </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI76" id="v22a" name="Akt phosphorylation (PIP3 modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI76">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI76">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:59:25Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_47bd800a-5416-43a8-a04a-ea9fc259eaab" species="PIP3" stoichiometry="1"/>
+          <speciesReference metaid="c674b892-6766-4d41-8922-617d6f358352" species="Akt" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="abe1f25d-a7b8-4fdf-96f7-b5cc4f4afdaf" species="PIP3" stoichiometry="1"/>
+          <speciesReference metaid="_14c7179e-73c9-4a86-a1e4-5b5889e3db6b" species="pAkt" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="fa1418e7-db54-4898-94b3-be870e1a3af5">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Akt_phosphorylation__PIP3_modifier </ci>
+                <ci> Akt </ci>
+                <ci> Kcat22a </ci>
+                <ci> Km22a </ci>
+                <ci> PIP3 </ci>
+                <ci> Cell </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI77" id="v22b" name="Akt dephosphorylation " reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI77">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI77">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:59:37Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="c540cdad-b00d-41f0-9f3b-5f429c2ba55e" species="pAkt" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_35c4f730-de01-4e6d-be54-93fd2eb9667b" species="Akt" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="e44eb1b7-4f01-4fdd-a5ff-9f8f1dd0cf8a">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Akt_dephosphorylation </ci>
+                <ci> Kcat22b </ci>
+                <ci> Km22b </ci>
+                <ci> Cell </ci>
+                <ci> pAkt </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI78" id="v23a" name="C3G phosphorylation (boundEGFR modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI78">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI78">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T11:59:48Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="f0321083-4f80-401f-b39e-39f2ee8be06c" species="bEGFR" stoichiometry="1"/>
+          <speciesReference metaid="ee153e38-2cb6-4953-ba5e-71569b8a241d" species="C3G" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="acdf431a-a36e-4485-bd58-2c6cfd5bfe48" species="bEGFR" stoichiometry="1"/>
+          <speciesReference metaid="_6124c30e-d2ff-4264-87cd-8ac8e6df5139" species="pC3G" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="c6ef63a0-fd8e-4610-802a-cfe615b4ff2e">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_C3G_phosphorylation__boundEGFR_modifier </ci>
+                <ci> C3G </ci>
+                <ci> Kcat23a </ci>
+                <ci> Km23a </ci>
+                <ci> bEGFR </ci>
+                <ci> Cell </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI79" id="v23b" name="C3G dephosphorylation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI79">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI79">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:00:00Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_28382da2-3083-4dd2-b29e-e11702a54779" species="pC3G" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_018d7fbd-94f3-4710-8aae-6f13bbdc41ed" species="C3G" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="b9690670-3d1e-4758-9b2a-076e4c934b3e">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_C3G_dephosphorylation </ci>
+                <ci> Cell </ci>
+                <ci> k23b </ci>
+                <ci> pC3G </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI80" id="v24" name="Rap1 phosphorylation (pC3G modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI80">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI80">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:00:12Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_2f5765a4-d090-4479-8482-92302825f754" species="pC3G" stoichiometry="1"/>
+          <speciesReference metaid="_8f42c9a4-f122-4661-9ed3-0fed9699f05a" species="Rap1" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_87757889-42d5-44ad-a685-c26313d7faa6" species="pC3G" stoichiometry="1"/>
+          <speciesReference metaid="_5a5feadb-4165-43ca-b789-724a262c91cb" species="pRap1" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_9ef9649e-1d5b-4b22-84e2-4d612a8202eb">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Rap1_phosphorylation__pC3G_modifier </ci>
+                <ci> Kcat24 </ci>
+                <ci> Km24 </ci>
+                <ci> Rap1 </ci>
+                <ci> Cell </ci>
+                <ci> pC3G </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI81" id="v25" name="Rap1 dephosphorylation (Rap1_GAP modifer)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI81">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI81">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:00:21Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="aa5713fa-c529-4112-a62e-ddba5186aa5f" species="Rap1Gap" stoichiometry="1"/>
+          <speciesReference metaid="_0452505d-3afd-46e3-83a2-bdb5532cfa95" species="pRap1" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_97026c8f-efff-4606-b02a-5d61b22c25bd" species="Rap1Gap" stoichiometry="1"/>
+          <speciesReference metaid="_05331cb1-f8ec-4552-bba0-4683c52907a9" species="Rap1" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_16c1e2c1-866e-4079-a4ef-1aae69c25dc3">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Rap1_dephosphorylation__Rap1_GAP_modifer </ci>
+                <ci> Kcat25 </ci>
+                <ci> Km25 </ci>
+                <ci> Rap1Gap </ci>
+                <ci> Cell </ci>
+                <ci> pRap1 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI82" id="v26a" name="PKCD synthesis" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI82">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0009058"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI82">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:00:33Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0009058"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_667acb6d-1375-4373-886f-52fd45a30306" species="GSK3B" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_02bdc6bc-6a21-4bdd-8ae7-5617557d0e41" species="GSK3B" stoichiometry="1"/>
+          <speciesReference metaid="be0ec532-e466-4e1b-9e0a-f1fcdf0555fb" species="PKCD" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="c4563f91-a14a-48fa-a5cf-cea4c26307ac">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_PKCD_synthesis </ci>
+                <ci> GSK3B </ci>
+                <ci> V26a </ci>
+                <ci> Cell </ci>
+                <ci> k26a </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI83" id="v26b" name="PKCD degradation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI83">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI83">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:00:49Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0030163"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="fb97ba23-8899-4ac3-8b4f-9b404fc445ce" species="PKCD" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_7dfec77b-a2c7-4575-9543-fec4ce95ff0d" species="null" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="c1cff173-8a8c-499a-a482-cdea60d90694">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_PKCD_degradation </ci>
+                <ci> PKCD </ci>
+                <ci> Cell </ci>
+                <ci> k26b </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI84" id="v27a" name="GSK3b phosphorylation (pERK modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI84">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI84">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:01:02Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_56dc8ba5-86da-4e27-81cc-2ea67bf5ef8b" species="pERK" stoichiometry="1"/>
+          <speciesReference metaid="_6366d347-6ebc-4016-a7d5-95065602ead6" species="GSK3B" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_644ef040-76c5-4d7f-a892-5942287a4a76" species="pERK" stoichiometry="1"/>
+          <speciesReference metaid="d3422452-ba3b-4893-8efb-e583c8da47b5" species="pGSK3B" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_25a6e5a3-c057-4473-aa3f-457e2b3652be">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_GSK3b_phosphorylation__pERK_modifier </ci>
+                <ci> GSK3B </ci>
+                <ci> Kcat27a </ci>
+                <ci> Cell </ci>
+                <ci> pERK </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI85" id="v27b" name="GSK3b phosphorylation (pAkt modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI85">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI85">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:01:14Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_6e1fd389-0b78-4436-8130-3257be222817" species="pAkt" stoichiometry="1"/>
+          <speciesReference metaid="_6fecd4da-6bf9-4eb3-adfd-1d7330095638" species="GSK3B" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="d84311ed-d265-4c8d-8c9c-693fabfe08c6" species="pAkt" stoichiometry="1"/>
+          <speciesReference metaid="dadb5a9d-eb0c-4324-b8fc-c3934c6174cc" species="pGSK3B" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_6400b372-cec0-40ac-b1e6-7f850856ab0f">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_GSK3b_phosphorylation__pAkt_modifier </ci>
+                <ci> GSK3B </ci>
+                <ci> Kcat27b </ci>
+                <ci> Cell </ci>
+                <ci> pAkt </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI86" id="v27c" name="GSK3b synthesis" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI86">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0009058"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI86">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:01:22Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0009058"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="ce494a79-53bb-40b4-9a4d-3dbec5c7b06b" species="RKIP" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="c2230734-47b6-4c32-a07a-e9529a87a13b" species="RKIP" stoichiometry="1"/>
+          <speciesReference metaid="f3fe6fda-1be0-46e4-bd7b-a537663c9eb1" species="GSK3B" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="c02ce219-f2bb-4f2b-b1c9-f52c56141869">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_GSK3b_synthesis </ci>
+                <ci> RKIP </ci>
+                <ci> Cell </ci>
+                <ci> k27c </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI87" id="v27d" name="GSK3b dephosphorylation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI87">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI87">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:01:32Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_505bd83a-cbf0-412f-952c-7658c2c1f647" species="pGSK3B" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_11655e46-88cc-48a4-99e6-f720ad3c9142" species="GSK3B" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_6c75896c-03ca-4796-90d0-0848cf234931">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_GSK3b_dephosphorylation </ci>
+                <ci> Kcat27d </ci>
+                <ci> Cell </ci>
+                <ci> pGSK3B </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI88" id="v28" name="Dsh activation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI88">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0072376"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI88">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:01:43Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0072376"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="a4d9ce0b-5063-42a1-b6f4-95cc0e483afa" species="Dshi" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="bde116a3-7e2f-42a2-8b8d-09590df8d204" species="Dsha" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_7c1726d4-5116-4731-afd6-2ac02e898075">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Dsh_activation </ci>
+                <ci> Dshi </ci>
+                <ci> W </ci>
+                <ci> Cell </ci>
+                <ci> k28 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI89" id="v29" name="Dsh deactivation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI89">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:2000257"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI89">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:01:56Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:2000257"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="bb4e0f94-1120-4be4-9e36-4bf0f89587d6" species="Dsha" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="b81fe957-9ef0-4b10-a40c-f8eba3e90ef3" species="Dshi" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_93eef871-d06f-42eb-bf45-660c6498be13">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Dsh_deactivation </ci>
+                <ci> Dsha </ci>
+                <ci> Cell </ci>
+                <ci> k29 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI90" id="v3" name="freeEGFR degradation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI90">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI90">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:02:08Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0030163"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_9a31de67-b92f-4776-bbae-d2f2649a4096" species="fEGFR" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="ef4990c9-d522-4560-87ab-5ce95528fa97" species="null" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="cec0daca-d385-4be1-bda8-24722e360418">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_freeEGFR_degradation </ci>
+                <ci> Cell </ci>
+                <ci> fEGFR </ci>
+                <ci> k3 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI91" id="v30" name="APC_Axin_GSK3b complex disassembly (Dsha modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI91">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0043624"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI91">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:02:19Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0043624"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_2f1026f9-26a4-4bfb-aa8f-198a49be5c03" species="Dsha" stoichiometry="1"/>
+          <speciesReference metaid="_7b0cf58b-27e0-4f63-b869-9d371e97d281" species="APCAxinGSK3B" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="d7ec9508-ce31-482f-b806-8fb0c90b9e50" species="GSK3B" stoichiometry="1"/>
+          <speciesReference metaid="d19e79a9-48db-4069-b82a-42d2e644e369" species="APCAxin" stoichiometry="1"/>
+          <speciesReference metaid="_97e12b53-7e3c-4eea-bb25-454b9b21ff42" species="Dsha" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_7c2fcc4b-1674-476f-a7ad-8351b2a907f1">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_APC_Axin_GSK3b_complex_disassembly__Dsha_modifier </ci>
+                <ci> APCAxinGSK3B </ci>
+                <ci> Dsha </ci>
+                <ci> Cell </ci>
+                <ci> k30 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI92" id="v31" name="APC_Axin_GSK3b complex formation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI92">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0005515"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI92">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:02:32Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0005515"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_0637539b-4c99-4d39-8159-b704eb3039c2" species="APCAxin" stoichiometry="1"/>
+          <speciesReference metaid="_75f79723-1bff-4ae5-879a-761b187aa68a" species="GSK3B" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_01976eaa-5178-4f1d-9b44-10d27ccac3a6" species="APCAxinGSK3B" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_55fc01b3-9861-46fd-b792-23a00349479e">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_APC_Axin_GSK3b_complex_formation </ci>
+                <ci> APCAxin </ci>
+                <ci> APCAxinGSK3B </ci>
+                <ci> GSK3B </ci>
+                <ci> Cell </ci>
+                <ci> k311 </ci>
+                <ci> k312 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI93" id="v32a" name="APC and Axin phosphorylation (in compound)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI93">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI93">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:02:43Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_84912c6b-3014-4b51-b97d-11c2c5df6176" species="APCAxinGSK3B" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_47cd410f-1037-4025-b20d-c4e67e68378c" species="pAPCpAxinGSK3B" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="d8667f64-e4fc-40cd-9a8a-14575ba1e1d7">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_APC_and_Axin_phosphorylation__in_compound </ci>
+                <ci> APCAxinGSK3B </ci>
+                <ci> Cell </ci>
+                <ci> k32a </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI94" id="v32b" name="APC and Axin dephosphorylation (in compound)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI94">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI94">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:02:55Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_2d6ab2a5-4625-4bbb-a7a9-2b5b979ffc3f" species="pAPCpAxinGSK3B" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_68f71e8b-f2ef-45e2-8a19-72dba025e641" species="APCAxinGSK3B" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_04dddfe9-b995-4d7c-b1c5-454fb3cf3a83">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_APC_and_Axin_dephosphorylation__in_compound </ci>
+                <ci> Cell </ci>
+                <ci> k32b </ci>
+                <ci> pAPCpAxinGSK3B </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI95" id="v33a" name="APC_Axin complex formation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI95">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0005515"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI95">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:03:06Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0005515"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="abe6e0c5-3439-425f-a386-8129d6b8e11f" species="APC" stoichiometry="1"/>
+          <speciesReference metaid="_5dd9b9b4-c241-4bb9-8587-440b1d5d715f" species="Axin" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_836d604c-eefb-4267-9838-bd3f72bb958b" species="APCAxin" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="a5173c9d-0c8a-427d-b982-b7d99c3b6769">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> APC_Axin_complex_formation </ci>
+                <ci> APC </ci>
+                <ci> APCAxin </ci>
+                <ci> Axin </ci>
+                <ci> Cell </ci>
+                <ci> k33a1 </ci>
+                <ci> k33a2 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI96" id="v33b" name="Axin degradation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI96">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI96">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:03:18Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0030163"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_430f7bdd-a970-452d-86f9-0e4e76534fc0" species="Axin" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="c812c32f-048d-4313-a17f-7c907ed177e7" species="null" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="e9792678-10fe-4c35-9b8c-315c51181851">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Axin_degradation </ci>
+                <ci> Axin </ci>
+                <ci> Cell </ci>
+                <ci> k33b </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI97" id="v33c" name="Axin synthesis" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI97">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0045727"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI97">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:03:31Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0045727"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="e073d5df-f8c4-423e-9a4d-981deea1510a" species="BCatenin" stoichiometry="1"/>
+          <speciesReference metaid="e071e374-942d-4a18-aef6-ef73c9d425f0" species="TCFBCatenin" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="f92c19b1-8384-441b-a416-144d45b13de3" species="BCatenin" stoichiometry="1"/>
+          <speciesReference metaid="_0b92088e-e265-4e76-a902-cd664744c220" species="TCFBCatenin" stoichiometry="1"/>
+          <speciesReference metaid="a8627411-569f-4e97-bc25-38fc5ca591c3" species="Axin" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_0984522f-7a30-4747-877f-6b56fb74f6a4">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Axin_synthesis </ci>
+                <ci> BCatenin </ci>
+                <ci> TCFBCatenin </ci>
+                <ci> Cell </ci>
+                <ci> k33c1 </ci>
+                <ci> k33c2 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI98" id="v34" name="pAPC_pAxin_GSK3b_bCatenin complex formation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI98">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0005515"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI98">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:03:42Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0005515"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_7055e4d3-1213-4e1a-a863-f2af40599e23" species="BCatenin" stoichiometry="1"/>
+          <speciesReference metaid="_7d6ef125-0aa1-4318-b32f-6357e1536270" species="pAPCpAxinGSK3B" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_953fc04f-292d-4d6c-bb3d-276c31a5aa96" species="pAPCpAxinGSK3BBCatenin" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="bd786efb-1d21-4b81-a523-fcad8dbf9ee7">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_pAPC_pAxin_GSK3b_bCatenin_complex_formation </ci>
+                <ci> BCatenin </ci>
+                <ci> Cell </ci>
+                <ci> k341 </ci>
+                <ci> k342 </ci>
+                <ci> pAPCpAxinGSK3B </ci>
+                <ci> pAPCpAxinGSK3BBCatenin </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI99" id="v35" name="bCatenin phosphorylation (in compond)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI99">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI99">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:03:52Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_3e33ef00-8b14-4752-9c68-718002421835" species="pAPCpAxinGSK3BBCatenin" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_676a3972-a697-4525-801d-a608810eb4a2" species="pAPCpAxinGSK3BpBCatenin" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_99e3b680-b1ca-48a6-b809-544a6a7c3471">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_bCatenin_phosphorylation__in_compound </ci>
+                <ci> Cell </ci>
+                <ci> k35 </ci>
+                <ci> pAPCpAxinGSK3BBCatenin </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI100" id="v36" name="pAPC_pAxin_GSK3b_pbCatenin complex disassembly" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI100">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0043624"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI100">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:04:02Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0043624"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_95f57937-8ce9-4472-bbe2-14892cfdc5a0" species="pAPCpAxinGSK3BpBCatenin" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_2dd9d75d-2f63-457e-97c2-f763b349b737" species="pBCatenin" stoichiometry="1"/>
+          <speciesReference metaid="a42c9dd8-c2be-4689-95fe-4e72ca9ecb91" species="pAPCpAxinGSK3B" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="ec62db12-9ee6-4b88-b939-4b86a3e36994">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_pAPC_pAxin_GSK3b_pbCatenin_complex_disassembly </ci>
+                <ci> Cell </ci>
+                <ci> k36 </ci>
+                <ci> pAPCpAxinGSK3BpBCatenin </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI101" id="v37a" name="APC_bCatenin complex formation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI101">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0043624"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI101">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:04:13Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0043624"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_343100d5-4ad7-4325-abf8-a383fcf9405b" species="BCatenin" stoichiometry="1"/>
+          <speciesReference metaid="_448d336e-7c5a-40bd-aa52-85e624cc9d83" species="APC" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_4ad0f546-21f6-45d7-88bd-8271de980cf4" species="APCBCatenin" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_55f844c1-6188-4277-89cd-a688c2128a04">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_APC_bCatenin_complex_formation </ci>
+                <ci> APC </ci>
+                <ci> APCBCatenin </ci>
+                <ci> BCatenin </ci>
+                <ci> Cell </ci>
+                <ci> k37a1 </ci>
+                <ci> k37a2 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI102" id="v37b" name="bCatenin synthesis" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI102">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0045727"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI102">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:04:27Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0045727"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_3d8b039d-092b-4752-be70-fd7fd0b051ac" species="null" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_75759c6f-a4c6-44d5-b442-870b82c47cf0" species="BCatenin" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_23b724ff-feeb-450b-ad7d-4b59854b4e8f">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_bCatenin_synthesis </ci>
+                <ci> V37b </ci>
+                <ci> Cell </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI103" id="v37c" name="bCatenin degradation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI103">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI103">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:04:42Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0030163"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="ec253a6d-2254-43ca-88a6-4dcc1e8d5e2b" species="BCatenin" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_8326e820-6fc0-4289-b1f5-6288a132fd23" species="null" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_881cabc2-834e-4b89-8df5-c90d7a72b343">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_bCatenin_degradation </ci>
+                <ci> BCatenin </ci>
+                <ci> Cell </ci>
+                <ci> k37c </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI104" id="v38" name="bCatenin_TCF complex binding" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI104">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0005515"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI104">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:05:04Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0005515"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="aab53dd5-361b-4272-af4a-c2f64d95279a" species="TCF" stoichiometry="1"/>
+          <speciesReference metaid="_8fa767de-de0c-466f-a53b-65e8cf771df1" species="BCatenin" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_8d7bde33-ee22-47ed-83f2-556551fc59ab" species="TCFBCatenin" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_4bc66b88-db6b-4977-b099-a5756980fc09">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_bCatenin_TCF_complex_binding </ci>
+                <ci> BCatenin </ci>
+                <ci> TCF </ci>
+                <ci> TCFBCatenin </ci>
+                <ci> Cell </ci>
+                <ci> k381 </ci>
+                <ci> k382 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI105" id="v39" name="X synthesis" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI105">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0009058"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI105">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:05:19Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0009058"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="e18f093f-db14-423d-a464-5f28cb6787d4" species="TCFBCatenin" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_6b50ebdc-5486-4064-87df-df767a939166" species="X" stoichiometry="1"/>
+          <speciesReference metaid="d3ead410-66b3-4482-a9ac-05b64c61d78c" species="TCFBCatenin" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_7e100599-2585-4777-9ea2-f4095f43c8a6">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_X_synthesis </ci>
+                <ci> Km39 </ci>
+                <ci> TCFBCatenin </ci>
+                <ci> Cell </ci>
+                <ci> k39 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI106" id="v4" name="boundEGFR degradation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI106">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI106">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:06:04Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0030163"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_845b0597-e3ee-4b36-b913-eb1ca9b80088" species="bEGFR" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="c314c5cc-dd40-4052-9fdc-50556fc124a8" species="null" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_3e1224d6-1010-4bb8-aa79-13f42e32fb7d">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_boundEGFR_degradation </ci>
+                <ci> bEGFR </ci>
+                <ci> Cell </ci>
+                <ci> k4 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI107" id="v40" name="X degradation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI107">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI107">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:06:17Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0030163"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="ebacb69d-ad7f-4c54-a05d-a49881691d54" species="X" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_2a13e2e6-5a2f-43b4-8a3f-76ceea830017" species="null" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_7aafbcb5-852d-43ef-aeb8-625a78cb867a">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_X_degradation </ci>
+                <ci> X </ci>
+                <ci> Cell </ci>
+                <ci> k40 </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI108" id="v41" name="pbCatenin degradation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI108">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0030163"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI108">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:06:30Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0030163"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_4491b334-09b2-4166-8dc2-27cfcf2130c8" species="pBCatenin" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_9e7da972-6638-4c8c-88fb-e484d6992a4a" species="null" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="b4c8060c-0ebc-4c2e-a2af-aa97f9ba586e">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_pbCatenin_degradation </ci>
+                <ci> Cell </ci>
+                <ci> k41 </ci>
+                <ci> pBCatenin </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI109" id="v5" name="SOS phosphorylation (PKCD. pERK and boundEGFR modifiers) " reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI109">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI109">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:06:39Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_74d4966a-b721-419e-a0ae-5da660b8e5e7" species="PKCD" stoichiometry="1"/>
+          <speciesReference metaid="_9edef015-a0ec-43b1-b71b-e11e7b20765e" species="pERK" stoichiometry="1"/>
+          <speciesReference metaid="f6003249-663f-4d50-a4b0-dde13f5cc16c" species="bEGFR" stoichiometry="1"/>
+          <speciesReference metaid="_898a3153-4ac5-461a-bb2b-940eae9e448d" species="SOS" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_31840ef8-51f4-45d0-b59b-53bdd62c0f57" species="PKCD" stoichiometry="1"/>
+          <speciesReference metaid="_8009b4d5-a8df-4807-ab6e-6094b5e1135e" species="pERK" stoichiometry="1"/>
+          <speciesReference metaid="_7e6049dc-1d4d-4104-8739-f480ab6edbc2" species="bEGFR" stoichiometry="1"/>
+          <speciesReference metaid="b759f039-ec6b-4231-8d46-6e3f647ffb61" species="pSOS" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="f78bcd35-d817-4173-a631-e9b47a6fbe12">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_SOS_phosphorylation__PKCD__pERK_and_boundEGFR_modifiers_ </ci>
+                <ci> PKCD </ci>
+                <ci> bEGFR </ci>
+                <ci> Cell </ci>
+                <ci> k51 </ci>
+                <ci> k52 </ci>
+                <ci> k53 </ci>
+                <ci> k54 </ci>
+                <ci> pERK </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI110" id="v6a" name="SOS dephosphorylation" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI110">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI110">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:06:50Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="cf384160-1c0d-439c-b54d-d7ce0b1c87f1" species="pSOS" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_0d9c2430-70d1-4ba7-8b47-2763bbc69c5f" species="SOS" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_152120a9-37fb-4dee-be8f-95e66b048fb1">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_SOS_dephosphorylation </ci>
+                <ci> Cell </ci>
+                <ci> k6a </ci>
+                <ci> pSOS </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI111" id="v6b" name="SOS dephosphorylation (pP90Rsk modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI111">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI111">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:07:23Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="c784c38f-5b6b-4a82-9811-52b657bbc085" species="pP90Rsk" stoichiometry="1"/>
+          <speciesReference metaid="_191a866d-3674-4f6d-a938-6efb6a60dffb" species="pSOS" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_1007e7b6-df48-48fc-bb1e-7a829e9e4261" species="pP90Rsk" stoichiometry="1"/>
+          <speciesReference metaid="_8351125b-ff99-414d-88fe-742dbcdc0091" species="SOS" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_430eb837-f18f-4e8d-b16d-e2628ad2d1fe">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_SOS_dephosphorylation__pP90Rsk_modifier </ci>
+                <ci> Kcat6b </ci>
+                <ci> Km6b </ci>
+                <ci> Cell </ci>
+                <ci> pP90Rsk </ci>
+                <ci> pSOS </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI112" id="v7" name="Ras phosphorylation (pSOS modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI112">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI112">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:07:03Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_94423f91-37a3-4870-9c7b-ef0363bfc24a" species="pSOS" stoichiometry="1"/>
+          <speciesReference metaid="_16e39581-178e-45ca-ba6c-b7eb4b83d90f" species="Ras" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_8fcdbd67-4c58-4a98-a9bc-55d7b95fdfa6" species="pSOS" stoichiometry="1"/>
+          <speciesReference metaid="_60bbfc24-4d2f-4c8b-847c-12d235f13c33" species="pRas" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_0a257a6e-9235-4ba0-8502-fea2ac5c71ba">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Ras_phosphorylation__pSOS_modifier </ci>
+                <ci> Kcat7 </ci>
+                <ci> Km7 </ci>
+                <ci> Ras </ci>
+                <ci> Cell </ci>
+                <ci> pSOS </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI113" id="v8a" name="Ras synthesis" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI113">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0045727"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI113">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:07:47Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0045727"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="ae7169ee-d2be-4808-a431-ed4b46a22a9f" species="null" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_5892ad20-6e05-41e6-b5b0-e91067f9b924" species="Ras" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_9fbdf608-9834-4ffd-8e62-5374b0e10d07">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Ras_synthesis </ci>
+                <ci> V8a </ci>
+                <ci> Cell </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI114" id="v8b" name="Ras dephosphorylation (Ras_Gap modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI114">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016311"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI114">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:07:58Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016311"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="dea09869-bff8-426c-ab98-8355656a60b5" species="RasGap" stoichiometry="1"/>
+          <speciesReference metaid="_3efd1619-52a4-41da-a937-9caedff82467" species="pRas" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_689ffb6c-b142-44d3-b9e4-10cf000fa9b7" species="RasGap" stoichiometry="1"/>
+          <speciesReference metaid="_21bab364-a1ef-4089-8af2-c4b40eda4170" species="Ras" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="c0e8830a-9679-496e-ac3b-c210b993ab43">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Ras_dephosphorylation__Ras_Gap_modifier </ci>
+                <ci> Kcat8b </ci>
+                <ci> Km8b </ci>
+                <ci> RasGap </ci>
+                <ci> Cell </ci>
+                <ci> pRas </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI115" id="v9a" name="Raf1 phosphorylation (pRas modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI115">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI115">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:08:11Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_638a3db8-a738-4c06-9d10-a0e56cf6888c" species="pRas" stoichiometry="1"/>
+          <speciesReference metaid="e2d99f60-3d0d-44e9-aa36-77e153fbf3e4" species="Raf1" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="c89b861c-1dda-4b6b-ae9b-a094c799797b" species="pRas" stoichiometry="1"/>
+          <speciesReference metaid="_73f9c6a8-401b-41b7-a530-c9c0f6125223" species="pRaf1" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_06795753-4f3a-4998-a538-3214079fbde1">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Raf1_phosphorylation__pRas_modifier </ci>
+                <ci> Kcat9a </ci>
+                <ci> Km9a </ci>
+                <ci> Raf1 </ci>
+                <ci> Cell </ci>
+                <ci> pRas </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI116" id="v9b" name="Raf1 phosphorylation (X modifier)" reversible="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI116">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016310"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI116">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-14T12:08:22Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:isVersionOf rdf:resource="urn:miriam:go:GO:0016310"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_7029a0d9-3071-4e3c-a820-8c30632ab431" species="X" stoichiometry="1"/>
+          <speciesReference metaid="_79d5f9b9-d284-4516-a531-36d09ebec431" species="Raf1" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="a90a53b4-3aa2-4ea5-b3a9-201d5a06aa05" species="X" stoichiometry="1"/>
+          <speciesReference metaid="b717f9b7-51f6-4bd6-8390-e88738638040" species="pRaf1" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_713f2810-81da-4101-abd3-a0c82b337b50">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> Function_for_Raf1_phosphorylation__X_modifier </ci>
+                <ci> Km9b </ci>
+                <ci> Raf1 </ci>
+                <ci> W </ci>
+                <ci> X </ci>
+                <ci> Cell </ci>
+                <ci> k9b </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI117" id="bRaf_dephosphorylation__RafPPtase_modifier" name="bRaf dephosphorylation (RafPPtase modifier)" reversible="true">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI117">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:23:52Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_41f0d5b3-cc22-4fb9-96f2-2bbe6ae2f841" species="RafPPtase" stoichiometry="1"/>
+          <speciesReference metaid="_65a9c2e2-b908-4583-b614-174df1ff498e" species="pBRaf" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_1bc37dc1-125b-4a70-9074-18f1ab8630de" species="RafPPtase" stoichiometry="1"/>
+          <speciesReference metaid="_3a10fc25-b32a-4581-8ae1-73a8e8334b2a" species="BRaf" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="c6ec3c1f-ac8e-48b1-b7a8-edc7d6a4b04a">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> function_for_bRaf_dephosphorylation </ci>
+                <ci> Kcat17a </ci>
+                <ci> RafPPtase </ci>
+                <ci> pBRaf </ci>
+                <ci> Km17a </ci>
+                <ci> Cell </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="COPASI118" id="bRaf_dephosphorylation__pAkt_modifier" name="bRaf dephosphorylation (pAkt modifier)" reversible="true">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI118">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2017-08-15T10:31:52Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="f0a11681-cbd6-430f-82b0-323a5e026a0f" species="pAkt" stoichiometry="1"/>
+          <speciesReference metaid="_9d306bc5-fb2e-444a-b47f-158f21117f5a" species="pBRaf" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="f39f25ce-bb20-4688-9480-b8a2347ac025" species="pAkt" stoichiometry="1"/>
+          <speciesReference metaid="_3d4c44d3-3edb-4513-b6cf-1bd8a5fe92c3" species="BRaf" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw metaid="_87dd9d46-085e-4f9b-ad78-ace7a33e62ae">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> Cell </ci>
+              <apply>
+                <ci> function_for_bRaf_dephosphorylation </ci>
+                <ci> Kcat17b </ci>
+                <ci> pBRaf </ci>
+                <ci> pAkt </ci>
+                <ci> Km17b </ci>
+                <ci> Cell </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/plugin_auto2000/auto2000.cpp
+++ b/test/plugin_auto2000/auto2000.cpp
@@ -25,20 +25,32 @@ public:
 };
 
 
-TEST_F(PluginAuto2000Tests, Issue_773_no_boundary_species)
+TEST_F(PluginAuto2000Tests, Issue_1259_crash_when_run_twice)
 {
-    //This just tests to make sure we don't crash if there's no boundary species.
+    //This tests to make sure we don't crash if we call 'execute' multiple times.
     PluginManager* PM = new PluginManager(rrPluginsBuildDir_.string());
 
     Plugin* a2kplugin = PM->getPlugin("tel_auto2000");
     ASSERT_TRUE(a2kplugin != NULL);
-    a2kplugin->setPropertyByString("SBML", (pluginsModelsDir / "auto2000_2rxn.xml").string().c_str());
-    a2kplugin->setPropertyByString("PrincipalContinuationParameter", "k");
-    a2kplugin->setPropertyByString("ScanDirection", "Positive");
-    a2kplugin->setPropertyByString("RL0", "0");
-    a2kplugin->setPropertyByString("RL1", "5");
-
+    a2kplugin->setPropertyByString("SBML", (pluginsModelsDir / "BIOMD0000000648_url.xml").string().c_str());
     a2kplugin->execute();
+    a2kplugin->execute();
+}
+
+TEST_F(PluginAuto2000Tests, Issue_773_no_boundary_species)
+{
+  //This just tests to make sure we don't crash if there's no boundary species.
+  PluginManager* PM = new PluginManager(rrPluginsBuildDir_.string());
+
+  Plugin* a2kplugin = PM->getPlugin("tel_auto2000");
+  ASSERT_TRUE(a2kplugin != NULL);
+  a2kplugin->setPropertyByString("SBML", (pluginsModelsDir / "auto2000_2rxn.xml").string().c_str());
+  a2kplugin->setPropertyByString("PrincipalContinuationParameter", "k");
+  a2kplugin->setPropertyByString("ScanDirection", "Positive");
+  a2kplugin->setPropertyByString("RL0", "0");
+  a2kplugin->setPropertyByString("RL1", "5");
+
+  a2kplugin->execute();
 
 }
 


### PR DESCRIPTION
Reported in #1259, repeated calls to steady state between loading new models into the roadrunner object.

Fixed this in several ways:
* The steady state decorator now nulls-out its own copy of the model pointer, and calls to 'getModel' now always call the child solver_ model.
* When creating a decorator, we now check to see if the current solver is already a decorator, and if so, leave it alone.
* After creating a decorator, we delete them *even when we fail* (catch the exception, delete, then re-throw).
* The decorators do a better job and doing what they are supposed to do.