### PR TITLE
Fix for issue #1284

### DIFF
--- a/source/llvm/LLVMModelDataSymbols.cpp
+++ b/source/llvm/LLVMModelDataSymbols.cpp
@@ -1348,10 +1348,28 @@ void LLVMModelDataSymbols::initReactions(const libsbml::Model* model)
         {
             const SimpleSpeciesReference *r = reactants->get(j);
 
+            int speciesIdx = getFloatingSpeciesIndex(r->getSpecies());
+            if (r->isSetId() && r->getId().length() > 0)
+            {
+              if (namedSpeciesReferenceInfo.find(r->getId()) ==
+                namedSpeciesReferenceInfo.end())
+              {
+                SpeciesReferenceInfo info =
+                { static_cast<uint>(speciesIdx), static_cast<uint>(i), Reactant, r->getId() };
+                namedSpeciesReferenceInfo[r->getId()] = info;
+              }
+              else
+              {
+                std::string msg = "Species Reference with id ";
+                msg += r->getId();
+                msg += " appears more than once in the model";
+                throw_llvm_exception(msg);
+              }
+            }
+
             if (isValidFloatingSpeciesReference(r, "reactant"))
             {
                 // at this point, we'd better have a floating species
-                int speciesIdx = getFloatingSpeciesIndex(r->getSpecies());
                 if (speciesIdx < 0) {
                     continue;
                 }
@@ -1369,23 +1387,6 @@ void LLVMModelDataSymbols::initReactions(const libsbml::Model* model)
                     // index of the just added Reactant
                     speciesMap[speciesIdx] = stoichTypes.size() - 1;
 
-                    if(r->isSetId() && r->getId().length() > 0)
-                    {
-                        if (namedSpeciesReferenceInfo.find(r->getId()) ==
-                                namedSpeciesReferenceInfo.end())
-                        {
-                            SpeciesReferenceInfo info =
-                            {static_cast<uint>(speciesIdx), static_cast<uint>(i), Reactant, r->getId()};
-                            namedSpeciesReferenceInfo[r->getId()] = info;
-                        }
-                        else
-                        {
-                            std::string msg = "Species Reference with id ";
-                            msg += r->getId();
-                            msg += " appears more than once in the model";
-                            throw_llvm_exception(msg);
-                        }
-                    }
                 }
                 else
                 {
@@ -1399,23 +1400,6 @@ void LLVMModelDataSymbols::initReactions(const libsbml::Model* model)
                     // set all the other ones to Multi...
                     setNamedSpeciesReferenceInfo(speciesIdx, i, MultiReactantProduct);
 
-                    if(r->isSetId() && r->getId().length() > 0)
-                    {
-                        if (namedSpeciesReferenceInfo.find(r->getId()) ==
-                                namedSpeciesReferenceInfo.end())
-                        {
-                            SpeciesReferenceInfo info =
-                            { static_cast<uint>(speciesIdx), static_cast<uint>(i), MultiReactantProduct, r->getId()};
-                            namedSpeciesReferenceInfo[r->getId()] = info;
-                        }
-                        else
-                        {
-                            std::string msg = "Species Reference with id ";
-                            msg += r->getId();
-                            msg += " appears more than once in the model";
-                            throw_llvm_exception(msg);
-                        }
-                    }
                 }
             }
         }
@@ -1426,9 +1410,26 @@ void LLVMModelDataSymbols::initReactions(const libsbml::Model* model)
             const SimpleSpeciesReference *p = products->get(j);
             // products had better be in the stoich matrix.
 
+            uint speciesIdx = getFloatingSpeciesIndex(p->getSpecies());
+            if (p->isSetId() && p->getId().length() > 0)
+            {
+              if (namedSpeciesReferenceInfo.find(p->getId())
+                == namedSpeciesReferenceInfo.end())
+              {
+                SpeciesReferenceInfo info =
+                { static_cast<uint>(speciesIdx), static_cast<uint>(i), Product, p->getId() };
+                namedSpeciesReferenceInfo[p->getId()] = info;
+              }
+              else
+              {
+                std::string msg = "Species Reference with id ";
+                msg += p->getId();
+                msg += " appears more than once in the model";
+                throw_llvm_exception(msg);
+              }
+            }
             if (isValidFloatingSpeciesReference(p, "product"))
             {
-                uint speciesIdx = getFloatingSpeciesIndex(p->getSpecies());
 
                 UIntUMap::const_iterator si = speciesMap.find(speciesIdx);
 
@@ -1445,23 +1446,6 @@ void LLVMModelDataSymbols::initReactions(const libsbml::Model* model)
                     // index of the just added Reactant
                     speciesMap[speciesIdx] = stoichTypes.size() - 1;
 
-                    if (p->isSetId() && p->getId().length() > 0)
-                    {
-                        if (namedSpeciesReferenceInfo.find(p->getId())
-                                == namedSpeciesReferenceInfo.end())
-                        {
-                            SpeciesReferenceInfo info =
-                            { static_cast<uint>(speciesIdx), static_cast<uint>(i), Product, p->getId()};
-                            namedSpeciesReferenceInfo[p->getId()] = info;
-                        }
-                        else
-                        {
-                            std::string msg = "Species Reference with id ";
-                            msg += p->getId();
-                            msg += " appears more than once in the model";
-                            throw_llvm_exception(msg);
-                        }
-                    }
                 }
                 else
                 {
@@ -1474,24 +1458,6 @@ void LLVMModelDataSymbols::initReactions(const libsbml::Model* model)
 
                     // set all the other ones to Multi...
                     setNamedSpeciesReferenceInfo(speciesIdx, i, MultiReactantProduct);
-
-                    if(p->isSetId() && p->getId().length() > 0)
-                    {
-                        if (namedSpeciesReferenceInfo.find(p->getId()) ==
-                                namedSpeciesReferenceInfo.end())
-                        {
-                            SpeciesReferenceInfo info =
-                            { static_cast<uint>(speciesIdx), static_cast<uint>(i), MultiReactantProduct, p->getId()};
-                            namedSpeciesReferenceInfo[p->getId()] = info;
-                        }
-                        else
-                        {
-                            std::string msg = "Species Reference with id ";
-                            msg += p->getId();
-                            msg += " appears more than once in the model";
-                            throw_llvm_exception(msg);
-                        }
-                    }
                 }
             }
         }

--- a/test/models/SBMLFeatures/named_boundary_species.xml
+++ b/test/models/SBMLFeatures/named_boundary_species.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v3.1.0 with libSBML version 5.20.5. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="S" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="h" value="4" constant="true"/>
+    </listOfParameters>
+    <listOfRules>
+      <assignmentRule variable="m">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <ci> h </ci>
+        </math>
+      </assignmentRule>
+    </listOfRules>
+    <listOfReactions>
+      <reaction id="J2" reversible="true">
+        <listOfProducts>
+          <speciesReference id="m" species="S" constant="false"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <cn type="integer"> 5 </cn>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/sbml_features/CMakeLists.txt
+++ b/test/sbml_features/CMakeLists.txt
@@ -5,6 +5,7 @@ add_test_executable(
         events.cpp
         fast.cpp
         invalid_sbml.cpp
+        named_stoich.cpp
         piecewise_triggers.cpp
         rateOf.cpp
         unsupported_packages.cpp

--- a/test/sbml_features/named_stoich.cpp
+++ b/test/sbml_features/named_stoich.cpp
@@ -1,0 +1,30 @@
+#include "gtest/gtest.h"
+#include "rrRoadRunner.h"
+#include "rrException.h"
+#include "rrUtils.h"
+#include "rrTestSuiteModelSimulation.h"
+#include "sbml/SBMLTypes.h"
+#include "sbml/SBMLReader.h"
+#include "../test_util.h"
+#include <filesystem>
+#include "RoadRunnerTest.h"
+
+using namespace testing;
+using namespace rr;
+using namespace std;
+using std::filesystem::path;
+
+class SBMLFeatures : public RoadRunnerTest {
+public:
+    path SBMLFeaturesDir = rrTestModelsDir_ / "SBMLFeatures";
+    SBMLFeatures() = default;
+};
+
+TEST_F(SBMLFeatures, NAMED_BOUNDARY_SPECIES)
+{
+    //Logger::enableConsoleLogging();
+    //Logger::setLevel(Logger::LOG_DEBUG);
+
+  RoadRunner rri((SBMLFeaturesDir / "named_boundary_species.xml").string());
+  rri.simulate();
+}

--- a/wrappers/Python/roadrunner/roadrunner.i
+++ b/wrappers/Python/roadrunner/roadrunner.i
@@ -1076,6 +1076,12 @@ PyObject *Integrator_NewPythonObj(rr::Integrator* i) {
 //%ignore rr::DictionaryImpl;
 %ignore rr::BasicDictionary(std::initializer_list<item>);
 
+//Ignore elements found by latest SWIG
+%ignore rr::FFSDyDtFcn;
+%ignore rr::FFSRootFcn;
+%ignore rr::cvodeDyDtFcn;
+%ignore rr::cvodeEventAndPiecewiseRootFcn;
+
 
 // Warning 389: operator[] ignored (consider using %extend)
 // Warning 401: Nothing known about base class 'Configurable'. Ignored.


### PR DESCRIPTION
Always store named species references, even if they're for boundary species (and therefore don't affect math).