### PR TITLE
A few 'cleanup' changes.

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -7,6 +7,7 @@ set(
         roadrunner
         roadrunner-static
         roadrunner_c_api
+        roadrunner_c_api-static
 )
 
 # We add some variables before including CPath

--- a/source/rrUtils.h
+++ b/source/rrUtils.h
@@ -127,9 +127,9 @@ RR_DECLSPEC double*         createVector(const std::vector<double>& vec);
 RR_DECLSPEC std::vector<double>  createVector(const double* src, const int& size);
 
 #if defined(_WIN32) || defined(__WIN32__)
-RR_DECLSPEC HINSTANCE       loadDLL(const std::string& dll);
-RR_DECLSPEC bool            unLoadDLL(HINSTANCE dllHandle);
-RR_DECLSPEC FARPROC         getFunctionPtr(const std::string& funcName, HINSTANCE DLLHandle);
+//RR_DECLSPEC HINSTANCE       loadDLL(const std::string& dll);
+//RR_DECLSPEC bool            unLoadDLL(HINSTANCE dllHandle);
+//RR_DECLSPEC FARPROC         getFunctionPtr(const std::string& funcName, HINSTANCE DLLHandle);
 RR_DECLSPEC std::string          getWINAPIError(DWORD errorCode, LPTSTR lpszFunction);
 #endif
 

--- a/test/serialization/state_saving.cpp
+++ b/test/serialization/state_saving.cpp
@@ -451,28 +451,24 @@ TEST_F(StateSavingTests, LOAD_VALID_FILE) {
 
     RoadRunner rri;
 #if defined(_WIN32)
-    rri.loadState((stateSavingModelsDir / "savedState_windows.rr").string());
-    EXPECT_EQ(rri.getNumberOfFloatingSpecies(), 2);
-    rri.loadState((stateSavingModelsDir / "savedState_windows.rr").string());
-    EXPECT_EQ(rri.getNumberOfFloatingSpecies(), 2);
+    path statefile = (stateSavingModelsDir / "savedState_windows.rr");
 #elif (defined(__APPLE__))
 #if defined(__arm64__)
-    rri.loadState((stateSavingModelsDir / "savedState_macos_arm64.rr").string());
-    EXPECT_EQ(rri.getNumberOfFloatingSpecies(), 2);
-    rri.loadState((stateSavingModelsDir / "savedState_macos_arm64.rr").string());
-    EXPECT_EQ(rri.getNumberOfFloatingSpecies(), 2);
+    path statefile = (stateSavingModelsDir / "savedState_macos_arm64.rr");
 #else
-    rri.loadState((stateSavingModelsDir / "savedState_macos_x86.rr").string());
-    EXPECT_EQ(rri.getNumberOfFloatingSpecies(), 2);
-    rri.loadState((stateSavingModelsDir / "savedState_macos_x86.rr").string());
-    EXPECT_EQ(rri.getNumberOfFloatingSpecies(), 2);
+    path statefile = (stateSavingModelsDir / "savedState_macos_x86.rr");
 #endif
 #else
-    rri.loadState((stateSavingModelsDir / "savedState_linux.rr").string());
-    EXPECT_EQ(rri.getNumberOfFloatingSpecies(), 2);
-    rri.loadState((stateSavingModelsDir / "savedState_linux.rr").string());
-    EXPECT_EQ(rri.getNumberOfFloatingSpecies(), 2);
+    path statefile = (stateSavingModelsDir / "savedState_linux.rr");
 #endif
+    rri.loadState(statefile.string());
+    EXPECT_EQ(rri.getNumberOfFloatingSpecies(), 2);
+    rri.simulate(0, 10, 10);
+
+    //Load and simulate multiple times, just to make sure.
+    rri.loadState(statefile.string());
+    EXPECT_EQ(rri.getNumberOfFloatingSpecies(), 2);
+    rri.simulate(0, 10, 10);
 }
 
 TEST_F(StateSavingTests, FromFile) {


### PR DESCRIPTION
* Add roadrunner_c_api-static as a target.
* Remove functions that were never defined.
* Clean up the 'load from saved state' test to do more, and also be cleaner about the differences between OSes.