### PR TITLE
Fix initialConcentration ignored when compartment set by time-dependent assignment rule (#1319)

### DIFF
--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -782,7 +782,21 @@ void LLVMExecutableModel::reset(int opt)
     if (opt & SelectionRecord::SBML_INITIALIZE)
     {
         rrLog(Logger::LOG_INFORMATION) << "resetting init conditions";
+
+        // Initial conditions are defined at the initial time (t = 0), not at
+        // the pre-simulation sentinel time (-inf) that the model carries before
+        // a simulation starts. evalInitialConditions copies the freshly
+        // computed species amounts into the init-value slots, and for a species
+        // whose compartment size is given by a time-dependent assignment rule
+        // that round trip evaluates the rule against modelData->time. With time
+        // left at -inf the volume comes out as +/-inf or NaN, which corrupts the
+        // initialConcentration -> amount conversion and leaves the species
+        // initialized to 0 (or inf/NaN). Pin time to 0 for the duration of the
+        // call so the volume is evaluated at the initial point. See issue #1319.
+        const double savedTime = getTime();
+        setTime(0.0);
         evalInitialConditions();
+        setTime(savedTime);
     }
 
     // eval the initial conditions and rates

--- a/test/sbml_features/CMakeLists.txt
+++ b/test/sbml_features/CMakeLists.txt
@@ -4,6 +4,7 @@ add_test_executable(
         boolean_delay.cpp
         events.cpp
         fast.cpp
+        init_conc_compartment_assignment.cpp
         invalid_sbml.cpp
         named_stoich.cpp
         piecewise_triggers.cpp

--- a/test/sbml_features/init_conc_compartment_assignment.cpp
+++ b/test/sbml_features/init_conc_compartment_assignment.cpp
@@ -1,0 +1,104 @@
+// Regression tests for issue #1319:
+// A species' initialConcentration was ignored (the species came out 0, or
+// inf/NaN depending on the rule) when its compartment size was governed by a
+// time-dependent assignment rule. The species amount was being converted from
+// concentration using a compartment volume evaluated against the pre-simulation
+// sentinel time (-inf) rather than the initial time (t = 0).
+#include "gtest/gtest.h"
+#include "rrRoadRunner.h"
+#include "rrExecutableModel.h"
+#include <cmath>
+#include <string>
+#include "RoadRunnerTest.h"
+
+using namespace testing;
+using namespace rr;
+using std::string;
+
+class InitConcCompartmentAssignment : public RoadRunnerTest {
+public:
+    InitConcCompartmentAssignment() = default;
+
+    // Build the minimal model from the issue, with the compartment V driven by
+    // the supplied assignment-rule expression. X has initialConcentration 0.05.
+    static string model(const string &compartmentRule) {
+        return
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            "<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n"
+            "  <model id=\"init_bug\">\n"
+            "    <listOfCompartments>\n"
+            "      <compartment id=\"V\" spatialDimensions=\"3\" size=\"1\" constant=\"false\"/>\n"
+            "    </listOfCompartments>\n"
+            "    <listOfSpecies>\n"
+            "      <species id=\"X\" compartment=\"V\" initialConcentration=\"0.05\"\n"
+            "               hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+            "    </listOfSpecies>\n"
+            "    <listOfRules>\n"
+            "      <assignmentRule variable=\"V\">\n"
+            "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+            + compartmentRule +
+            "        </math>\n"
+            "      </assignmentRule>\n"
+            "    </listOfRules>\n"
+            "  </model>\n"
+            "</sbml>\n";
+    }
+};
+
+// V := 1 + time. At t = 0, V = 1, so X should start at its stated
+// initialConcentration of 0.05 (amount 0.05). Before the fix this read 0.
+TEST_F(InitConcCompartmentAssignment, OnePlusTime) {
+    RoadRunner rr(model(
+        "          <apply><plus/>\n"
+        "            <cn type=\"integer\">1</cn>\n"
+        "            <csymbol encoding=\"text\" definitionURL=\"http://www.sbml.org/sbml/symbols/time\">time</csymbol>\n"
+        "          </apply>\n"));
+    EXPECT_DOUBLE_EQ(rr.getValue("V"), 1.0);
+    EXPECT_DOUBLE_EQ(rr.getValue("[X]"), 0.05);
+    EXPECT_DOUBLE_EQ(rr.getValue("X"), 0.05);   // amount = conc * V(0)
+}
+
+// V := 2 / (1 + time). At t = 0, V = 2. [X] must still be 0.05
+// (amount 0.10). Before the fix this read -inf.
+TEST_F(InitConcCompartmentAssignment, TwoOverOnePlusTime) {
+    RoadRunner rr(model(
+        "          <apply><divide/>\n"
+        "            <cn type=\"integer\">2</cn>\n"
+        "            <apply><plus/>\n"
+        "              <cn type=\"integer\">1</cn>\n"
+        "              <csymbol encoding=\"text\" definitionURL=\"http://www.sbml.org/sbml/symbols/time\">time</csymbol>\n"
+        "            </apply>\n"
+        "          </apply>\n"));
+    EXPECT_DOUBLE_EQ(rr.getValue("V"), 2.0);
+    EXPECT_DOUBLE_EQ(rr.getValue("[X]"), 0.05);
+    EXPECT_DOUBLE_EQ(rr.getValue("X"), 0.10);
+}
+
+// V := 2 + 0*time. At t = 0, V = 2. [X] must still be 0.05.
+// Before the fix this read NaN (0 * (-inf) = NaN).
+TEST_F(InitConcCompartmentAssignment, TwoPlusZeroTime) {
+    RoadRunner rr(model(
+        "          <apply><plus/>\n"
+        "            <cn type=\"integer\">2</cn>\n"
+        "            <apply><times/>\n"
+        "              <cn type=\"integer\">0</cn>\n"
+        "              <csymbol encoding=\"text\" definitionURL=\"http://www.sbml.org/sbml/symbols/time\">time</csymbol>\n"
+        "            </apply>\n"
+        "          </apply>\n"));
+    EXPECT_DOUBLE_EQ(rr.getValue("V"), 2.0);
+    EXPECT_DOUBLE_EQ(rr.getValue("[X]"), 0.05);
+    EXPECT_DOUBLE_EQ(rr.getValue("X"), 0.10);
+}
+
+// The initial concentration must survive an explicit reset as well, since reset
+// re-runs the initial-condition evaluation.
+TEST_F(InitConcCompartmentAssignment, SurvivesReset) {
+    RoadRunner rr(model(
+        "          <apply><plus/>\n"
+        "            <cn type=\"integer\">1</cn>\n"
+        "            <csymbol encoding=\"text\" definitionURL=\"http://www.sbml.org/sbml/symbols/time\">time</csymbol>\n"
+        "          </apply>\n"));
+    rr.getModel()->setTime(10.0);
+    rr.reset();
+    EXPECT_DOUBLE_EQ(rr.getValue("[X]"), 0.05);
+}


### PR DESCRIPTION
reset() ran evalInitialConditions() while the model time was still the pre-simulation sentinel (-inf). For a species whose compartment size is given by a time-dependent assignment rule, the init-value copy converts the species amount to concentration and back by evaluating that rule against the model time. With time at -inf the volume evaluated to +/-inf or NaN, which corrupted the initialConcentration->amount conversion and left the species initialized to 0 (or inf/NaN).

Pin the time to 0 for the duration of evalInitialConditions so the compartment volume is evaluated at the initial point, then restore it.