### PR TITLE
Don't stop the whole Gillespie run when a species amount goes negative.

### DIFF
--- a/source/GillespieIntegrator.cpp
+++ b/source/GillespieIntegrator.cpp
@@ -324,12 +324,21 @@ namespace rr
                         + getStoich(i - floatingSpeciesStart, reaction)
                         * stoichScale * sign;
 
+                    // A floating species amount may legitimately go negative (it
+                    // can stand for a charge or a membrane voltage rather than a
+                    // molecule count), so a negative value is neither an error nor
+                    // a reason to stop the trajectory.  Callers that require
+                    // non-negative populations enable the "nonnegative" setting,
+                    // which skips any reaction that would drive a species below zero
+                    // (handled above via 'skip').  This block previously set
+                    // t = infinity here, which silently froze the entire run; a
+                    // benign rounding-error-sized dip below zero from a non-integer
+                    // initial amount was enough to trigger it and corrupt the
+                    // trajectory (#1317).
                     if (stateVector[i] < 0.0) {
-                        rrLog(Logger::LOG_WARNING) << "Error, negative value of "
-                            << stateVector[i]
-                            << " encountred for floating species "
+                        rrLog(Logger::LOG_DEBUG) << "Negative amount ("
+                            << stateVector[i] << ") for floating species "
                             << mModel->getFloatingSpeciesId(i - floatingSpeciesStart);
-                        t = std::numeric_limits<double>::infinity();
                     }
                 }
             }

--- a/test/cxx_api_tests/GillespieTests.cpp
+++ b/test/cxx_api_tests/GillespieTests.cpp
@@ -98,6 +98,84 @@ TEST_F(GillespieTests, MaxStepSize) {
     EXPECT_NEAR(results->Element(1, 0), 55, 0.001);
 }
 
+/**
+ * Regression test for https://github.com/sys-bio/roadrunner/issues/1317
+ *
+ * A floating species M starts at a non-integer amount and only degrades.  The
+ * value used here, 24.999999999999996, is what an initialAssignment that should
+ * give 25 evaluates to in floating point; that is how the gene-expression model
+ * in #1317 set its initial mRNA amounts.  Stepping down by whole molecules, M
+ * crosses below zero by a rounding-error-sized amount (about -1e-15).  The
+ * integrator used to treat any negative amount as fatal and set the simulation
+ * time to infinity, which silently froze the entire trajectory, including an
+ * independent two-state toggle that shares the model but is dynamically
+ * decoupled from M.  Different seeds froze the toggle at different points, so its
+ * stationary on-fraction came out badly biased instead of kon/(kon+koff) = 0.25.
+ * With the halt removed the toggle equilibrates correctly regardless of M's
+ * harmless dip below zero.
+ */
+static const std::string NonIntegerDegraderSBML = R"(<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4"><model id="m">
+ <listOfCompartments><compartment id="c" size="1"/></listOfCompartments>
+ <listOfSpecies>
+  <species id="M"    compartment="c" initialAmount="24.999999999999996" hasOnlySubstanceUnits="true"/>
+  <species id="Soff" compartment="c" initialAmount="1" hasOnlySubstanceUnits="true"/>
+  <species id="Son"  compartment="c" initialAmount="0" hasOnlySubstanceUnits="true"/>
+ </listOfSpecies>
+ <listOfParameters>
+  <parameter id="kdeg" value="100"/>
+  <parameter id="kon"  value="0.25"/>
+  <parameter id="koff" value="0.75"/>
+ </listOfParameters>
+ <listOfReactions>
+  <reaction id="Rdeg" reversible="false">
+   <listOfReactants><speciesReference species="M"/></listOfReactants>
+   <kineticLaw><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><times/><ci>kdeg</ci><ci>M</ci></apply></math></kineticLaw>
+  </reaction>
+  <reaction id="Ron" reversible="false">
+   <listOfReactants><speciesReference species="Soff"/></listOfReactants>
+   <listOfProducts><speciesReference species="Son"/></listOfProducts>
+   <kineticLaw><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><times/><ci>kon</ci><ci>Soff</ci></apply></math></kineticLaw>
+  </reaction>
+  <reaction id="Roff" reversible="false">
+   <listOfReactants><speciesReference species="Son"/></listOfReactants>
+   <listOfProducts><speciesReference species="Soff"/></listOfProducts>
+   <kineticLaw><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><times/><ci>koff</ci><ci>Son</ci></apply></math></kineticLaw>
+  </reaction>
+ </listOfReactions>
+</model></sbml>)";
+
+TEST_F(GillespieTests, NegativeAmountDoesNotFreezeRun) {
+    RoadRunner rr(NonIntegerDegraderSBML);
+    rr.setIntegrator("gillespie");
+    rr.getIntegrator()->setValue("variable_step_size", false);
+    rr.setSelections(std::vector<std::string>{"time", "Son"});
+
+    // The toggle is decoupled from M, so its time-averaged on-fraction must
+    // approach kon/(kon+koff) = 0.25.  M degrades far faster than the toggle
+    // switches, so before the fix M's tiny dip below zero froze every run almost
+    // immediately, pinning Son near its initial value of 0.  Average over
+    // independent trajectories to keep the assertion away from per-seed
+    // stochastic noise.
+    double sum = 0.0;
+    long rows = 0;
+    const int nrep = 20;
+    for (int seed = 1; seed <= nrep; ++seed) {
+        rr.reset();
+        rr.getIntegrator()->setValue("seed", seed);
+        const ls::DoubleMatrix* results = rr.simulate(0, 4000, 2001);
+        for (unsigned int row = 0; row < results->RSize(); ++row) {
+            sum += results->Element(row, 1);
+            ++rows;
+        }
+    }
+    double onFraction = sum / static_cast<double>(rows);
+    EXPECT_NEAR(onFraction, 0.25, 0.05)
+        << "toggle on-fraction " << onFraction
+        << " is far from the analytic 0.25; the run likely froze when M dipped "
+           "below zero (issue #1317).";
+}
+
 TEST_F(GillespieTests, MaxNumSteps) {
     RoadRunner rr(openLinearFlux.str());
     rr.setIntegrator("gillespie");


### PR DESCRIPTION
Fixes #1317. The Gillespie loop set the simulation time to infinity whenever a floating species went below zero, which silently froze the entire trajectory. A species amount can legitimately be negative (it might stand for a charge or a voltage rather than a molecule count), and even for an ordinary population a rounding-error-sized dip below zero is enough to trip it. For example, an `initialAssignment` that should give 25 can evaluate to 24.999999999999996 in floating point, and 25 single-molecule degradation steps then land the amount at about -1e-15. Removed the halt so the run continues. The opt-in `nonnegative` setting still skips any reaction that would take a species below zero, for models that want that floor.

## Why this matters

The freeze is silent and seed-dependent, so it shows up as a wrong stationary distribution rather than an error. In the gene-expression model in #1317, three two-state gene toggles that are identical by construction (each has analytic stationary on-fraction `kOn/(kOn+kOff) = 0.25`) are dynamically decoupled from the mRNA species. When an mRNA amount crossed zero the run froze, pinning every toggle at whatever state it happened to be in, and different seeds froze at different points. That is why the three identical toggles came out at three different biased on-fractions instead of one common value.

## Before / after

Mean time-averaged on-fraction over the three toggles (fixed step, the reproducer from #1317):

| toggle | before | after | analytic |
|--------|--------|-------|----------|
| S8  | 0.173 | 0.252 | 0.25 |
| S9  | 0.311 | 0.251 | 0.25 |
| S10 | 0.323 | 0.253 | 0.25 |

## What changed

`GillespieIntegrator::integrate` no longer sets `t = infinity` on a negative amount; it continues, with a debug-level log. Everything else in the loop is untouched.

## Tests

- New regression test `NegativeAmountDoesNotFreezeRun`: a species that starts at a non-integer amount and only degrades crosses zero by one rounding step; an independent toggle in the same model must still reach its analytic on-fraction.
- Models that do not go negative are unchanged: on a mass-action model the fixed-step output is byte-for-byte identical to develop across many seeds, and the stochastic test suite is unaffected.

This is independent of #1318 (the other Gillespie fix) and can be merged in either order.
