### PR TITLE
Fix Gillespie SSA driving species counts below zero (#1320)

### DIFF
--- a/docs/source/PythonAPIReference/cls_Integrator.rst
+++ b/docs/source/PythonAPIReference/cls_Integrator.rst
@@ -165,7 +165,11 @@ Gillespie
 
 .. attribute:: Integrator.nonnegative
 
-    Prevents species amounts from going negative during a simulation. Default value is false.
+    Prevents species amounts from going negative during a simulation. When enabled, a reaction
+    that lacks sufficient reactant molecules is given zero propensity and cannot fire, which is
+    the standard Gillespie direct-method behavior. Default value is true. Set to false to evaluate
+    rate laws literally, which allows e.g. zeroth-order or sign-indefinite rate laws to drive a
+    species' molecule count below zero.
 
 
 .. attribute:: Integrator.seed

--- a/source/GillespieIntegrator.cpp
+++ b/source/GillespieIntegrator.cpp
@@ -180,7 +180,7 @@ namespace rr
         //addSetting("initial_time_step",     Setting(0.0),   "Initial Time Step", "Specifies the initial time step size. (double)", "(double) Specifies the initial time step size.");
         addSetting("minimum_time_step",     Setting(0.0),   "Minimum Time Step", "Specifies the minimum absolute value of step size allowed. (double)", "(double) The minimum absolute value of step size allowed.");
         addSetting("maximum_time_step",     Setting(0.0),   "Maximum Time Step", "Specifies the maximum absolute value of step size allowed. (double)", "(double) The maximum absolute value of step size allowed.");
-        addSetting("nonnegative",           Setting(false), "Non-negative species only", "Prevents species amounts from going negative during a simulation. (bool)", "(bool) Enforce non-negative species constraint.");
+        addSetting("nonnegative",           Setting(true), "Non-negative species only", "Prevents species amounts from going negative during a simulation. (bool)", "(bool) When enabled (the default), a reaction that lacks sufficient reactant molecules is given zero propensity and cannot fire, so species amounts never go negative -- the standard Gillespie direct-method behavior.  Disable to evaluate rate laws literally, which allows e.g. zeroth-order or sign-indefinite rate laws to drive a species' molecule count below zero.");
         addSetting("max_output_rows",       Setting(Config::getInt(Config::MAX_OUTPUT_ROWS)), "Maximum Output Rows", "For variable step size simulations, the maximum number of output rows produced (int).", "(int) This will set the maximum number of output rows for variable step size integration.  This may truncate some simulations that may not reach the desired end time, but prevents massive output for simulations where the variable step size ends up decreasing too much.  This setting is ignored when the variable_step_size is false, and is also ignored when the output is being written directly to a file.");
         addSetting("maximum_num_steps", Setting(0), "Maximum Number of Steps",
             "Specifies the maximum number of steps to be taken by the Gillespie solver before reaching the next reporting time. (int)",
@@ -250,9 +250,27 @@ namespace rr
             // get the 'propensity' -- reaction rates
             mModel->getReactionRates(nReactions, nullptr, reactionRates);
 
+            const bool nonnegative = getValue("nonnegative").get<bool>();
+
             // sum the propensity
             for (int k = 0; k < nReactions; k++)
             {
+                // In the direct method a reaction that lacks enough reactant
+                // molecules to fire has zero propensity.  Reactant-dependent
+                // rate laws (e.g. mass action) already evaluate to zero at zero
+                // reactant count, but zeroth-order (constant flux), saturating,
+                // and sign-indefinite rate laws do not -- so without this guard
+                // such a reaction keeps firing and drives a species' molecule
+                // count below zero.  Giving it an effective propensity of zero
+                // removes it from both tau sampling and reaction selection,
+                // which is the standard way to keep populations non-negative.
+                if (nonnegative)
+                {
+                    const double sign = (reactionRates[k] > 0) - (reactionRates[k] < 0);
+                    if (reactionWouldGoNegative(k, sign))
+                        reactionRates[k] = 0.0;
+                }
+
                 rrLog(Logger::LOG_DEBUG) << "reac rate: " << k << ": "
                     << reactionRates[k];
 
@@ -303,34 +321,23 @@ namespace rr
             double sign = (reactionRates[reaction] > 0)
                 - (reactionRates[reaction] < 0);
 
-            bool skip = false;
+            // When the non-negativity guard is on, the selected reaction cannot
+            // have been one that would take a species negative (its effective
+            // propensity was zeroed above), so the warning below only fires for
+            // the legacy "nonnegative = false" path that evaluates rate laws
+            // literally.
+            for (int i = floatingSpeciesStart; i < stateVectorSize; ++i)
+            {
+                stateVector[i] = stateVector[i]
+                    + getStoich(i - floatingSpeciesStart, reaction)
+                    * stoichScale * sign;
 
-            if ((bool)getValue("nonnegative")) {
-                // skip reactions which cause species amts to become negative
-                for (int i = floatingSpeciesStart; i < stateVectorSize; ++i) {
-                    if (stateVector[i]
-                        + getStoich(i - floatingSpeciesStart, reaction)
-                        * stoichScale * sign < 0.0) {
-                        skip = true;
-                        break;
-                    }
-                }
-            }
-
-            if (!skip) {
-                for (int i = floatingSpeciesStart; i < stateVectorSize; ++i)
-                {
-                    stateVector[i] = stateVector[i]
-                        + getStoich(i - floatingSpeciesStart, reaction)
-                        * stoichScale * sign;
-
-                    if (stateVector[i] < 0.0) {
-                        rrLog(Logger::LOG_WARNING) << "Error, negative value of "
-                            << stateVector[i]
-                            << " encountred for floating species "
-                            << mModel->getFloatingSpeciesId(i - floatingSpeciesStart);
-                        t = std::numeric_limits<double>::infinity();
-                    }
+                if (stateVector[i] < 0.0) {
+                    rrLog(Logger::LOG_WARNING) << "Error, negative value of "
+                        << stateVector[i]
+                        << " encountred for floating species "
+                        << mModel->getFloatingSpeciesId(i - floatingSpeciesStart);
+                    t = std::numeric_limits<double>::infinity();
                 }
             }
 

--- a/source/GillespieIntegrator.h
+++ b/source/GillespieIntegrator.h
@@ -148,6 +148,31 @@ namespace rr
         }
 
         /**
+        * @brief True if firing @p reaction once, in the direction given by
+        * @p sign (+1 forward, -1 reverse), would drive any floating species'
+        * amount below zero.
+        * @details Such a reaction lacks the reactant molecules needed to fire
+        * and therefore has zero propensity in the Gillespie direct method.
+        * Reactant-dependent rate laws already vanish at zero reactant count, so
+        * this guard matters for zeroth-order, saturating, and sign-indefinite
+        * rate laws whose value stays non-zero there.  The check mirrors exactly
+        * how the reaction is applied to the state vector in @ref integrate.
+        */
+        inline bool reactionWouldGoNegative(uint reaction, double sign)
+        {
+            for (int i = floatingSpeciesStart; i < stateVectorSize; ++i)
+            {
+                if (stateVector[i]
+                    + getStoich(i - floatingSpeciesStart, reaction)
+                    * stoichScale * sign < 0.0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /**
         * @author JKM
         * @brief Initialize model-specific variables
         * @details Called whenever a model is loaded or a Gillespie

--- a/test/cxx_api_tests/GillespieTests.cpp
+++ b/test/cxx_api_tests/GillespieTests.cpp
@@ -10,6 +10,9 @@
 #include "GillespieIntegrator.h"
 #include "rrConfig.h"
 #include "RoadRunnerTest.h"
+
+#include <algorithm>
+#include <limits>
 using namespace rr;
 
 /**
@@ -96,6 +99,67 @@ TEST_F(GillespieTests, MaxStepSize) {
     ASSERT_EQ(results->RSize(), 2);
     EXPECT_EQ(results->Element(0, 0), 0);
     EXPECT_NEAR(results->Element(1, 0), 55, 0.001);
+}
+
+/**
+ * Regression test for https://github.com/sys-bio/roadrunner/issues/1320
+ *
+ * A single irreversible reaction consumes X at a constant (zeroth-order)
+ * propensity that does not depend on X.  Once X reaches 0 a correct
+ * direct-method SSA can no longer fire the reaction, so X must floor at 0.
+ * Previously the reaction kept firing because reactant availability was never
+ * checked, driving the molecule count below zero.
+ */
+static const std::string ZerothOrderSinkSBML = R"(<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4"><model id="m">
+ <listOfCompartments><compartment id="c" size="1"/></listOfCompartments>
+ <listOfSpecies><species id="X" compartment="c" initialAmount="20" hasOnlySubstanceUnits="true"/></listOfSpecies>
+ <listOfParameters><parameter id="k" value="10"/></listOfParameters>
+ <listOfReactions><reaction id="R" reversible="false">
+   <listOfReactants><speciesReference species="X"/></listOfReactants>
+   <kineticLaw><math xmlns="http://www.w3.org/1998/Math/MathML"><ci>k</ci></math></kineticLaw>
+ </reaction></listOfReactions></model></sbml>)";
+
+TEST_F(GillespieTests, ZerothOrderReactantStaysNonNegative) {
+    RoadRunner rr(ZerothOrderSinkSBML);
+    rr.setIntegrator("gillespie");
+    rr.getIntegrator()->setValue("variable_step_size", false);
+    rr.setSelections({"time", "X"});
+
+    // nonnegative is on by default: X must never drop below zero, and because
+    // the 20 initial molecules are always fully consumed within t = 10, the
+    // floor of exactly zero is reached in every replicate.
+    double globalMin = std::numeric_limits<double>::infinity();
+    for (int seed = 1; seed <= 20; ++seed) {
+        rr.reset();
+        rr.getIntegrator()->setValue("seed", seed);
+        const ls::DoubleMatrix* results = rr.simulate(0, 10, 11);
+        for (unsigned int row = 0; row < results->RSize(); ++row) {
+            double x = results->Element(row, 1);
+            EXPECT_GE(x, 0.0) << "X went negative (" << x << ") at seed " << seed;
+            globalMin = std::min(globalMin, x);
+        }
+    }
+    EXPECT_EQ(globalMin, 0.0);
+}
+
+TEST_F(GillespieTests, NonnegativeDisabledReproducesNegativeAmounts) {
+    // The pre-fix behavior remains available as an explicit opt-out: with the
+    // guard disabled the rate law is evaluated literally, so the zeroth-order
+    // sink drives X below zero.
+    RoadRunner rr(ZerothOrderSinkSBML);
+    rr.setIntegrator("gillespie");
+    rr.getIntegrator()->setValue("variable_step_size", false);
+    rr.getIntegrator()->setValue("nonnegative", false);
+    rr.setSelections({"time", "X"});
+    rr.reset();
+    rr.getIntegrator()->setValue("seed", 1);
+
+    const ls::DoubleMatrix* results = rr.simulate(0, 10, 11);
+    double minX = std::numeric_limits<double>::infinity();
+    for (unsigned int row = 0; row < results->RSize(); ++row)
+        minX = std::min(minX, results->Element(row, 1));
+    EXPECT_LT(minX, 0.0);
 }
 
 TEST_F(GillespieTests, MaxNumSteps) {


### PR DESCRIPTION
Fixes #1320.

## Summary

The Gillespie direct-method SSA used each reaction's rate-law value directly as its propensity. When a rate law does not vanish as a reactant depletes — a zeroth-order / constant-flux consumption, a saturating (Michaelis–Menten) law near the floor, or a sign-indefinite law — the reaction kept firing after the reactant reached zero, driving the molecule count negative. The minimal reproducer in #1320 (a single irreversible reaction `X →` with constant propensity `k`) ends every replicate with `X < 0`.

In the direct method, a reaction that lacks sufficient reactant molecules has **zero propensity** and cannot fire. This PR enforces that invariant: any reaction whose firing would take a floating species below zero is given an effective propensity of zero, removing it from both the τ sampling and the reaction-selection step. Once no reaction can fire, the integrator advances straight to the reporting time.

## Behavior change

This is gated by the existing `nonnegative` integrator setting, whose default changes from `false` to `true`. The legacy behavior — evaluate the rate law literally, allowing negative counts — remains available with `nonnegative = false`.

The guard is a **no-op for mass-action and any other reactant-dependent rate law**: their propensity already vanishes at zero reactant count. I verified this empirically — turning the guard on produces byte-for-byte identical trajectories (same seed) on the SBML stochastic test suite and on the existing `OddStoichiometries` test models. So only models that were producing physically impossible negative populations change.

## Implementation notes

- The previous opt-in path selected the offending reaction and then skipped it while still advancing time by τ (phantom steps). Folding the availability check into the propensity removes those wasted steps and avoids a spurious `maximum_num_steps` overrun when the system is stuck at a boundary.
- The non-negativity guard also covers the sign-indefinite case from the issue insofar as it would violate non-negativity (a reverse firing that would deplete a species is blocked). Fully honoring `reversible="false"` — refusing a reverse firing even when its products are available — would require exposing reaction reversibility to the integrator, which currently only sees `ExecutableModel`; that is left out of scope here.

## Tests

Added two C++ tests in `GillespieTests.cpp`:

- `ZerothOrderReactantStaysNonNegative` — the #1320 reproducer; asserts `X ≥ 0` across 20 seeds and that it floors at exactly 0.
- `NonnegativeDisabledReproducesNegativeAmounts` — documents the `nonnegative = false` opt-out (still goes negative).

Updated the `nonnegative` attribute docs to reflect the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
