### PR TITLE
Adjust workflow to install swig from a github action.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -294,6 +294,8 @@ jobs:
 
       - name: Install Swig
         uses: mmomtchev/setup-swig@v5
+        with:
+          branch: jse
 
       - name: Save standardized os/compiler names
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,11 +90,6 @@ jobs:
           echo "python_v4_name=v4" >> $GITHUB_ENV
 
       - name: Checkout RoadRunner
-        if: matrix.platform.os_type == 'manylinux'
-        uses: actions/checkout@v4
-
-      - name: Checkout RoadRunner
-        if: matrix.platform.os_type != 'manylinux'
         uses: actions/checkout@v4
 
       - name: Setup Python for non-Manylinux platforms
@@ -298,60 +293,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install Swig
-        shell: bash
-        run: |
-          cd ${RUNNER_WORKSPACE}
-          # running against the latest version of swig fails, so we build version 4.0.2
-          if [ "${{ matrix.platform.os_type }}" == 'macos' ]; then
-            brew install pcre pcre2
-            mkdir -p ${RUNNER_WORKSPACE}/swig
-            cd swig
-            curl -L https://sourceforge.net/projects/swig/files/swig/swig-4.0.2/swig-4.0.2.tar.gz/download > swig.tar.gz
-            tar -zxf swig.tar.gz
-            rm swig.tar.gz
-            mkdir -p install-swig
-            cd swig-4.0.2/
-            ./configure --prefix=${RUNNER_WORKSPACE}/swig/install-swig
-            make
-            make install
-            echo SWIG_DIR="-DSWIG_EXECUTABLE=${RUNNER_WORKSPACE}/swig/install-swig/bin/swig" >> $GITHUB_ENV
-          elif [ "${{ matrix.platform.os_type }}" == 'windows' ]; then
-            mkdir -p swig
-            cd swig
-            curl -L https://sourceforge.net/projects/swig/files/swigwin/swigwin-4.0.2/swigwin-4.0.2.zip/download > swig.zip
-            unzip -q swig.zip -d install-swig
-            rm swig.zip
-            echo SWIG_DIR="-DSWIG_EXECUTABLE=${RUNNER_WORKSPACE}/swig/install-swig/swigwin-4.0.2/" >> "${GITHUB_PATH}"
-          elif [ "${{ matrix.platform.os_type }}" == 'manylinux' ]; then
-            dnf install -y pcre-devel
-            mkdir -p swig
-            cd swig
-            curl -L https://sourceforge.net/projects/swig/files/swig/swig-4.0.2/swig-4.0.2.tar.gz/download > swig.tar.gz
-            tar -zxf swig.tar.gz
-            rm swig.tar.gz
-            mkdir -p install-swig
-            cd swig-4.0.2/
-            ./configure --disable-dependency-tracking --prefix=${RUNNER_WORKSPACE}/swig/install-swig
-            make
-            make install
-            echo SWIG_DIR="-DSWIG_EXECUTABLE=${RUNNER_WORKSPACE}/swig/install-swig/bin/swig" >> $GITHUB_ENV
-          elif [ "${{ matrix.platform.os_type }}" == 'ubuntu' ]; then
-            # To fix installed swig 4.2:
-            sudo sed -i "681,684d;686d" /usr/share/swig4.0/swig.swg
-            # mkdir -p swig
-            # cd swig
-            # curl -L https://sourceforge.net/projects/swig/files/swig/swig-4.3.0/swig-4.3.0.tar.gz/download > swig.tar.gz
-            # tar -zxf swig.tar.gz
-            # rm swig.tar.gz
-            # mkdir -p install-swig
-            # cd swig-4.3.0/
-            # sed -i "677,680d;682d" Lib/swig.swg
-            # ./configure --disable-dependency-tracking --prefix=${RUNNER_WORKSPACE}/swig/install-swig
-            # make
-            # make install
-            # echo SWIG_DIR="-DSWIG_EXECUTABLE=${RUNNER_WORKSPACE}/swig/install-swig/bin/swig" >> $GITHUB_ENV
-          fi
-          echo PYTHON_DIR="-DPython_ROOT_DIR=${{ env.python_v1_dir }}" >> $GITHUB_ENV
+        uses: mmomtchev/setup-swig@v5
 
       - name: Save standardized os/compiler names
         shell: bash


### PR DESCRIPTION
Shouldn't need to pin to 4.0.1 any more; just use latest.

(Might not work with manylinux; if not, use the manual install we had before for that.)