### PR TITLE
Some models with named stoichiometries couldn't calculate the steady state.

### DIFF
--- a/source/conservation/ConservedMoietyConverter.cpp
+++ b/source/conservation/ConservedMoietyConverter.cpp
@@ -132,6 +132,7 @@ static void updateReactions(Model* newModel,
 static ASTNode *createSpeciesAmountNode(const Model* model, const std::string& name);
 
 static void insertAsModifier(Reaction* reaction, SimpleSpeciesReference *s);
+static void addParameterIfNeeded(SpeciesReference* s, Model* newModel);
 
 void ConservedMoietyConverter::init()
 {
@@ -643,12 +644,13 @@ static void updateReactions(Model* newModel,
         unsigned j = 0;
         while(j < products->size())
         {
-            SimpleSpeciesReference *product = products->get(j);
+            SpeciesReference *product = r->getProduct(j);
 
             if (depSet.find(product->getSpecies()) != depSet.end())
             {
                 products->remove(j);
                 insertAsModifier(r, product);
+                addParameterIfNeeded(product, newModel);
                 delete product;
             }
             else
@@ -660,12 +662,13 @@ static void updateReactions(Model* newModel,
         j = 0;
         while(j < reactants->size())
         {
-            SimpleSpeciesReference *reactant = reactants->get(j);
+            SpeciesReference *reactant = r->getReactant(j);
 
             if (depSet.find(reactant->getSpecies()) != depSet.end())
             {
                 reactants->remove(j);
                 insertAsModifier(r, reactant);
+                addParameterIfNeeded(reactant, newModel);
                 delete reactant;
             }
             else
@@ -679,11 +682,26 @@ static void updateReactions(Model* newModel,
 static void insertAsModifier(Reaction* reaction, SimpleSpeciesReference *s)
 {
     ModifierSpeciesReference *m = reaction->createModifier();
-    m->setId(s->getId());
+    if (s->isSetId()) {
+      m->setId(s->getId() + "_orig");
+    }
     m->setSpecies(s->getSpecies());
     m->setName(s->getName());
 }
 
+static void addParameterIfNeeded(SpeciesReference* s, Model* newModel)
+{
+  if (s->isSetId()) {
+    Parameter* p = newModel->createParameter();
+    p->setId(s->getId());
+    p->setValue(s->getStoichiometry());
+    if (s->isSetStoichiometryMath()) {
+      AssignmentRule* ar = newModel->createAssignmentRule();
+      ar->setVariable(s->getId());
+      ar->setMath(s->getStoichiometryMath()->getMath());
+    }
+  }
+}
 
 static ASTNode *createSpeciesAmountNode(const Model* model, const std::string& name)
 {

--- a/source/llvm/ModelDataSymbolResolver.cpp
+++ b/source/llvm/ModelDataSymbolResolver.cpp
@@ -152,7 +152,7 @@ namespace rrllvm
 
         if (modelDataSymbols.isNamedSpeciesReference(symbol))
         {
-            const LLVMModelDataSymbols::SpeciesReferenceInfo& info =
+              const LLVMModelDataSymbols::SpeciesReferenceInfo& info =
                 modelDataSymbolsPtr->getNamedSpeciesReferenceInfo(symbol);
 
             Value* value = mdbuilder.createStoichiometryLoad(info.row, info.column, symbol);
@@ -188,7 +188,7 @@ namespace rrllvm
         }
 
 
-        std::string msg = "the symbol \'";
+        std::string msg = "The symbol \'";
         msg += symbol;
         msg += "\' is not physically stored in the ModelData structure, "
             "it either does not exist or is defined by an assigment rule (hence it "

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -22,6 +22,12 @@ public:
 };
 
 
+TEST_F(ModelAnalysisTests, issue1306_named_stoich_steadyState) {
+  rr::RoadRunner rr((modelAnalysisModelsDir / "named_stoic_in_kinetic_law.xml").string());
+  rr.steadyState();// , CoreException);
+}
+
+
 TEST_F(ModelAnalysisTests, issue1259) {
   BasicDictionary opt;
   opt.setItem("allow_approx", true);

--- a/test/models/ModelAnalysis/named_stoic_in_kinetic_law.xml
+++ b/test/models/ModelAnalysis/named_stoic_in_kinetic_law.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v3.1.0 with libSBML version 5.20.5. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
+  <model metaid="__main" id="__main">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="A" compartment="default_compartment" initialConcentration="5" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="B" compartment="default_compartment" initialConcentration="7" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="C" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="D" compartment="default_compartment" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="k1" value="0.1" constant="true"/>
+      <parameter id="k2" value="0.04" constant="true"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction id="_J0" reversible="true">
+        <listOfReactants>
+          <speciesReference species="A" stoichiometry="1" constant="true"/>
+          <speciesReference id="n" species="B" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference id="m" species="C" stoichiometry="2" constant="true"/>
+          <speciesReference id="q" species="D" stoichiometry="3" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <minus/>
+              <apply>
+                <times/>
+                <ci> k1 </ci>
+                <ci> A </ci>
+                <apply>
+                  <power/>
+                  <ci> B </ci>
+                  <ci> n </ci>
+                </apply>
+              </apply>
+              <apply>
+                <times/>
+                <ci> k2 </ci>
+                <apply>
+                  <power/>
+                  <ci> C </ci>
+                  <ci> m </ci>
+                </apply>
+                <apply>
+                  <power/>
+                  <ci> D </ci>
+                  <ci> q </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>


### PR DESCRIPTION
This turned out to be because the conserved moiety converter would remove some species references, making the variable they represented disappear.  Added a bit to the converter where if a species reference was removed, we'd add a new parameter with that name and a value of its stoichiometry to the model.