### PR TITLE
Update swig version.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -300,11 +300,11 @@ jobs:
             brew install pcre pcre2
             mkdir -p ${RUNNER_WORKSPACE}/swig
             cd swig
-            curl -L https://sourceforge.net/projects/swig/files/swig/swig-4.4.0/swig-4.4.0.tar.gz/download > swig.tar.gz
+            curl -L https://sourceforge.net/projects/swig/files/swig/swig-4.4.1/swig-4.4.1.tar.gz/download > swig.tar.gz
             tar -zxf swig.tar.gz
             rm swig.tar.gz
             mkdir -p install-swig
-            cd swig-4.4.0/
+            cd swig-4.4.1/
             ./configure --prefix=${RUNNER_WORKSPACE}/swig/install-swig
             make
             make install
@@ -312,19 +312,19 @@ jobs:
           elif [ "${{ matrix.platform.os_type }}" == 'windows' ]; then
             mkdir -p swig
             cd swig
-            curl -L https://sourceforge.net/projects/swig/files/swigwin/swigwin-4.4.0/swigwin-4.4.0.zip/download > swig.zip
+            curl -L https://sourceforge.net/projects/swig/files/swigwin/swigwin-4.4.1/swigwin-4.4.1.zip/download > swig.zip
             unzip -q swig.zip -d install-swig
             rm swig.zip
-            echo SWIG_DIR="-DSWIG_EXECUTABLE=${RUNNER_WORKSPACE}/swig/install-swig/swigwin-4.4.0/" >> "${GITHUB_PATH}"
+            echo SWIG_DIR="-DSWIG_EXECUTABLE=${RUNNER_WORKSPACE}/swig/install-swig/swigwin-4.4.1/" >> "${GITHUB_PATH}"
           elif [ "${{ matrix.platform.os_type }}" == 'manylinux' ]; then
             dnf install -y pcre-devel pcre2-devel
             mkdir -p swig
             cd swig
-            curl -L https://sourceforge.net/projects/swig/files/swig/swig-4.4.0/swig-4.4.0.tar.gz/download > swig.tar.gz
+            curl -L https://sourceforge.net/projects/swig/files/swig/swig-4.4.1/swig-4.4.1.tar.gz/download > swig.tar.gz
             tar -zxf swig.tar.gz
             rm swig.tar.gz
             mkdir -p install-swig
-            cd swig-4.4.0/
+            cd swig-4.4.1/
             ./configure --disable-dependency-tracking --prefix=${RUNNER_WORKSPACE}/swig/install-swig
             make
             make install
@@ -334,11 +334,11 @@ jobs:
             sudo sed -i "681,684d;686d" /usr/share/swig4.0/swig.swg
             # mkdir -p swig
             # cd swig
-            # curl -L https://sourceforge.net/projects/swig/files/swig/swig-4.3.0/swig-4.3.0.tar.gz/download > swig.tar.gz
+            # curl -L https://sourceforge.net/projects/swig/files/swig/swig-4.4.1/swig-4.4.1.tar.gz/download > swig.tar.gz
             # tar -zxf swig.tar.gz
             # rm swig.tar.gz
             # mkdir -p install-swig
-            # cd swig-4.3.0/
+            # cd swig-4.4.1/
             # sed -i "677,680d;682d" Lib/swig.swg
             # ./configure --disable-dependency-tracking --prefix=${RUNNER_WORKSPACE}/swig/install-swig
             # make


### PR DESCRIPTION
Hopefully fix for https://github.com/sbmlteam/python-libsbml/issues/40 , since at least one of the linked issues claims that the underlying swig bug is 'fixed'.  Hopefully this means 'with 4.4.1'.