### PR TITLE
Gillespie gives the wrong mean when a reaction rate depends explicitly on time.

### DIFF
--- a/source/GillespieIntegrator.cpp
+++ b/source/GillespieIntegrator.cpp
@@ -16,6 +16,8 @@
 #include <exception>
 #include <limits>
 #include <chrono>
+#include <cmath>
+#include <algorithm>
 
 
 
@@ -66,6 +68,9 @@ namespace rr
 
         assert(floatingSpeciesStart >= 0);
 
+        // Determined lazily on the first integrate() call for this model.
+        timeDependentRates = -1;
+
         setEngineSeed(getValue("seed"));
     }
 
@@ -76,7 +81,8 @@ namespace rr
         reactionRates(nullptr),
         reactionRatesBuffer(nullptr),
         stateVector(nullptr),
-        stateVectorRate(nullptr)
+        stateVectorRate(nullptr),
+        timeDependentRates(-1)
     {
         GillespieIntegrator::resetSettings();
 
@@ -187,6 +193,51 @@ namespace rr
             "(int) Maximum number of steps to be taken by the Gillespie solver before reaching the next reporting time.");
     }
 
+    double GillespieIntegrator::totalPropensity(double tEval)
+    {
+        mModel->setTime(tEval);
+        mModel->getReactionRates(nReactions, nullptr, reactionRates);
+        double s = 0.0;
+        for (int k = 0; k < nReactions; ++k)
+            s += std::abs(reactionRates[k]);
+        return s;
+    }
+
+    bool GillespieIntegrator::detectTimeDependentRates(double t, double probeSpan)
+    {
+        // Compare the reaction rates at the current state for several times.  The
+        // state vector is not touched, so the species- and parameter-dependent
+        // parts of every rate law are identical between probes and any difference
+        // can only come from an explicit dependence on time (directly, or through
+        // a time-dependent assignment or rate rule that a rate law reads).
+        if (!(probeSpan > 0.0))
+            probeSpan = 1.0;
+
+        mModel->setTime(t);
+        mModel->getReactionRates(nReactions, nullptr, reactionRatesBuffer);
+
+        const double fractions[] = { 1.0e-3, 0.1, 0.5, 1.0 };
+        bool dependent = false;
+        for (double frac : fractions)
+        {
+            mModel->setTime(t + frac * probeSpan);
+            mModel->getReactionRates(nReactions, nullptr, reactionRates);
+            for (int k = 0; k < nReactions; ++k)
+            {
+                if (reactionRates[k] != reactionRatesBuffer[k])
+                {
+                    dependent = true;
+                    break;
+                }
+            }
+            if (dependent)
+                break;
+        }
+
+        mModel->setTime(t);
+        return dependent;
+    }
+
     double GillespieIntegrator::integrate(double t, double hstep)
     {
         double tf;
@@ -232,6 +283,19 @@ namespace rr
         mModel->getStateVector(stateVector);
         int step = 0;
 
+        // The direct method samples the waiting time from a propensity it assumes
+        // is constant until the next reaction.  That holds only when the rate laws
+        // are time-homogeneous.  Decide once (lazily, so the common case keeps its
+        // exact, byte-for-byte unchanged path) whether any rate depends explicitly
+        // on time; if so, integrate the propensity over time below instead of
+        // freezing it (issue #1318).
+        if (timeDependentRates < 0)
+        {
+            timeDependentRates = detectTimeDependentRates(t, hstep) ? 1 : 0;
+            mModel->setTime(t);
+            mModel->getStateVector(stateVector);
+        }
+
         while (singleStep || (t < tf && (maxNumSteps == 0 || step < maxNumSteps)))
         {
             step++;
@@ -241,61 +305,183 @@ namespace rr
 
             assert(r1 > 0 && r1 <= 1 && r2 >= 0 && r2 <= 1);
 
-            // sum of propensities
-            double s = 0;
+            // which reaction fires this step
+            int reaction = -1;
 
-            // next time
-            double tau;
-
-            // get the 'propensity' -- reaction rates
-            mModel->getReactionRates(nReactions, nullptr, reactionRates);
-
-            // sum the propensity
-            for (int k = 0; k < nReactions; k++)
+            if (!timeDependentRates)
             {
-                rrLog(Logger::LOG_DEBUG) << "reac rate: " << k << ": "
-                    << reactionRates[k];
+                // ---------------- time-homogeneous: standard direct method ----------------
+                // sum of propensities
+                double s = 0;
 
-                // if reaction rate is negative, that means reaction goes in reverse,
-                // this is fine, we just have to reverse the stoichiometry,
-                // but still need to sum the absolute value of the propensities
-                // to get tau.
-                s += std::abs(reactionRates[k]);
-            }
+                // next time
+                double tau;
 
-            // sample tau
-            if (s > 0)
-            {
-                tau = -log(r1) / s;
+                // get the 'propensity' -- reaction rates
+                mModel->getReactionRates(nReactions, nullptr, reactionRates);
+
+                // sum the propensity
+                for (int k = 0; k < nReactions; k++)
+                {
+                    rrLog(Logger::LOG_DEBUG) << "reac rate: " << k << ": "
+                        << reactionRates[k];
+
+                    // if reaction rate is negative, that means reaction goes in reverse,
+                    // this is fine, we just have to reverse the stoichiometry,
+                    // but still need to sum the absolute value of the propensities
+                    // to get tau.
+                    s += std::abs(reactionRates[k]);
+                }
+
+                // sample tau
+                if (s > 0)
+                {
+                    tau = -log(r1) / s;
+                }
+                else
+                {
+                    // no reaction occurs
+                    return tf;
+                }
+                if (!singleStep && t + tau > tf)        // if time exhausted, don't allow reaction to proceed
+                {
+                    return tf;
+                }
+
+                t = t + tau;
+
+                // select reaction
+                double sp = 0.0;
+
+                r2 = r2 * s;
+                for (int i = 0; i < nReactions; ++i)
+                {
+                    sp += std::abs(reactionRates[i]);
+                    if (r2 < sp)
+                    {
+                        reaction = i;
+                        break;
+                    }
+                }
+
+                assert(reaction >= 0 && reaction < nReactions);
             }
             else
             {
-                // no reaction occurs
-                return tf;
-            }
-            if (!singleStep && t + tau > tf)        // if time exhausted, don't allow reaction to proceed
-            {
-                return tf;
-            }
+                // ---------------- time-dependent propensity ----------------
+                // The waiting time tau is defined implicitly by
+                //     integral_{t}^{t+tau} s(u) du = -log(r1),
+                // with s(u) the total propensity re-evaluated as time advances
+                // (species are frozen between reaction events).  This is the
+                // direct-method form of the integrated-propensity representation
+                // for time-dependent rates (D. F. Anderson, J. Chem. Phys. 127,
+                // 214107 (2007)): reaction times are firings of unit-rate Poisson
+                // processes whose internal clock is the integral of the
+                // propensity.  That representation is exact; here we realize it by
+                // accumulating the integral with an adaptive trapezoidal rule,
+                // halving each panel until the propensity is nearly constant
+                // across it, then solving for the firing time inside the panel
+                // that reaches the target.  The result is therefore exact in the
+                // limit of small panels and converges as timeDependentRelTol is
+                // tightened; it is not bit-exact sampling at a finite tolerance.
+                // It reduces exactly to tau = -log(r1)/s when s is constant.
+                const double target = -log(r1);
 
-            t = t + tau;
+                // Largest panel allowed: stay within the reporting interval so a
+                // rate that is rising from zero gets sampled, honouring a user-set
+                // maximum_time_step if it is tighter.
+                double cap = singleStep ? hstep : (tf - t);
+                if (maxTimeStep > minTimeStep && maxTimeStep > 0.0)
+                    cap = std::min(cap, maxTimeStep);
+                if (cap <= 0.0)
+                    return tf;
 
-            // select reaction
-            int reaction = -1;
-            double sp = 0.0;
+                double tEvent = t;
+                double accumulated = 0.0;
+                double s0 = totalPropensity(tEvent);
+                bool fired = false;
 
-            r2 = r2 * s;
-            for (int i = 0; i < nReactions; ++i)
-            {
-                sp += std::abs(reactionRates[i]);
-                if (r2 < sp)
+                // Bound the panel count so a rate that never permits a reaction
+                // (e.g. one that stays exactly zero across the interval) cannot
+                // spin forever.
+                const long maxPanels = 2000000;
+                for (long panel = 0; panel < maxPanels; ++panel)
                 {
-                    reaction = i;
-                    break;
-                }
-            }
+                    const double remaining = target - accumulated;
+                    const double dtFire = (s0 > 0.0)
+                        ? remaining / s0
+                        : std::numeric_limits<double>::infinity();
+                    double h = std::min(dtFire, cap);
+                    if (!singleStep)
+                        h = std::min(h, tf - tEvent);
+                    if (h <= 0.0)
+                        break;      // reached the reporting time with no reaction
 
-            assert(reaction >= 0 && reaction < nReactions);
+                    // shrink the panel until the propensity barely changes over it
+                    double s1 = totalPropensity(tEvent + h);
+                    for (int it = 0; it < 50; ++it)
+                    {
+                        const double denom = std::max(std::max(s0, s1), 1e-12);
+                        if (std::abs(s1 - s0) <= timeDependentRelTol * denom)
+                            break;
+                        h *= 0.5;
+                        s1 = totalPropensity(tEvent + h);
+                    }
+
+                    const double inc = 0.5 * (s0 + s1) * h;   // trapezoidal integral over the panel
+                    if (accumulated + inc >= target && (s0 + s1) > 0.0)
+                    {
+                        // event fires within this panel; with s ~ linear across it,
+                        // s(u) = s0 + k (u - tEvent), so solve
+                        //   s0 * delta + 0.5 * k * delta^2 = remaining
+                        // for the offset delta in [0, h].
+                        const double k = (h > 0.0) ? (s1 - s0) / h : 0.0;
+                        double delta;
+                        if (std::abs(k) < 1e-12)
+                            delta = remaining / s0;
+                        else
+                        {
+                            const double disc = s0 * s0 + 2.0 * k * remaining;
+                            delta = (-s0 + std::sqrt(std::max(disc, 0.0))) / k;
+                        }
+                        if (delta < 0.0) delta = 0.0;
+                        if (delta > h)   delta = h;
+                        tEvent += delta;
+                        fired = true;
+                        break;
+                    }
+
+                    accumulated += inc;
+                    tEvent += h;
+                    s0 = s1;        // reuse the right endpoint as the next left endpoint
+                }
+
+                if (!fired)
+                {
+                    // no reaction before the reporting time
+                    return tf;
+                }
+
+                t = tEvent;
+
+                // select the reaction using the propensities at the firing time
+                double s = totalPropensity(t);
+                if (s <= 0.0)
+                    return tf;
+                double sp = 0.0;
+                r2 = r2 * s;
+                for (int i = 0; i < nReactions; ++i)
+                {
+                    sp += std::abs(reactionRates[i]);
+                    if (r2 < sp)
+                    {
+                        reaction = i;
+                        break;
+                    }
+                }
+                if (reaction < 0)
+                    reaction = nReactions - 1;   // guard against round-off when r2*s == s
+            }
 
             // update chemical species
             // if rate is negative, means reaction goes in reverse, so

--- a/source/GillespieIntegrator.h
+++ b/source/GillespieIntegrator.h
@@ -136,11 +136,59 @@ namespace rr
         std::vector<unsigned char> eventStatus;
         std::vector<unsigned char> previousEventStatus;
 
+        /**
+         * @brief Whether any reaction rate depends explicitly on time.
+         * @details -1 = not yet determined, 0 = no, 1 = yes.  When a rate law is
+         * an explicit function of time (directly, or through a time-dependent
+         * assignment or rate rule) the propensity is not constant between
+         * reaction events, so the standard direct method (which samples the
+         * waiting time from a frozen propensity) is biased.  When this is 1 the
+         * integrator instead integrates the propensity over time (see
+         * @ref integrate).  Determined once, lazily, on the first @ref integrate
+         * call so the (common) time-homogeneous case keeps its exact, unchanged
+         * code path.
+         */
+        int timeDependentRates;
+
         void testRootsAtInitialTime();
         void applyEvents(double timeEnd, std::vector<unsigned char> &prevEventStatus);
 
         double urand();
         void setEngineSeed(Setting seedSetting);
+
+        /**
+         * @brief Sum of the absolute reaction rates (the total propensity) with
+         * the model evaluated at time @p tEval and the current state vector.
+         * @details Leaves @ref reactionRates holding the individual rates at
+         * @p tEval so the caller can use them for reaction selection.  Species
+         * amounts are not modified, so this re-evaluates only the time- and
+         * parameter-dependent parts of each rate law.
+         */
+        double totalPropensity(double tEval);
+
+        /**
+         * @brief Detect whether any reaction rate changes with time alone.
+         * @details Compares the reaction rates at the current state for several
+         * times spanning @p probeSpan.  If any rate differs the propensity is
+         * time-dependent.  Restores the model time to @p t before returning.
+         *
+         * This is a value-based heuristic: it can in principle miss a rate that
+         * is flat at the sampled times but varies elsewhere.  Explicit time
+         * dependence is a structural property, so inspecting the rate-law
+         * expression trees for the SBML time symbol (following the assignment-rule
+         * graph, so it also catches a rate that reads a time-dependent parameter,
+         * which the value-based check gets for free) would be more robust than
+         * sampling values.
+         */
+        bool detectTimeDependentRates(double t, double probeSpan);
+
+        /**
+         * @brief Relative change in the total propensity tolerated across a
+         * single panel when integrating a time-dependent propensity.  Smaller
+         * values track a fast-varying rate more accurately at the cost of more
+         * rate-law evaluations.
+         */
+        static constexpr double timeDependentRelTol = 0.05;
 
         inline double getStoich(uint species, uint reaction)
         {

--- a/test/cxx_api_tests/GillespieTests.cpp
+++ b/test/cxx_api_tests/GillespieTests.cpp
@@ -10,6 +10,9 @@
 #include "GillespieIntegrator.h"
 #include "rrConfig.h"
 #include "RoadRunnerTest.h"
+
+#include <cmath>
+#include <vector>
 using namespace rr;
 
 /**
@@ -141,5 +144,94 @@ TEST_F(GillespieTests, MaxNumSteps) {
     rr.getIntegrator()->setValue("minimum_time_step", 0.0);
     rr.getIntegrator()->setValue("maximum_num_steps", 1);
     results = rr.simulate(0, 50, 11);
+}
+
+/**
+ * Regression test for https://github.com/sys-bio/roadrunner/issues/1318
+ *
+ * An immigration-death process whose immigration rate is an explicit function
+ * of time: N is produced at rate lam(t) = A*(exp(c t) - exp(d t)) (zeroth order
+ * in N, and zero at t = 0) and removed at rate mu*N.  Because the system is
+ * affine, the ensemble mean satisfies exactly  m'(t) = lam(t) - mu m,  whose
+ * closed-form solution is the oracle below.  The direct method sampled the
+ * waiting time from a propensity frozen at the start of each reporting interval:
+ * at t = 0 the propensity is zero, so it jumped straight to the next reporting
+ * time leaving N pinned at 0 for the whole first interval, and it then trailed
+ * the true mean by about one interval for the rest of the run.  Integrating the
+ * (time-varying) propensity over the waiting time removes the lag.
+ */
+static const std::string TimeDependentImmigrationSBML = R"(<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4"><model id="td">
+ <listOfCompartments><compartment id="c" size="1"/></listOfCompartments>
+ <listOfSpecies>
+  <species id="N" compartment="c" initialAmount="0" hasOnlySubstanceUnits="true"/>
+ </listOfSpecies>
+ <listOfParameters>
+  <parameter id="A"  value="10"/>
+  <parameter id="cc" value="-0.2156"/>
+  <parameter id="dd" value="-0.783"/>
+  <parameter id="mu" value="0.5"/>
+  <parameter id="lam" value="0" constant="false"/>
+ </listOfParameters>
+ <listOfRules>
+  <assignmentRule variable="lam">
+   <math xmlns="http://www.w3.org/1998/Math/MathML">
+    <apply><times/><ci>A</ci>
+     <apply><minus/>
+      <apply><exp/><apply><times/><ci>cc</ci><csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> t </csymbol></apply></apply>
+      <apply><exp/><apply><times/><ci>dd</ci><csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> t </csymbol></apply></apply>
+     </apply>
+    </apply>
+   </math>
+  </assignmentRule>
+ </listOfRules>
+ <listOfReactions>
+  <reaction id="Birth" reversible="false">
+   <listOfProducts><speciesReference species="N"/></listOfProducts>
+   <kineticLaw><math xmlns="http://www.w3.org/1998/Math/MathML"><ci>lam</ci></math></kineticLaw>
+  </reaction>
+  <reaction id="Death" reversible="false">
+   <listOfReactants><speciesReference species="N"/></listOfReactants>
+   <kineticLaw><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><times/><ci>mu</ci><ci>N</ci></apply></math></kineticLaw>
+  </reaction>
+ </listOfReactions>
+</model></sbml>)";
+
+TEST_F(GillespieTests, TimeDependentPropensityMatchesODE) {
+    // closed-form mean of m'(t) = A(e^{c t}-e^{d t}) - mu m,  m(0)=0
+    const double A = 10.0, c = -0.2156, d = -0.783, mu = 0.5;
+    auto odeMean = [&](double t) {
+        return A * ((std::exp(c * t) - std::exp(-mu * t)) / (c + mu)
+                  - (std::exp(d * t) - std::exp(-mu * t)) / (d + mu));
+    };
+
+    RoadRunner rr(TimeDependentImmigrationSBML);
+    rr.setIntegrator("gillespie");
+    rr.getIntegrator()->setValue("variable_step_size", false);
+    rr.setSelections(std::vector<std::string>{"time", "N"});
+
+    const int nrep = 300;
+    const int npts = 6;                 // coarse grid: t = 0, 2, 4, 6, 8, 10
+    std::vector<double> mean(npts, 0.0);
+    for (int seed = 1; seed <= nrep; ++seed) {
+        rr.reset();
+        rr.getIntegrator()->setValue("seed", seed);
+        const ls::DoubleMatrix* results = rr.simulate(0, 10, npts);
+        for (int row = 0; row < npts; ++row)
+            mean[row] += results->Element(row, 1);
+    }
+    for (int row = 0; row < npts; ++row)
+        mean[row] /= nrep;
+
+    // The SSA mean must track the analytic ODE mean at every reporting time.
+    // Before the fix the t = 2 value was pinned at ~0 (frozen first interval)
+    // against an analytic ~4.3, far outside this tolerance.
+    for (int row = 1; row < npts; ++row) {
+        double t = 10.0 * row / (npts - 1);
+        EXPECT_NEAR(mean[row], odeMean(t), 0.7)
+            << "SSA mean " << mean[row] << " at t=" << t
+            << " does not track the ODE mean " << odeMean(t)
+            << " (time-dependent propensity not integrated; issue #1318).";
+    }
 }
 


### PR DESCRIPTION


Fixes #1318. The direct method samples the waiting time from a propensity it treats as constant until the next reaction, which is only correct when the rate laws are time-homogeneous. When a rate depends explicitly on time (directly, or through a time-dependent assignment or rate rule), the SSA mean drifts off the ODE: a rate that is zero at t=0 froze the first reporting interval, and coarse output intervals trailed the true mean by about one interval.

Now we check once, on the first step, whether any rate varies with time (the detection adds no random draws, so time-homogeneous models keep the original code path and produce bit-identical results). When a rate does depend on time, the waiting time tau satisfies integral over [t, t+tau] of s(u) du = -log(r1), where s is the total propensity re-evaluated as time advances; we accumulate that integral with an adaptive trapezoidal sub-step and select the reaction using the propensities at the firing time. This is the direct-method form of the integrated-propensity representation in D. F. Anderson, J. Chem. Phys. 127, 214107 (2007). The representation is exact; this implementation realizes it up to the quadrature error of the sub-step, so it is exact in the limit of small steps and converges as the tolerance is tightened, not bit-exact at a finite tolerance.

Adds regression test TimeDependentPropensityMatchesODE, an immigration-death process with a time-dependent immigration rate and a closed-form ODE mean. The time-homogeneous path is byte-for-byte identical to before, and the stochastic test suite is unaffected (its rate laws are all time-homogeneous; the CSymbolTime models use time only in event triggers).

The time-dependence check is a value-based heuristic; inspecting the rate-law expression trees for the time symbol would be more robust, which is noted in the code.