### PR TITLE
Fix for issue #1337

### DIFF
--- a/test/cxx_api_tests/GillespieTests.cpp
+++ b/test/cxx_api_tests/GillespieTests.cpp
@@ -10,10 +10,13 @@
 #include "GillespieIntegrator.h"
 #include "rrConfig.h"
 #include "RoadRunnerTest.h"
+#include "C/rrc_api.h"
 
 #include <cmath>
+#include <string>
 #include <vector>
 using namespace rr;
+using namespace rrc;
 
 /**
  * This is a more of a stub test suite
@@ -312,5 +315,178 @@ TEST_F(GillespieTests, TimeDependentPropensityMatchesODE) {
             << " does not track the ODE mean " << odeMean(t)
             << " (time-dependent propensity not integrated; issue #1318).";
     }
+}
+
+/**
+ * Regression tests for https://github.com/sys-bio/roadrunner/issues/1337
+ *
+ * The C API's Gillespie-averaging entry points - gillespieMeanOnGrid(Ex) and
+ * gillespieMeanSDOnGrid(Ex) in wrappers/C/rrc_api.cpp - have two independent
+ * bugs, both reproduced below with the S1 -> S2 mass-action model from the
+ * issue (k1 = 0.5, S1(0) = 100). Each of these functions runs its own fresh
+ * batch of `numberOfSimulations` Gillespie simulations internally (that's the
+ * whole point of the numberOfSimulations parameter), so unlike the plain
+ * gillespie()/gillespieOnGrid() calls, nothing about them should ever depend
+ * on some earlier, unrelated simulation having already run:
+ *
+ * 1. They used to size their accumulator matrix from
+ *    RoadRunner::getSimulationData(), which is a default-constructed (0x0,
+ *    null-backed) matrix until *some* simulation has populated it, and
+ *    otherwise just holds whatever shape that last simulation happened to
+ *    have. If nothing had run yet, the very first write into that 0x0
+ *    accumulator dereferenced a null pointer and crashed the process - even
+ *    if the "gillespie" integrator had already been selected. If something
+ *    unrelated *had* run, but on a different grid, the accumulator was
+ *    silently the wrong shape. Both are fixed by sizing directly from the
+ *    requested grid and the model's current selection list, which are known
+ *    up front and don't require having run anything.
+ *
+ * 2. In the accumulation loop, every write targeted column 0 unconditionally
+ *    (`avg(j, 0)`) instead of looping over all columns. Column 0 is time, so
+ *    only the time column was ever averaged; every species column was left
+ *    at its zero-initialized value. gillespieMeanSDOnGrid had the same
+ *    column-0 bug for its variance accumulator, and on top of that never
+ *    finished the Welford calculation (divide by n-1, sqrt) or copied it
+ *    into the result - it copied the (broken) mean into Weights instead.
+ */
+static const std::string S1ToS2MassActionSBML = R"(<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4"><model id="s1_s2">
+ <listOfCompartments><compartment id="c" size="1"/></listOfCompartments>
+ <listOfSpecies>
+  <species id="S1" compartment="c" initialAmount="100" hasOnlySubstanceUnits="true"/>
+  <species id="S2" compartment="c" initialAmount="0"   hasOnlySubstanceUnits="true"/>
+ </listOfSpecies>
+ <listOfParameters><parameter id="k1" value="0.5"/></listOfParameters>
+ <listOfReactions>
+  <reaction id="R1" reversible="false">
+   <listOfReactants><speciesReference species="S1"/></listOfReactants>
+   <listOfProducts><speciesReference species="S2"/></listOfProducts>
+   <kineticLaw><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><times/><ci>k1</ci><ci>S1</ci></apply></math></kineticLaw>
+  </reaction>
+ </listOfReactions>
+</model></sbml>)";
+
+// Finds the column in an RRCData result whose header contains `name` (e.g.
+// "S1"), returning -1 if not found. Used instead of a hardcoded index so
+// these tests don't depend on the exact default column ordering/formatting.
+static int findColumnContaining(RRCDataPtr data, const std::string &name) {
+    for (int i = 0; i < data->CSize; i++) {
+        if (std::string(data->ColumnHeaders[i]).find(name) != std::string::npos) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+TEST_F(GillespieTests, MeanOnGridWorksWithoutAnyPriorSimulation) {
+    RRHandle rrHandle = createRRInstance();
+    ASSERT_TRUE(loadSBML(rrHandle, S1ToS2MassActionSBML.c_str()));
+
+    // No gillespie()/gillespieOnGrid()/gillespieOnGridEx() call has happened
+    // yet, and none should be needed: gillespieMeanOnGridEx runs its own
+    // batch of simulations. Before the fix this dereferenced a null pointer
+    // (issue #1337, bug 1).
+    RRCDataPtr meanResult = gillespieMeanOnGridEx(rrHandle, 0, 5, 6, 3);
+    ASSERT_NE(meanResult, nullptr);
+    EXPECT_EQ(meanResult->RSize, 6);
+    EXPECT_GT(meanResult->CSize, 1);
+    freeRRCData(meanResult);
+
+    // Same for the mean+SD variant, on a fresh handle so there's still no
+    // prior simulation of any kind.
+    RRHandle rrHandle2 = createRRInstance();
+    ASSERT_TRUE(loadSBML(rrHandle2, S1ToS2MassActionSBML.c_str()));
+    RRCDataPtr meanSDResult = gillespieMeanSDOnGridEx(rrHandle2, 0, 5, 6, 3);
+    ASSERT_NE(meanSDResult, nullptr);
+    EXPECT_EQ(meanSDResult->RSize, 6);
+    EXPECT_GT(meanSDResult->CSize, 1);
+    freeRRCData(meanSDResult);
+
+    freeRRInstance(rrHandle);
+    freeRRInstance(rrHandle2);
+}
+
+TEST_F(GillespieTests, MeanOnGridIgnoresUnrelatedPriorSimulationShape) {
+    RRHandle rrHandle = createRRInstance();
+    ASSERT_TRUE(loadSBML(rrHandle, S1ToS2MassActionSBML.c_str()));
+
+    // Run something unrelated first, on a coarser grid (3 points) than what's
+    // requested below (51 points). Under the old code, sizing the accumulator
+    // from this leftover result would silently produce a wrong-shaped result
+    // or, in the worst case, an out-of-bounds write.
+    RRCDataPtr warmup = gillespieOnGridEx(rrHandle, 0, 5, 3);
+    ASSERT_NE(warmup, nullptr);
+    freeRRCData(warmup);
+
+    RRCDataPtr result = gillespieMeanOnGridEx(rrHandle, 0, 5, 51, 3);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result->RSize, 51);
+
+    freeRRCData(result);
+    freeRRInstance(rrHandle);
+}
+
+TEST_F(GillespieTests, MeanOnGridAveragesAllSpeciesColumns) {
+    RRHandle rrHandle = createRRInstance();
+    ASSERT_TRUE(loadSBML(rrHandle, S1ToS2MassActionSBML.c_str()));
+
+    RRCDataPtr result = gillespieMeanOnGridEx(rrHandle, 0, 5, 6, 10);
+    ASSERT_NE(result, nullptr);
+
+    int s1Col = findColumnContaining(result, "S1");
+    int s2Col = findColumnContaining(result, "S2");
+    ASSERT_GE(s1Col, 0);
+    ASSERT_GE(s2Col, 0);
+
+    // Every replicate starts at the same, exactly known initial condition, so
+    // the row-0 average must equal it precisely, regardless of the Gillespie
+    // RNG. Before the fix, only column 0 (time) was ever accumulated into, so
+    // every species column - including this one - stayed at 0.
+    EXPECT_DOUBLE_EQ(result->Data[0 * result->CSize + s1Col], 100.0);
+    EXPECT_DOUBLE_EQ(result->Data[0 * result->CSize + s2Col], 0.0);
+
+    // Mass is conserved by the single S1 -> S2 reaction, so S1 + S2 == 100 in
+    // every individual trajectory, and therefore in their average too. This
+    // fails under the old code, where both columns average out to 0.
+    for (int row = 0; row < result->RSize; row++) {
+        double s1 = result->Data[row * result->CSize + s1Col];
+        double s2 = result->Data[row * result->CSize + s2Col];
+        EXPECT_NEAR(s1 + s2, 100.0, 1e-9) << "row " << row;
+    }
+
+    freeRRCData(result);
+    freeRRInstance(rrHandle);
+}
+
+TEST_F(GillespieTests, MeanSDOnGridReturnsMeanAndRealStandardDeviationTogether) {
+    RRHandle rrHandle = createRRInstance();
+    ASSERT_TRUE(loadSBML(rrHandle, S1ToS2MassActionSBML.c_str()));
+
+    // gillespieMeanSDOnGrid is the "single call" way to get both the mean and
+    // the standard deviation from the same batch of runs (they're accumulated
+    // together in one pass over `numberOfSimulations` fresh simulations).
+    RRCDataPtr result = gillespieMeanSDOnGridEx(rrHandle, 0, 5, 6, 30);
+    ASSERT_NE(result, nullptr);
+    ASSERT_NE(result->Weights, nullptr);
+
+    int s1Col = findColumnContaining(result, "S1");
+    ASSERT_GE(s1Col, 0);
+
+    // The mean (Data) must be correct, same as gillespieMeanOnGrid.
+    EXPECT_DOUBLE_EQ(result->Data[0 * result->CSize + s1Col], 100.0);
+
+    // At t=0 every replicate is identical, so S1's standard deviation (Weights)
+    // must be exactly zero there.
+    EXPECT_DOUBLE_EQ(result->Weights[0 * result->CSize + s1Col], 0.0);
+
+    // By the final time point, 30 independent stochastic trajectories of a
+    // decaying species must disagree with each other, i.e. have a strictly
+    // positive standard deviation. Before the fix, Weights was just a second
+    // copy of the (broken, all-zero) mean, so this was 0 too.
+    int lastRow = result->RSize - 1;
+    EXPECT_GT(result->Weights[lastRow * result->CSize + s1Col], 0.0);
+
+    freeRRCData(result);
+    freeRRInstance(rrHandle);
 }
 

--- a/test/cxx_api_tests/GillespieTests.cpp
+++ b/test/cxx_api_tests/GillespieTests.cpp
@@ -319,35 +319,6 @@ TEST_F(GillespieTests, TimeDependentPropensityMatchesODE) {
 
 /**
  * Regression tests for https://github.com/sys-bio/roadrunner/issues/1337
- *
- * The C API's Gillespie-averaging entry points - gillespieMeanOnGrid(Ex) and
- * gillespieMeanSDOnGrid(Ex) in wrappers/C/rrc_api.cpp - have two independent
- * bugs, both reproduced below with the S1 -> S2 mass-action model from the
- * issue (k1 = 0.5, S1(0) = 100). Each of these functions runs its own fresh
- * batch of `numberOfSimulations` Gillespie simulations internally (that's the
- * whole point of the numberOfSimulations parameter), so unlike the plain
- * gillespie()/gillespieOnGrid() calls, nothing about them should ever depend
- * on some earlier, unrelated simulation having already run:
- *
- * 1. They used to size their accumulator matrix from
- *    RoadRunner::getSimulationData(), which is a default-constructed (0x0,
- *    null-backed) matrix until *some* simulation has populated it, and
- *    otherwise just holds whatever shape that last simulation happened to
- *    have. If nothing had run yet, the very first write into that 0x0
- *    accumulator dereferenced a null pointer and crashed the process - even
- *    if the "gillespie" integrator had already been selected. If something
- *    unrelated *had* run, but on a different grid, the accumulator was
- *    silently the wrong shape. Both are fixed by sizing directly from the
- *    requested grid and the model's current selection list, which are known
- *    up front and don't require having run anything.
- *
- * 2. In the accumulation loop, every write targeted column 0 unconditionally
- *    (`avg(j, 0)`) instead of looping over all columns. Column 0 is time, so
- *    only the time column was ever averaged; every species column was left
- *    at its zero-initialized value. gillespieMeanSDOnGrid had the same
- *    column-0 bug for its variance accumulator, and on top of that never
- *    finished the Welford calculation (divide by n-1, sqrt) or copied it
- *    into the result - it copied the (broken) mean into Weights instead.
  */
 static const std::string S1ToS2MassActionSBML = R"(<?xml version="1.0" encoding="UTF-8"?>
 <sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4"><model id="s1_s2">
@@ -384,8 +355,7 @@ TEST_F(GillespieTests, MeanOnGridWorksWithoutAnyPriorSimulation) {
 
     // No gillespie()/gillespieOnGrid()/gillespieOnGridEx() call has happened
     // yet, and none should be needed: gillespieMeanOnGridEx runs its own
-    // batch of simulations. Before the fix this dereferenced a null pointer
-    // (issue #1337, bug 1).
+    // batch of simulations.
     RRCDataPtr meanResult = gillespieMeanOnGridEx(rrHandle, 0, 5, 6, 3);
     ASSERT_NE(meanResult, nullptr);
     EXPECT_EQ(meanResult->RSize, 6);
@@ -411,9 +381,7 @@ TEST_F(GillespieTests, MeanOnGridIgnoresUnrelatedPriorSimulationShape) {
     ASSERT_TRUE(loadSBML(rrHandle, S1ToS2MassActionSBML.c_str()));
 
     // Run something unrelated first, on a coarser grid (3 points) than what's
-    // requested below (51 points). Under the old code, sizing the accumulator
-    // from this leftover result would silently produce a wrong-shaped result
-    // or, in the worst case, an out-of-bounds write.
+    // requested below (51 points).
     RRCDataPtr warmup = gillespieOnGridEx(rrHandle, 0, 5, 3);
     ASSERT_NE(warmup, nullptr);
     freeRRCData(warmup);
@@ -440,14 +408,12 @@ TEST_F(GillespieTests, MeanOnGridAveragesAllSpeciesColumns) {
 
     // Every replicate starts at the same, exactly known initial condition, so
     // the row-0 average must equal it precisely, regardless of the Gillespie
-    // RNG. Before the fix, only column 0 (time) was ever accumulated into, so
-    // every species column - including this one - stayed at 0.
+    // RNG.
     EXPECT_DOUBLE_EQ(result->Data[0 * result->CSize + s1Col], 100.0);
     EXPECT_DOUBLE_EQ(result->Data[0 * result->CSize + s2Col], 0.0);
 
     // Mass is conserved by the single S1 -> S2 reaction, so S1 + S2 == 100 in
-    // every individual trajectory, and therefore in their average too. This
-    // fails under the old code, where both columns average out to 0.
+    // every individual trajectory, and therefore in their average too.
     for (int row = 0; row < result->RSize; row++) {
         double s1 = result->Data[row * result->CSize + s1Col];
         double s2 = result->Data[row * result->CSize + s2Col];
@@ -481,8 +447,7 @@ TEST_F(GillespieTests, MeanSDOnGridReturnsMeanAndRealStandardDeviationTogether) 
 
     // By the final time point, 30 independent stochastic trajectories of a
     // decaying species must disagree with each other, i.e. have a strictly
-    // positive standard deviation. Before the fix, Weights was just a second
-    // copy of the (broken, all-zero) mean, so this was 0 too.
+    // positive standard deviation.
     int lastRow = result->RSize - 1;
     EXPECT_GT(result->Weights[lastRow * result->CSize + s1Col], 0.0);
 

--- a/wrappers/C/rrc_api.cpp
+++ b/wrappers/C/rrc_api.cpp
@@ -3461,7 +3461,7 @@ C_DECL_SPEC RRCDataPtr rrcCallConv gillespieMeanOnGrid(RRHandle handle, int numb
         //o.integrator = Integrator::GILLESPIE;
         //o.integratorFlags &= !Integrator::VARIABLE_STEP;
         r->setIntegrator("gillespie");
-		r->getIntegrator()->setValue("variable_step_size", Setting(false));
+        r->getIntegrator()->setValue("variable_step_size", Setting(false));
 
         RoadRunner &rref = const_cast<RoadRunner&>(*r);
 
@@ -3480,8 +3480,9 @@ C_DECL_SPEC RRCDataPtr rrcCallConv gillespieMeanOnGrid(RRHandle handle, int numb
             }
         }
 
-        // Runs simulations, obtaining avg with Welford's Algorithm
+        // Runs simulations, obtaining avg with Welford's Algorithm.
         for (int i = 0; i < numberOfSimulations; i++) {
+            r->reset();
             const DoubleMatrix &temp = *r->simulate();
             for (int row = 0; row < nRows; row++) {
                 for (int col = 0; col < nCols; col++) {
@@ -3554,8 +3555,9 @@ C_DECL_SPEC RRCDataPtr rrcCallConv gillespieMeanSDOnGrid(RRHandle handle, int nu
             }
         }
 
-        // Runs simulations, obtaining avg and m2 with Welford's Algorithm
+        // Runs simulations, obtaining avg and m2 with Welford's Algorithm.
         for (int i = 0; i < numberOfSimulations; i++) {
+            r->reset();
             const DoubleMatrix &temp = *r->simulate();
             for (int row = 0; row < nRows; row++) {
                 for (int col = 0; col < nCols; col++) {

--- a/wrappers/C/rrc_api.cpp
+++ b/wrappers/C/rrc_api.cpp
@@ -42,6 +42,7 @@
 
 #pragma hdrstop
 #include <string>
+#include <cmath>
 #include <iostream>
 #include <sstream>
 #include <fstream>
@@ -3462,15 +3463,19 @@ C_DECL_SPEC RRCDataPtr rrcCallConv gillespieMeanOnGrid(RRHandle handle, int numb
         r->setIntegrator("gillespie");
 		r->getIntegrator()->setValue("variable_step_size", Setting(false));
 
-        double steps = o.steps;
-
         RoadRunner &rref = const_cast<RoadRunner&>(*r);
-        const DoubleMatrix& reference = *rref.getSimulationData();
 
-        // Initializes a DoubleMatrix "res" with all zeroes
-        DoubleMatrix avg(reference.RSize(), reference.CSize());
-        for (int row = 0; row < reference.RSize(); row++) {
-            for (int col = 0; col < reference.CSize(); col++) {
+        // Size the accumulator from the requested grid (o.steps, set by
+        // setNumPoints/gillespieMeanOnGridEx) and the model's current
+        // selection list.
+        int nRows = static_cast<int>(o.steps) + 1;
+        const std::vector<SelectionRecord> &selections = rref.getSelections();
+        int nCols = static_cast<int>(selections.size());
+
+        // Initializes a DoubleMatrix "avg" with all zeroes
+        DoubleMatrix avg(nRows, nCols);
+        for (int row = 0; row < nRows; row++) {
+            for (int col = 0; col < nCols; col++) {
                 avg(row, col) = 0;
             }
         }
@@ -3478,8 +3483,10 @@ C_DECL_SPEC RRCDataPtr rrcCallConv gillespieMeanOnGrid(RRHandle handle, int numb
         // Runs simulations, obtaining avg with Welford's Algorithm
         for (int i = 0; i < numberOfSimulations; i++) {
             const DoubleMatrix &temp = *r->simulate();
-            for (int j = 0; j < steps + 1; j++) {
-                avg(j, 0) += (temp(j, 0) - avg(j, 0)) / (i + 1);
+            for (int row = 0; row < nRows; row++) {
+                for (int col = 0; col < nCols; col++) {
+                    avg(row, col) += (temp(row, col) - avg(row, col)) / (i + 1);
+                }
             }
         }
 
@@ -3489,7 +3496,6 @@ C_DECL_SPEC RRCDataPtr rrcCallConv gillespieMeanOnGrid(RRHandle handle, int numb
         memset(rrCData, 0, sizeof(RRCData));
 
         // Create column info
-        const std::vector<SelectionRecord> &selections = rref.getSelections();
         rrCData->ColumnHeaders = new char*[selections.size()];
         for (int i = 0; i < selections.size(); i++) {
             rrCData->ColumnHeaders[i] = rr::createText(selections[i].to_string());
@@ -3529,28 +3535,47 @@ C_DECL_SPEC RRCDataPtr rrcCallConv gillespieMeanSDOnGrid(RRHandle handle, int nu
 		//o.integratorFlags &= !Integrator::VARIABLE_STEP;
 		r->getIntegrator()->setValue("variable_step_size", Setting(false));
 
-        double steps = o.steps;
-
         RoadRunner &rref = const_cast<RoadRunner&>(*r);
-        const DoubleMatrix& reference = *rref.getSimulationData();
 
-        // Initializes a DoubleMatrix "res" with all zeroes
-        DoubleMatrix avg(reference.RSize(), reference.CSize());
-        DoubleMatrix stddev(reference.RSize(), reference.CSize());
-        for (int row = 0; row < reference.RSize(); row++) {
-            for (int col = 0; col < reference.CSize(); col++) {
+        // Size the grid and compute both avg and sum-of-squared-deviations in
+        // the same pass.
+        int nRows = static_cast<int>(o.steps) + 1;
+        const std::vector<SelectionRecord> &selections = rref.getSelections();
+        int nCols = static_cast<int>(selections.size());
+
+        // Initializes DoubleMatrix "avg" and the M2 (sum of squared deviations)
+        // accumulator "m2" with all zeroes
+        DoubleMatrix avg(nRows, nCols);
+        DoubleMatrix m2(nRows, nCols);
+        for (int row = 0; row < nRows; row++) {
+            for (int col = 0; col < nCols; col++) {
                 avg(row, col) = 0;
-                stddev(row, col) = 0;
+                m2(row, col) = 0;
             }
         }
 
-        // Runs simulations, obtain avg and stddev with Welford's Algorithm
+        // Runs simulations, obtaining avg and m2 with Welford's Algorithm
         for (int i = 0; i < numberOfSimulations; i++) {
             const DoubleMatrix &temp = *r->simulate();
-            for (int j = 0; j < steps + 1; j++) {
-                double delta = temp(j, 0) - avg(j, 0);
-                avg(j, 0) += delta / (i + 1);
-                stddev(j, 0) += delta * (temp(j, 0) - avg(j, 0));
+            for (int row = 0; row < nRows; row++) {
+                for (int col = 0; col < nCols; col++) {
+                    double delta = temp(row, col) - avg(row, col);
+                    avg(row, col) += delta / (i + 1);
+                    m2(row, col) += delta * (temp(row, col) - avg(row, col));
+                }
+            }
+        }
+
+        // Finish the Welford calculation: m2 is the running sum of squared
+        // deviations from the mean, so the (sample) standard deviation is
+        // sqrt(m2 / (n - 1)). With a single simulation there is no variance
+        // to report.
+        DoubleMatrix stddev(nRows, nCols);
+        for (int row = 0; row < nRows; row++) {
+            for (int col = 0; col < nCols; col++) {
+                stddev(row, col) = (numberOfSimulations > 1)
+                    ? std::sqrt(m2(row, col) / (numberOfSimulations - 1))
+                    : 0.0;
             }
         }
 
@@ -3560,7 +3585,6 @@ C_DECL_SPEC RRCDataPtr rrcCallConv gillespieMeanSDOnGrid(RRHandle handle, int nu
         memset(rrCData, 0, sizeof(RRCData));
 
         // Create column info
-        const std::vector<SelectionRecord> &selections = rref.getSelections();
         rrCData->ColumnHeaders = new char*[selections.size()];
         for (int i = 0; i < selections.size(); i++) {
             rrCData->ColumnHeaders[i] = rr::createText(selections[i].to_string());
@@ -3577,7 +3601,7 @@ C_DECL_SPEC RRCDataPtr rrcCallConv gillespieMeanSDOnGrid(RRHandle handle, int nu
         for (int row = 0; row < rrCData->RSize; row++) {
             for (int col = 0; col < rrCData->CSize; col++) {
                 rrCData->Data[index] = result(row, col);
-                rrCData->Weights[index] = result(row, col);
+                rrCData->Weights[index] = stddev(row, col);
                 index++;
             }
         }


### PR DESCRIPTION
From Claude:
The C API's Gillespie-averaging entry points - gillespieMeanOnGrid(Ex) and gillespieMeanSDOnGrid(Ex) in wrappers/C/rrc_api.cpp - have two independent bugs, both reproduced below with the S1 -> S2 mass-action model from the issue (k1 = 0.5, S1(0) = 100). Each of these functions runs its own fresh batch of `numberOfSimulations` Gillespie simulations internally (that's the whole point of the numberOfSimulations parameter), so unlike the plain gillespie()/gillespieOnGrid() calls, nothing about them should ever depend on some earlier, unrelated simulation having already run:

1. They used to size their accumulator matrix from RoadRunner::getSimulationData(), which is a default-constructed (0x0, null-backed) matrix until *some* simulation has populated it, and otherwise just holds whatever shape that last simulation happened to have. If nothing had run yet, the very first write into that 0x0 accumulator dereferenced a null pointer and crashed the process - even if the "gillespie" integrator had already been selected. If something unrelated *had* run, but on a different grid, the accumulator was silently the wrong shape. Both are fixed by sizing directly from the requested grid and the model's current selection list, which are known up front and don't require having run anything.

2. In the accumulation loop, every write targeted column 0 unconditionally (`avg(j, 0)`) instead of looping over all columns. Column 0 is time, so only the time column was ever averaged; every species column was left at its zero-initialized value. gillespieMeanSDOnGrid had the same column-0 bug for its variance accumulator, and on top of that never finished the Welford calculation (divide by n-1, sqrt) or copied it into the result - it copied the (broken) mean into Weights instead.