### PR TITLE
As a first pass at fixing named stoichiometries, throw on invalid name strings.

### DIFF
--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -1485,8 +1485,8 @@ double LLVMExecutableModel::getValue(const std::string& id)
         }
         break;
     default:
-        rrLog(Logger::LOG_ERROR) << "A new SelectionRecord should not have this value: "
-        << sel.to_repr();
+        //rrLog(Logger::LOG_ERROR) << "A new SelectionRecord should not have this value: "
+        //<< sel.to_repr();
         throw LLVMException("Invalid selection '" + id + "' for setting value");
         break;
     }
@@ -1631,11 +1631,16 @@ const rr::SelectionRecord& LLVMExecutableModel::getSelection(const std::string& 
             break;
         case SelectionRecord::STOICHIOMETRY:
             sel.index = getStoichiometryIndex(sel.p1, sel.p2);
+            if (sel.index == -1) {
+              throw LLVMException("Invalid id '" + str + "': could not find a species with the ID '" + sel.p1 + "', and/or a reaction with the ID '" + sel.p2 + "'");
+              break;
+            }
+
             break;
 
         default:
-            rrLog(Logger::LOG_ERROR) << "A new SelectionRecord should not have this value: "
-                << sel.to_repr();
+            //rrLog(Logger::LOG_ERROR) << "A new SelectionRecord should not have this value: "
+            //    << sel.to_repr();
             throw LLVMException("Invalid selection '" + str + "' for setting value");
             break;
         }

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -4719,7 +4719,8 @@ namespace rr {
     void RoadRunner::setValue(const std::string &sId, double dValue) {
         check_model();
 
-        SelectionRecord sel(sId);
+        //Run 'createSelection' so it throws if it's an invalid ID right away.
+        SelectionRecord sel = createSelection(sId);
 
         if (sel.selectionType & SelectionRecord::INITIAL && sel.p2 == "") {
             if (sel.selectionType & SelectionRecord::CONCENTRATION) {
@@ -4839,7 +4840,7 @@ namespace rr {
                     break;
                 } else {
                     std::string msg = "No sbml element exists for concentration selection '" + str + "'";
-                    rrLog(Logger::LOG_ERROR) << msg;
+                    //rrLog(Logger::LOG_ERROR) << msg;
                     throw Exception(msg);
                     break;
                 }
@@ -4956,9 +4957,10 @@ namespace rr {
                     break;
                 }
             default:
-                rrLog(Logger::LOG_ERROR) << "A new SelectionRecord should not have this value: "
-                                         << sel.to_repr();
-                break;
+                //rrLog(Logger::LOG_ERROR) << "A new SelectionRecord should not have this value: "
+                //                         << sel.to_repr();
+                throw Exception("Invalid selection '" + str + "' for selecting an element of this model.");
+              break;
         }
 
         return sel;

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -4840,7 +4840,6 @@ namespace rr {
                     break;
                 } else {
                     std::string msg = "No sbml element exists for concentration selection '" + str + "'";
-                    //rrLog(Logger::LOG_ERROR) << msg;
                     throw Exception(msg);
                     break;
                 }

--- a/test/cxx_api_tests/SelectionRecordTests.cpp
+++ b/test/cxx_api_tests/SelectionRecordTests.cpp
@@ -44,6 +44,111 @@ TEST_F(SelectionRecordTests, REACTION_RATE) {
     delete testModel;
 }
 
+TEST_F(SelectionRecordTests, NO_SUCH_ELEMENT) {
+  TestModel* testModel = TestModelFactory("SimpleFlux");
+  RoadRunner rr(testModel->str());
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("foo"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("[foo]"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("[S1"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("init(S1"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("init([S1]"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("init(foo)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("eigen(foo)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("eigenReal(foo)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("eigenImag(foo)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("uec(foo, bar)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("ec(foo, bar)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("ucc(foo, bar)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("cc(foo, bar)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("stoich(foo, bar)"), Exception);
+  delete testModel;
+}
+
+TEST_F(SelectionRecordTests, NO_SUCH_ELEMENT_COMBINATION) {
+// test selection records that require two inputs, only one of which doesn't exist.
+  TestModel* testModel = TestModelFactory("SimpleFlux");
+  RoadRunner rr(testModel->str());
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("uec(foo, S1)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("uec(_J1, foo)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("ec(foo, S1)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("ec(_J1, foo)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("ucc(foo, S1)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("ucc(_J1, foo)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("cc(foo, S1)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("cc(_J1, foo)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("stoich(foo, _J1)"), Exception);
+  EXPECT_THROW(SelectionRecord record = rr.createSelection("stoich(S1, foo)"), Exception);
+  delete testModel;
+}
+
+TEST_F(SelectionRecordTests, NO_SUCH_ELEMENT_SET) {
+  TestModel* testModel = TestModelFactory("SimpleFlux");
+  RoadRunner rr(testModel->str());
+  EXPECT_THROW(rr.setValue("foo", 5), Exception);
+  EXPECT_THROW(rr.setValue("[foo]", 5), Exception);
+  EXPECT_THROW(rr.setValue("init(foo)", 5), Exception);
+  EXPECT_THROW(rr.setValue("eigen(foo)", 5), Exception);
+  EXPECT_THROW(rr.setValue("eigenReal(foo)", 5), Exception);
+  EXPECT_THROW(rr.setValue("eigenImag(foo)", 5), Exception);
+  EXPECT_THROW(rr.setValue("uec(foo, bar)", 5), Exception);
+  EXPECT_THROW(rr.setValue("ec(foo, bar)", 5), Exception);
+  EXPECT_THROW(rr.setValue("ucc(foo, bar)", 5), Exception);
+  EXPECT_THROW(rr.setValue("cc(foo, bar)", 5), Exception);
+  EXPECT_THROW(rr.setValue("stoich(foo, bar)", 5), Exception);
+  delete testModel;
+}
+
+TEST_F(SelectionRecordTests, NO_SUCH_ELEMENT_COMBINATION_SET) {
+  // test selection records that require two inputs, only one of which doesn't exist.
+  TestModel* testModel = TestModelFactory("SimpleFlux");
+  RoadRunner rr(testModel->str());
+  EXPECT_THROW(rr.setValue("uec(foo, S1)", 5), Exception);
+  EXPECT_THROW(rr.setValue("uec(_J1, foo)", 5), Exception);
+  EXPECT_THROW(rr.setValue("ec(foo, S1)", 5), Exception);
+  EXPECT_THROW(rr.setValue("ec(_J1, foo)", 5), Exception);
+  EXPECT_THROW(rr.setValue("ucc(foo, S1)", 5), Exception);
+  EXPECT_THROW(rr.setValue("ucc(_J1, foo)", 5), Exception);
+  EXPECT_THROW(rr.setValue("cc(foo, S1)", 5), Exception);
+  EXPECT_THROW(rr.setValue("cc(_J1, foo)", 5), Exception);
+  EXPECT_THROW(rr.setValue("stoich(foo, _J1)", 5), Exception);
+  EXPECT_THROW(rr.setValue("stoich(S1, foo)", 5), Exception);
+  delete testModel;
+}
+
+TEST_F(SelectionRecordTests, NO_SUCH_ELEMENT_GET) {
+  TestModel* testModel = TestModelFactory("SimpleFlux");
+  RoadRunner rr(testModel->str());
+  EXPECT_THROW(rr.getValue("foo"), Exception);
+  EXPECT_THROW(rr.getValue("[foo]"), Exception);
+  EXPECT_THROW(rr.getValue("init(foo)"), Exception);
+  EXPECT_THROW(rr.getValue("eigen(foo)"), Exception);
+  EXPECT_THROW(rr.getValue("eigenReal(foo)"), Exception);
+  EXPECT_THROW(rr.getValue("eigenImag(foo)"), Exception);
+  EXPECT_THROW(rr.getValue("uec(foo, bar)"), Exception);
+  EXPECT_THROW(rr.getValue("ec(foo, bar)"), Exception);
+  EXPECT_THROW(rr.getValue("ucc(foo, bar)"), Exception);
+  EXPECT_THROW(rr.getValue("cc(foo, bar)"), Exception);
+  EXPECT_THROW(rr.getValue("stoich(foo, bar)"), Exception);
+  delete testModel;
+}
+
+TEST_F(SelectionRecordTests, NO_SUCH_ELEMENT_COMBINATION_GET) {
+  // test selection records that require two inputs, only one of which doesn't exist.
+  TestModel* testModel = TestModelFactory("SimpleFlux");
+  RoadRunner rr(testModel->str());
+  EXPECT_THROW(rr.getValue("uec(foo, S1)"), Exception);
+  EXPECT_THROW(rr.getValue("uec(_J1, foo)"), Exception);
+  EXPECT_THROW(rr.getValue("ec(foo, S1)"), Exception);
+  EXPECT_THROW(rr.getValue("ec(_J1, foo)"), Exception);
+  EXPECT_THROW(rr.getValue("ucc(foo, S1)"), Exception);
+  EXPECT_THROW(rr.getValue("ucc(_J1, foo)"), Exception);
+  EXPECT_THROW(rr.getValue("cc(foo, S1)"), Exception);
+  EXPECT_THROW(rr.getValue("cc(_J1, foo)"), Exception);
+  EXPECT_THROW(rr.getValue("stoich(foo, _J1)"), Exception);
+  EXPECT_THROW(rr.getValue("stoich(S1, foo)"), Exception);
+  delete testModel;
+}
+
 TEST_F(SelectionRecordTests, BOUNDARY_CONCENTRATION) {
     TestModel* testModel = TestModelFactory("SimpleFlux");
     RoadRunner rr(testModel->str());

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -25,6 +25,8 @@ public:
 TEST_F(ModelAnalysisTests, issue1306_named_stoich_steadyState) {
   rr::RoadRunner rr((modelAnalysisModelsDir / "named_stoic_in_kinetic_law.xml").string());
   rr.steadyState();// , CoreException);
+  rr.setValue("stoich(A, _J0)", 3);
+  rr.setValue("n", 3);
 }
 
 


### PR DESCRIPTION
Also, don't log errors and then throw that same error; that's redundant.