### PR TITLE
Fix for issue #1339: simulating with 'times' conflicted with simulations without.

### DIFF
--- a/apps/rr-sbml-benchmark/main.cpp
+++ b/apps/rr-sbml-benchmark/main.cpp
@@ -123,7 +123,7 @@ int main(int argc, char** argv)
         {
             int steps = strtol(argv[6], NULL, 0);
             if (steps > 0) {
-                settings.steps = steps;
+                settings.setSteps(steps);
             }
         }
 
@@ -131,13 +131,13 @@ int main(int argc, char** argv)
         {
             double dur = atof(argv[7]);
             if (dur > 0) {
-                settings.duration = dur;
+                settings.setDuration(dur);
             }
         }
 
 	    roadRunner.getIntegrator()->setValue("stiff", false);
 
-        std::cout << "running for " << settings.steps << ", duration " << settings.duration << std::endl;
+        std::cout << "running for " << settings.getSteps() << ", duration " << settings.getDuration() << std::endl;
 
         std::cout << "absolute: " << roadRunner.getIntegrator()->getValue("absolute_tolerance").convert<bool>() << std::endl;
 	    std::cout << "relative: " << roadRunner.getIntegrator()->getValue("relative_tolerance").convert<bool>() << std::endl;

--- a/apps/rr/main.cpp
+++ b/apps/rr/main.cpp
@@ -71,9 +71,9 @@ int main(int argc, char * argv[])
         RoadRunner rr(args.ModelFileName);
 
         SimulateOptions& opt = rr.getSimulateOptions();
-        opt.start = args.StartTime;
-        opt.duration = args.EndTime - args.StartTime;
-        opt.steps = args.Steps;
+        opt.setStartTime(args.StartTime);
+        opt.setDuration(args.EndTime - args.StartTime);
+        opt.setSteps(args.Steps);
         if(args.variableStep) 
 		{
 			rr.getIntegrator()->setValue("variable_step_size", true);

--- a/cmake/AddTestExecutable.cmake
+++ b/cmake/AddTestExecutable.cmake
@@ -36,6 +36,7 @@ function(add_test_executable TEST_TARGET OUT_VARIABLE)
     set(TEST_ENV_VARS "testdir=${RR_ROOT}/test" "CTEST_OUTPUT_ON_FAILURE=TRUE")
     gtest_discover_tests(
             ${TEST_TARGET}
+            DISCOVERY_MODE PRE_TEST
             DISCOVERY_TIMEOUT 500
             PROPERTIES
             TIMEOUT 500

--- a/rrplugins/examples/cpp/one_rr/main.cpp
+++ b/rrplugins/examples/cpp/one_rr/main.cpp
@@ -33,9 +33,9 @@ int main(int argc, char** argv)
         rr1.load(modelFile, &opt);
 
         SimulateOptions simOpt;
-        simOpt.start = 0;
-        simOpt.start = 10;
-        simOpt.steps= 511;
+        simOpt.setStartTime(0);
+        simOpt.setStartTime(10);
+        simOpt.setSteps(511);
 
         rr1.setGlobalParameterByIndex(2, 0.2);
         double ss = rr1.steadyState();

--- a/rrplugins/plugins/nelder_mead/lib/rr_example/sbml_model_one_para.cpp
+++ b/rrplugins/plugins/nelder_mead/lib/rr_example/sbml_model_one_para.cpp
@@ -60,9 +60,9 @@ double objfun(double par[], const void* userData)
     }
 
     rr::SimulateOptions opt;
-    opt.start       = expData.getTimeStart();
-    opt.duration    = expData.getTimeEnd() - expData.getTimeStart();
-    opt.steps       = expData.rSize() -1;
+    opt.setStartTime(expData.getTimeStart());
+    opt.setDuration(expData.getTimeEnd() - expData.getTimeStart());
+    opt.setSteps(expData.rSize() -1);
     TelluriumData simData(rr.simulate(&opt));
 
     //Calculate Chi Square using the ChiSquare plugin

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1574,16 +1574,12 @@ namespace rr {
             throw CoreException(gEmptyModelMessage);
         }
 
-        double start = impl->simulateOpt.start;
-        double duration = impl->simulateOpt.duration;
-        int steps = impl->simulateOpt.steps;
-        impl->simulateOpt.start = 0;
-        impl->simulateOpt.duration = 10.0;
-        impl->simulateOpt.steps = 100;
+        SimulateOptions savedOpt = impl->simulateOpt;
+        impl->simulateOpt.setStartTime(0);
+        impl->simulateOpt.setDuration(10.0);
+        impl->simulateOpt.setSteps(100);
         simulate();
-        impl->simulateOpt.start = start;
-        impl->simulateOpt.duration = duration;
-        impl->simulateOpt.steps = steps;
+        impl->simulateOpt = savedOpt;
 
         return steadyState();
     }
@@ -2370,19 +2366,20 @@ namespace rr {
     }
 
     const ls::DoubleMatrix *RoadRunner::simulate(double start, double stop, int points) {
-        SimulateOptions opt;
-        opt.start = start;
-        opt.duration = stop;
+        // Use existing simulateOpt, so we don't lose other options in it.
+        get_self();
+        self.simulateOpt.setStartTime(start);
+        self.simulateOpt.setDuration(stop);
         // substract 1 so that start, stop, num has the same meaning as it does in numpy functions
         // i.e. see https://numpy.org/doc/stable/reference/generated/numpy.linspace.html
-        opt.steps = points - 1;
-        return simulate(&opt);
+        self.simulateOpt.setSteps(points - 1);
+        return simulate();
     }
 
     const ls::DoubleMatrix *RoadRunner::simulate(const std::vector<double> &times) {
-        SimulateOptions opt;
-        opt.times = times;
-        return simulate(&opt);
+        get_self();
+        self.simulateOpt.setTimes(times);
+        return simulate();
     }
 
     Matrix3D<double, double> RoadRunner::timeSeriesSensitivities(

--- a/source/rrRoadRunner.h
+++ b/source/rrRoadRunner.h
@@ -330,9 +330,9 @@ namespace rr {
          * @code
          * RoadRunner rr = RoadRunner("someFile.xml");
          * SimulateOptions opt = rr.getSimulateOptions();
-         * opt.start = 0;
-         * opt.duration = 10;
-         * opt.steps = 1000;
+         * opt.setStartTime(0);
+         * opt.setDuration(10);
+         * opt.setSteps(1000);
          * const DoubleMatrix *result = rr.simulate(&opt);
          * @endcode
          *
@@ -343,9 +343,9 @@ namespace rr {
          * RoadRunner rr = RoadRunner("someFile.xml");
          * rr.setIntegrator("gillespie");
          * SimulateOptions opt;
-         * opt.start = 0;
-         * opt.duration = 10;
-         * opt.steps = 1000;
+         * opt.setStartTime(0);
+         * opt.setDuration(10);
+         * opt.setSteps(1000);
          * opt.setItem("stiff", true);
          * opt.setItem("seed", 12345);
          * const DoubleMatrix *result = rr.simulate(&opt);

--- a/source/rrRoadRunnerOptions.cpp
+++ b/source/rrRoadRunnerOptions.cpp
@@ -72,6 +72,56 @@ namespace rr {
         hstep = 0;
     }
 
+    void SimulateOptions::setTimes(const std::vector<double>& newTimes)
+    {
+        times = newTimes;
+        // 'times' is now authoritative: discard whatever steps-based state a
+        // previous call may have left behind, so it can't be mistaken for a
+        // deliberate, still-current steps request.
+        steps = Config::getInt(Config::SIMULATEOPTIONS_STEPS);
+        start = 0;
+        duration = Config::getDouble(Config::SIMULATEOPTIONS_DURATION);
+        hstep = 0;
+    }
+
+    const std::vector<double>& SimulateOptions::getTimes() const
+    {
+        return times;
+    }
+
+    void SimulateOptions::setStartTime(double newStart)
+    {
+        times.clear();
+        start = newStart;
+    }
+
+    double SimulateOptions::getStartTime() const
+    {
+        return start;
+    }
+
+    void SimulateOptions::setDuration(double newDuration)
+    {
+        times.clear();
+        duration = newDuration;
+    }
+
+    double SimulateOptions::getDuration() const
+    {
+        return duration;
+    }
+
+    void SimulateOptions::setSteps(int newSteps)
+    {
+        times.clear();
+        steps = newSteps;
+    }
+
+    int SimulateOptions::getSteps() const
+    {
+        return steps;
+    }
+
     void SimulateOptions::loadSBMLSettings(const std::string &fname) {
         if (!fname.size()) {
             rrLog(Logger::LOG_ERROR) << "Empty file name for setings file";

--- a/source/rrRoadRunnerOptions.h
+++ b/source/rrRoadRunnerOptions.h
@@ -315,26 +315,6 @@ namespace rr
         bool copy_result;
 
         /**
-        * The number of steps at which the output is sampled. The samples are evenly spaced.
-        * When a simulation system calculates the data points to record, it will typically
-        * divide the duration by the number of time steps. Thus, for X steps, the output
-        * will have X+1 data rows.
-        */
-        int steps;
-
-        /**
-        * The start time of the simulation time-series data.
-        * Often this is 0, but not necessarily.
-        */
-        double start;
-
-        /**
-        * The duration of the simulation run, in the model's units of time.
-        */
-        double duration;
-
-
-        /**
         * The ouptut file for simulation results. If non-empty, then the
         * simulation results are batch-written to output_file every
         * Config::K_ROWS_PER_WRITE rows, and an empty
@@ -372,11 +352,45 @@ namespace rr
         */
         std::vector<std::string> concentrations;
 
-        /*
-        * A list of the requested output times.  If set, the simulator will only
-        * report simulation output at the requested values.
+        /**
+        * Set the requested output times.  The simulation will report output only
+        * at these values.  'times' takes precedence over 'steps'/'start'/'duration':
+        * setting it clears any previously-set steps-based state so that
+        * times-mode and steps-mode are always freely interleavable regardless of
+        * what a previous call configured.
         */
-        std::vector<double> times;
+        void setTimes(const std::vector<double>& times);
+
+        /**
+        * The requested output times, or empty if the simulation is steps-based.
+        */
+        const std::vector<double>& getTimes() const;
+
+        /**
+        * Set the start time of the simulation time-series data.  Often this is 0,
+        * but not necessarily.  Clears any previously-set 'times', since 'times'
+        * and the steps/start/duration triplet are mutually exclusive.
+        */
+        void setStartTime(double start);
+
+        double getStartTime() const;
+
+        /**
+        * Set the duration of the simulation run, in the model's units of time.
+        * Clears any previously-set 'times'.
+        */
+        void setDuration(double duration);
+
+        double getDuration() const;
+
+        /**
+        * Set the number of steps at which the output is sampled. The samples are
+        * evenly spaced. Thus, for X steps, the output will have X+1 data rows.
+        * Clears any previously-set 'times'.
+        */
+        void setSteps(int steps);
+
+        int getSteps() const;
 
         /**
         * get a description of this object, compatable with python __str__
@@ -408,6 +422,35 @@ namespace rr
         virtual void reset();
 
     private:
+
+        // RoadRunner is a tightly-coupled internal collaborator that needs
+        // direct access to these fields.
+        friend class RoadRunner;
+
+        /**
+        * The number of steps at which the output is sampled. The samples are evenly spaced.
+        * When a simulation system calculates the data points to record, it will typically
+        * divide the duration by the number of time steps. Thus, for X steps, the output
+        * will have X+1 data rows.
+        */
+        int steps;
+
+        /**
+        * The start time of the simulation time-series data.
+        * Often this is 0, but not necessarily.
+        */
+        double start;
+
+        /**
+        * The duration of the simulation run, in the model's units of time.
+        */
+        double duration;
+
+        /**
+        * The requested output times.  If set, the simulator will only report
+        * simulation output at the requested values.
+        */
+        std::vector<double> times;
 
         double hstep; //Used if we have a duration and number of steps, but not 'times'.
 

--- a/source/rrSBMLModelSimulation.cpp
+++ b/source/rrSBMLModelSimulation.cpp
@@ -208,19 +208,19 @@ namespace rr
 
     bool SBMLModelSimulation::SetTimeStart(const double& startTime)
     {
-        mSettings.start = startTime;
+        mSettings.setStartTime(startTime);
         return true;
     }
 
     bool SBMLModelSimulation::SetTimeEnd(const double& endTime)
     {
-        mSettings.duration = endTime - mSettings.start;
+        mSettings.setDuration(endTime - mSettings.getStartTime());
         return true;
     }
 
     bool SBMLModelSimulation::SetNumberOfPoints(const int& steps)
     {
-        mSettings.steps = steps;
+        mSettings.setSteps(steps);
         return true;
     }
 

--- a/test/c_api_core/CAPICoreTest.cpp
+++ b/test/c_api_core/CAPICoreTest.cpp
@@ -260,8 +260,8 @@ TEST_F(CAPICoreTest, CheckRK4WorksFromC) {
     }
 
     SimulateOptions opt;
-    opt.start = 0;
-    opt.duration = 10;
+    opt.setStartTime(0);
+    opt.setDuration(10);
     auto *cvode = rr.simulate(&opt);
 
     rr.setIntegrator("rk4");

--- a/test/c_api_core/CMakeLists.txt
+++ b/test/c_api_core/CMakeLists.txt
@@ -5,6 +5,7 @@ add_test_executable(test_c_api_core test_targets
         CAPICoreTest
         libstruct.cpp
         model_editing.cpp
+        SimulateOptionsCAPITests.cpp
         )
 
 

--- a/test/c_api_core/SimulateOptionsCAPITests.cpp
+++ b/test/c_api_core/SimulateOptionsCAPITests.cpp
@@ -1,0 +1,177 @@
+#include "gtest/gtest.h"
+#include "C/rrc_api.h"
+#include "C/rrc_types.h"
+#include "RoadRunnerTest.h"
+#include <filesystem>
+
+using namespace rrc;
+using std::filesystem::path;
+
+// https://github.com/sys-bio/roadrunner/issues/1339
+// setTimeStart/setTimeEnd/setNumPoints/setTimes mutate a persistent
+// SimulateOptions field-by-field across repeated simulate() calls, so
+// simulateEx/simulateTimes/gillespieEx and friends need to clear whichever
+// of 'times' or the steps-triplet a previous call left behind. These tests
+// exercise that directly through the C API's handle-based functions.
+class SimulateOptionsCAPITests : public RoadRunnerTest {
+public:
+    path modelFile = rrTestModelsDir_ / "ModelAnalysis" / "no_steady_state.xml";
+    path gillespieModelFile = rrTestModelsDir_ / "ModelAnalysis" / "gillespie_random_seed.xml";
+};
+
+TEST_F(SimulateOptionsCAPITests, simulateExThenSimulateTimes) {
+    RRHandle rr = createRRInstance();
+    ASSERT_TRUE(loadSBMLFromFileE(rr, modelFile.string().c_str(), true));
+
+    // Steps-based simulation: start=0, duration=9, steps=3 (4 points).
+    RRCDataPtr result = simulateEx(rr, 0, 9, 4);
+    ASSERT_NE(result, nullptr);
+    freeRRCData(result);
+    ASSERT_TRUE(reset(rr));
+
+    // Switch to a times-based simulation via simulateTimes.
+    double times[] = { 0, 1, 2, 9 };
+    result = simulateTimes(rr, times, 4);
+    ASSERT_NE(result, nullptr);
+    ASSERT_EQ(result->RSize, 4);
+    for (int i = 0; i < 4; i++) {
+        EXPECT_EQ(result->Data[i * result->CSize + 0], times[i]);
+    }
+    freeRRCData(result);
+    freeRRInstance(rr);
+}
+
+TEST_F(SimulateOptionsCAPITests, simulateTimesThenSimulateEx) {
+    RRHandle rr = createRRInstance();
+    ASSERT_TRUE(loadSBMLFromFileE(rr, modelFile.string().c_str(), true));
+
+    double times[] = { 0, 1, 5, 10, 20 };
+    RRCDataPtr result = simulateTimes(rr, times, 5);
+    ASSERT_NE(result, nullptr);
+    freeRRCData(result);
+    ASSERT_TRUE(reset(rr));
+
+    // Switch back to a steps-based simulation via simulateEx.
+    result = simulateEx(rr, 0, 6, 4);
+    ASSERT_NE(result, nullptr);
+    ASSERT_EQ(result->RSize, 4);
+    EXPECT_EQ(result->Data[0 * result->CSize + 0], 0);
+    EXPECT_EQ(result->Data[3 * result->CSize + 0], 6);
+    freeRRCData(result);
+    freeRRInstance(rr);
+}
+
+TEST_F(SimulateOptionsCAPITests, largerSimulateTimesAfterSimulateTimes) {
+    RRHandle rr = createRRInstance();
+    ASSERT_TRUE(loadSBMLFromFileE(rr, modelFile.string().c_str(), true));
+
+    double times1[] = { 0, 5, 10 };
+    RRCDataPtr result = simulateTimes(rr, times1, 3);
+    ASSERT_NE(result, nullptr);
+    freeRRCData(result);
+    ASSERT_TRUE(reset(rr));
+
+    double times2[] = { 0, 1, 2, 3, 10 };
+    result = simulateTimes(rr, times2, 5);
+    ASSERT_NE(result, nullptr);
+    ASSERT_EQ(result->RSize, 5);
+    for (int i = 0; i < 5; i++) {
+        EXPECT_EQ(result->Data[i * result->CSize + 0], times2[i]);
+    }
+    freeRRCData(result);
+    freeRRInstance(rr);
+}
+
+TEST_F(SimulateOptionsCAPITests, smallerSimulateTimesAfterSimulateTimes) {
+    RRHandle rr = createRRInstance();
+    ASSERT_TRUE(loadSBMLFromFileE(rr, modelFile.string().c_str(), true));
+
+    double times1[] = { 0, 1, 2, 3, 10 };
+    RRCDataPtr result = simulateTimes(rr, times1, 5);
+    ASSERT_NE(result, nullptr);
+    freeRRCData(result);
+    ASSERT_TRUE(reset(rr));
+
+    double times2[] = { 0, 5, 10 };
+    result = simulateTimes(rr, times2, 3);
+    ASSERT_NE(result, nullptr);
+    ASSERT_EQ(result->RSize, 3);
+    for (int i = 0; i < 3; i++) {
+        EXPECT_EQ(result->Data[i * result->CSize + 0], times2[i]);
+    }
+    freeRRCData(result);
+    freeRRInstance(rr);
+}
+
+// Same bug, exercised via the raw setters instead of the bundling *Ex
+// functions -- setTimeStart/setTimeEnd/setNumPoints/setTimes must each
+// clear the complementary state themselves, since simulateEx/simulateTimes
+// are just call-sequences of these.
+TEST_F(SimulateOptionsCAPITests, rawSettersTimesAfterSteps) {
+    RRHandle rr = createRRInstance();
+    ASSERT_TRUE(loadSBMLFromFileE(rr, modelFile.string().c_str(), true));
+
+    ASSERT_TRUE(setTimeStart(rr, 0));
+    ASSERT_TRUE(setTimeEnd(rr, 9));
+    ASSERT_TRUE(setNumPoints(rr, 4));
+    RRCDataPtr result = simulate(rr);
+    ASSERT_NE(result, nullptr);
+    freeRRCData(result);
+    ASSERT_TRUE(reset(rr));
+
+    double times[] = { 0, 1, 2, 9 };
+    ASSERT_TRUE(setTimes(rr, times, 4));
+    result = simulate(rr);
+    ASSERT_NE(result, nullptr);
+    ASSERT_EQ(result->RSize, 4);
+    for (int i = 0; i < 4; i++) {
+        EXPECT_EQ(result->Data[i * result->CSize + 0], times[i]);
+    }
+    freeRRCData(result);
+    freeRRInstance(rr);
+}
+
+TEST_F(SimulateOptionsCAPITests, rawSettersStepsAfterTimes) {
+    RRHandle rr = createRRInstance();
+    ASSERT_TRUE(loadSBMLFromFileE(rr, modelFile.string().c_str(), true));
+
+    double times[] = { 0, 1, 5, 10, 20 };
+    ASSERT_TRUE(setTimes(rr, times, 5));
+    RRCDataPtr result = simulate(rr);
+    ASSERT_NE(result, nullptr);
+    freeRRCData(result);
+    ASSERT_TRUE(reset(rr));
+
+    ASSERT_TRUE(setTimeStart(rr, 0));
+    ASSERT_TRUE(setTimeEnd(rr, 6));
+    ASSERT_TRUE(setNumPoints(rr, 4));
+    result = simulate(rr);
+    ASSERT_NE(result, nullptr);
+    ASSERT_EQ(result->RSize, 4);
+    EXPECT_EQ(result->Data[0 * result->CSize + 0], 0);
+    EXPECT_EQ(result->Data[3 * result->CSize + 0], 6);
+    freeRRCData(result);
+    freeRRInstance(rr);
+}
+
+// gillespieOnGridEx has the identical bundling pattern (setTimeStart/
+// setTimeEnd/setNumPoints, then a bare gillespieOnGrid call) and needs the
+// identical fix.
+TEST_F(SimulateOptionsCAPITests, gillespieOnGridExStepsAfterSimulateTimes) {
+    RRHandle rr = createRRInstance();
+    ASSERT_TRUE(loadSBMLFromFileE(rr, gillespieModelFile.string().c_str(), true));
+
+    double times[] = { 0, 1, 5, 10, 20 };
+    RRCDataPtr result = simulateTimes(rr, times, 5);
+    ASSERT_NE(result, nullptr);
+    freeRRCData(result);
+    ASSERT_TRUE(reset(rr));
+
+    result = gillespieOnGridEx(rr, 0, 6, 4);
+    ASSERT_NE(result, nullptr);
+    ASSERT_EQ(result->RSize, 4);
+    EXPECT_EQ(result->Data[0 * result->CSize + 0], 0);
+    EXPECT_EQ(result->Data[3 * result->CSize + 0], 6);
+    freeRRCData(result);
+    freeRRInstance(rr);
+}

--- a/test/c_api_rrtests/OtherRRTestFileTests.cpp
+++ b/test/c_api_rrtests/OtherRRTestFileTests.cpp
@@ -92,9 +92,9 @@ TEST_F(RRTestFilesOtherTests, OUTPUT_FILE_VARIABLE_TIMESTEP) {
     rr.getIntegrator()->setValue("seed", 123);
 
     SimulateOptions opt;
-    opt.start = 0;
-    opt.duration = 100;
-    opt.steps = 0;
+    opt.setStartTime(0);
+    opt.setDuration(100);
+    opt.setSteps(0);
     opt.output_file = outputFileName.string();
     rr.setSimulateOptions(opt);
 
@@ -126,9 +126,9 @@ TEST_F(RRTestFilesOtherTests, OUTPUT_FILE_FIXED_TIMESTEP) {
     ASSERT_STREQ("gillespie", rr.getIntegrator()->getName().c_str());
     rr.getIntegrator()->setValue("seed", 123);
     rr.getIntegrator()->setValue("variable_step_size", false);
-    opt.start = 0;
-    opt.duration = 50;
-    opt.steps = 100;
+    opt.setStartTime(0);
+    opt.setDuration(50);
+    opt.setSteps(100);
     opt.output_file = outputFileName.string();
     rr.setSimulateOptions(opt);
 

--- a/test/c_api_rrtests/RRTestFileTests.cpp
+++ b/test/c_api_rrtests/RRTestFileTests.cpp
@@ -1097,8 +1097,8 @@ public:
 
         RoadRunner *rri = castToRoadRunner(gRR);
         SimulateOptions opt;
-        opt.start = 0;
-        opt.duration = 10;
+        opt.setStartTime(0);
+        opt.setDuration(10);
 
         // cvode
         //clog <<endl << "  simulate with " << opt.start << ", " << opt.duration << ", " << opt.steps << "\n";
@@ -1122,8 +1122,8 @@ public:
 
         RoadRunner *rri = castToRoadRunner(gRR);
         SimulateOptions opt;
-        opt.start = 0;
-        opt.duration = 10;
+        opt.setStartTime(0);
+        opt.setDuration(10);
 
         // cvode
         //clog <<endl << "  simulate with " << opt.start << ", " << opt.duration << ", " << opt.steps << "\n";
@@ -1710,8 +1710,8 @@ public:
 
         RoadRunner *rri = castToRoadRunner(gRR);
         SimulateOptions opt;
-        opt.start = toDouble(refList.at(0));
-        opt.duration = toDouble(refList.at(1));
+        opt.setStartTime(toDouble(refList.at(0)));
+        opt.setDuration(toDouble(refList.at(1)));
 
         // For variable step
         rri->getIntegrator()->setValue("variable_step_size", true);
@@ -1722,7 +1722,7 @@ public:
         }
 
         // For fixed step
-        opt.steps = toInt(refList.at(2));
+        opt.setSteps(toInt(refList.at(2)));
         rri->getIntegrator()->setValue("variable_step_size", false);
         //clog <<endl << "  simulate with " << opt.start << ", " << opt.duration << ", " << opt.steps << "\n";
         result = rri->simulate(&opt);
@@ -1741,8 +1741,8 @@ public:
 
         RoadRunner *rri = castToRoadRunner(gRR);
         SimulateOptions opt;
-        opt.start = 0;
-        opt.duration = 10;
+        opt.setStartTime(0);
+        opt.setDuration(10);
 
         // For variable step
         rri->getIntegrator()->setValue("variable_step_size", true);

--- a/test/cxx_api_tests/RoadRunnerAPITests.h
+++ b/test/cxx_api_tests/RoadRunnerAPITests.h
@@ -488,14 +488,14 @@ public:
         TestModel *testModel = TestModelFactory("SimpleFlux");
         RoadRunner rr(testModel->str());
         SimulateOptions options;
-        options.steps = 101;
-        options.duration = 100;
-        options.start = 0;
+        options.setSteps(101);
+        options.setDuration(100);
+        options.setStartTime(0);
         rr.setSimulateOptions(options);
         auto x = rr.getSimulateOptions();
-        ASSERT_EQ(x.steps, 101);
-        ASSERT_EQ(x.duration, 100);
-        ASSERT_EQ(x.start, 0);
+        ASSERT_EQ(x.getSteps(), 101);
+        ASSERT_EQ(x.getDuration(), 100);
+        ASSERT_EQ(x.getStartTime(), 0);
         delete testModel;
     }
 

--- a/test/model_analysis/model_analysis.cpp
+++ b/test/model_analysis/model_analysis.cpp
@@ -22,6 +22,104 @@ public:
 };
 
 
+// https://github.com/sys-bio/roadrunner/issues/1339
+// SimulateOptions is a long-lived object (RoadRunner::self.simulateOpt) that
+// the C API mutates field-by-field across repeated simulate() calls.  The
+// planned fix makes 'times'/'start'/'duration'/'steps' private and adds
+// setTimes/setStartTime/setDuration/setSteps methods, each of which clears
+// whichever of 'times' or the steps-triplet is now stale, so that times-mode
+// and steps-mode are always freely interleavable regardless of what a
+// previous call left behind.  These tests exercise those methods directly
+// through SimulateOptions and do not compile until they exist.
+TEST_F(ModelAnalysisTests, issue1339_timesAfterSteps) {
+  RoadRunner rr((modelAnalysisModelsDir / "no_steady_state.xml").string());
+
+  // Steps-based simulation: start=0, duration=9, steps=3.
+  rr.simulate(0, 9, 4);
+  rr.reset();
+
+  // Switch to a times-based simulation, as the C API's setTimes should,
+  // via a method that clears the steps-based state left behind.
+  std::vector<double> times{ 0, 1, 2, 9 };
+  SimulateOptions& opt = rr.getSimulateOptions();
+  opt.setTimes(times);
+  const ls::DoubleMatrix* result = rr.simulate();
+
+  ASSERT_EQ(result->numRows(), times.size());
+  for (size_t i = 0; i < times.size(); i++) {
+    EXPECT_EQ(result->Element(i, 0), times[i]);
+  }
+}
+
+TEST_F(ModelAnalysisTests, issue1339_stepsAfterTimes) {
+  RoadRunner rr((modelAnalysisModelsDir / "no_steady_state.xml").string());
+
+  // Times-based simulation.
+  SimulateOptions& opt = rr.getSimulateOptions();
+  opt.setTimes(std::vector<double>{ 0, 1, 5, 10, 20 });
+  rr.simulate();
+  rr.reset();
+
+  // Switch back to a steps-based simulation, as the C API's
+  // setTimeStart/setTimeEnd/setNumPoints should, via methods that clear
+  // the stale 'times' left behind.
+  opt.setStartTime(0);
+  opt.setDuration(6);
+  opt.setSteps(3);
+  const ls::DoubleMatrix* result = nullptr;
+  EXPECT_NO_THROW(result = rr.simulate());
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->numRows(), 4);
+  EXPECT_EQ(result->Element(0, 0), 0);
+  EXPECT_EQ(result->Element(3, 0), 6);
+}
+
+TEST_F(ModelAnalysisTests, issue1339_largerTimesAfterTimes) {
+  RoadRunner rr((modelAnalysisModelsDir / "no_steady_state.xml").string());
+
+  // Times-based simulation with a shorter vector.
+  std::vector<double> times1{ 0, 5, 10 };
+  SimulateOptions& opt = rr.getSimulateOptions();
+  opt.setTimes(times1);
+  rr.simulate();
+  rr.reset();
+
+  // Switch to a longer times vector, without calling setSteps in between:
+  // setTimes itself must clear whatever 'steps' the previous call left.
+  std::vector<double> times2{ 0, 1, 2, 3, 10 };
+  opt.setTimes(times2);
+  const ls::DoubleMatrix* result = nullptr;
+  EXPECT_NO_THROW(result = rr.simulate());
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->numRows(), times2.size());
+  for (size_t i = 0; i < times2.size(); i++) {
+    EXPECT_EQ(result->Element(i, 0), times2[i]);
+  }
+}
+
+TEST_F(ModelAnalysisTests, issue1339_smallerTimesAfterTimes) {
+  RoadRunner rr((modelAnalysisModelsDir / "no_steady_state.xml").string());
+
+  // Times-based simulation with a longer vector.
+  std::vector<double> times1{ 0, 1, 2, 3, 10 };
+  SimulateOptions& opt = rr.getSimulateOptions();
+  opt.setTimes(times1);
+  rr.simulate();
+  rr.reset();
+
+  // Switch to a shorter times vector, without calling setSteps in between:
+  // setTimes itself must clear whatever 'steps' the previous call left.
+  std::vector<double> times2{ 0, 5, 10 };
+  opt.setTimes(times2);
+  const ls::DoubleMatrix* result = nullptr;
+  EXPECT_NO_THROW(result = rr.simulate());
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->numRows(), times2.size());
+  for (size_t i = 0; i < times2.size(); i++) {
+    EXPECT_EQ(result->Element(i, 0), times2[i]);
+  }
+}
+
 TEST_F(ModelAnalysisTests, issue1259) {
   BasicDictionary opt;
   opt.setItem("allow_approx", true);
@@ -61,7 +159,7 @@ TEST_F(ModelAnalysisTests, SimulateWithSameTimes) {
     times.push_back(1);
     times.push_back(10);
     SimulateOptions opt;
-    opt.times = times;
+    opt.setTimes(times);
     const ls::DoubleMatrix* result = rr.simulate(&opt);
     EXPECT_EQ(result->numRows(), 4);
     EXPECT_EQ(result->Element(0, 0), 0);
@@ -81,7 +179,7 @@ TEST_F(ModelAnalysisTests, SimulateWithSameTimes) {
 //    times.push_back(1);
 //    times.push_back(10);
 //    SimulateOptions opt;
-//    opt.times = times;
+//    opt.setTimes(times);
 //    const ls::DoubleMatrix* result = rr.simulate(&opt);
 //    EXPECT_EQ(result->numRows(), 4);
 //    EXPECT_EQ(result->Element(0, 0), 0);
@@ -101,7 +199,7 @@ TEST_F(ModelAnalysisTests, SimulateWithSameEndTimes) {
     times.push_back(10);
     times.push_back(10);
     SimulateOptions opt;
-    opt.times = times;
+    opt.setTimes(times);
     const ls::DoubleMatrix* result = rr.simulate(&opt);
     EXPECT_EQ(result->numRows(), 4);
     EXPECT_EQ(result->Element(0, 0), 0);
@@ -392,9 +490,9 @@ TEST_F(ModelAnalysisTests, SameJacobians1) {
     rr.setValue("Vli", 0.1 * (0.3 + (1 - 0.3 - 0.2)));
 
     SimulateOptions opt;
-    opt.start = 0;
-    opt.duration = 0.1;
-    opt.steps = 1;
+    opt.setStartTime(0);
+    opt.setDuration(0.1);
+    opt.setSteps(1);
     rr.simulate(&opt);
 
     double origVext = rr.getValue("Vext");
@@ -426,9 +524,9 @@ TEST_F(ModelAnalysisTests, SameJacobians2) {
     rr.setValue("Vli", 0.1 * (0.3 + (1 - 0.3 - 0.2)));
 
     SimulateOptions opt;
-    opt.start = 0;
-    opt.duration = 0.1;
-    opt.steps = 1;
+    opt.setStartTime(0);
+    opt.setDuration(0.1);
+    opt.setSteps(1);
     rr.simulate(&opt);
 
     double origVext = rr.getValue("Vext");
@@ -457,9 +555,9 @@ TEST_F(ModelAnalysisTests, SameJacobians3) {
     RoadRunner rr((modelAnalysisModelsDir / "apap_liver_core_volchange.xml").string());
 
     SimulateOptions opt;
-    opt.start = 0;
-    opt.duration = 1;
-    opt.steps = 10;
+    opt.setStartTime(0);
+    opt.setDuration(1);
+    opt.setSteps(10);
     rr.simulate(&opt);
 
     ls::DoubleMatrix jf = rr.getFullJacobian();
@@ -758,9 +856,9 @@ TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStartGeneral) {
     //Event:  at S1 > 500: S1 = 300;
     RoadRunner rr((modelAnalysisModelsDir / "negstart_event.xml").string());
     SimulateOptions opt;
-    opt.start = -2;
-    opt.duration = 10;
-    opt.steps = 120;
+    opt.setStartTime(-2);
+    opt.setDuration(10);
+    opt.setSteps(120);
     const ls::DoubleMatrix* result = rr.simulate(&opt);
     ASSERT_EQ(result->CSize(), 2);
     ASSERT_EQ(result->RSize(), 121);
@@ -778,9 +876,9 @@ TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStart_Time) {
     //Event:  at time > -1.1: S1 = 0;
     RoadRunner rr((modelAnalysisModelsDir / "negstart_event_time.xml").string());
     SimulateOptions opt;
-    opt.start = -2;
-    opt.duration = 10;
-    opt.steps = 120;
+    opt.setStartTime(-2);
+    opt.setDuration(10);
+    opt.setSteps(120);
     const ls::DoubleMatrix* result = rr.simulate(&opt);
     ASSERT_EQ(result->CSize(), 2);
     ASSERT_EQ(result->RSize(), 121);
@@ -795,9 +893,9 @@ TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStart_TimeDelay) {
     //Event:  at 0.5 after time > -1.1: S1 = 0;
     RoadRunner rr((modelAnalysisModelsDir / "negstart_event_time_delay.xml").string());
     SimulateOptions opt;
-    opt.start = -2;
-    opt.duration = 10;
-    opt.steps = 120;
+    opt.setStartTime(-2);
+    opt.setDuration(10);
+    opt.setSteps(120);
     const ls::DoubleMatrix* result = rr.simulate(&opt);
     ASSERT_EQ(result->CSize(), 2);
     ASSERT_EQ(result->RSize(), 121);
@@ -812,9 +910,9 @@ TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStart_T0fire) {
     //Event:  at S1 > 500, t0=false: S1 = 300;
     RoadRunner rr((modelAnalysisModelsDir / "negstart_event_t0fire.xml").string());
     SimulateOptions opt;
-    opt.start = -2;
-    opt.duration = 10;
-    opt.steps = 120;
+    opt.setStartTime(-2);
+    opt.setDuration(10);
+    opt.setSteps(120);
     const ls::DoubleMatrix* result = rr.simulate(&opt);
     ASSERT_EQ(result->CSize(), 2);
     ASSERT_EQ(result->RSize(), 121);
@@ -832,9 +930,9 @@ TEST_F(ModelAnalysisTests, SimulateCVODEFromNegativeStart_Combo) {
     //         E2: at 0.5 after S1 > 500: S1 = 300;
     RoadRunner rr((modelAnalysisModelsDir / "negstart_event_combo.xml").string());
     SimulateOptions opt;
-    opt.start = -2;
-    opt.duration = 10;
-    opt.steps = 120;
+    opt.setStartTime(-2);
+    opt.setDuration(10);
+    opt.setSteps(120);
     const ls::DoubleMatrix* result = rr.simulate(&opt);
     ASSERT_EQ(result->CSize(), 2);
     ASSERT_EQ(result->RSize(), 121);
@@ -854,9 +952,9 @@ TEST_F(ModelAnalysisTests, DISABLED_SimulateCVODEFromNegativeStart_T0fireDelay) 
     //Event:  at 0.5 after S1 > 500, t0=false: S1 = 300;
     RoadRunner rr((modelAnalysisModelsDir / "negstart_event_t0fire_delay.xml").string());
     SimulateOptions opt;
-    opt.start = -2;
-    opt.duration = 10;
-    opt.steps = 120;
+    opt.setStartTime(-2);
+    opt.setDuration(10);
+    opt.setSteps(120);
     const ls::DoubleMatrix* result = rr.simulate(&opt);
     ASSERT_EQ(result->CSize(), 2);
     ASSERT_EQ(result->RSize(), 121);
@@ -877,12 +975,12 @@ TEST_F(ModelAnalysisTests, SimulateGillespieFromNegativeStart_General) {
     rr.getIntegrator()->setValue("seed", -1);
     //std::cout << rr.getSeed("gillespie") << std::endl;
     SimulateOptions opt;
-    opt.start = -2;
-    opt.duration = 10;
-    opt.steps = 120;
+    opt.setStartTime(-2);
+    opt.setDuration(10);
+    opt.setSteps(120);
     const ls::DoubleMatrix* result = rr.simulate(&opt);
 
-    for (int i = 0; i <= opt.steps; i++)
+    for (int i = 0; i <= opt.getSteps(); i++)
     {
         EXPECT_LE(result->Element(i, 1), 500);
         EXPECT_GE(result->Element(i, 1), 300);
@@ -896,13 +994,13 @@ TEST_F(ModelAnalysisTests, SimulateGillespieFromNegativeStart_T0fire) {
     rr.getIntegrator()->setValue("variable_step_size", false);
     rr.getIntegrator()->setValue("seed", -1);
     SimulateOptions opt;
-    opt.start = -2;
-    opt.duration = 10;
-    opt.steps = 120;
+    opt.setStartTime(-2);
+    opt.setDuration(10);
+    opt.setSteps(120);
     const ls::DoubleMatrix* result = rr.simulate(&opt);
 
     EXPECT_EQ(result->Element(0, 1), 300);
-    for (int i = 1; i <= opt.steps; i++)
+    for (int i = 1; i <= opt.getSteps(); i++)
     {
         EXPECT_LE(result->Element(i, 1), 500);
         EXPECT_GE(result->Element(i, 1), 300);
@@ -915,19 +1013,19 @@ TEST_F(ModelAnalysisTests, NonZeroStarts_CVODE) {
     rr.setIntegrator("cvode");
     //rr.getIntegrator()->setValue("variable_step_size", false);
     SimulateOptions opt;
-    opt.start = 0;
-    opt.duration = 10;
-    opt.steps = 50;
+    opt.setStartTime(0);
+    opt.setDuration(10);
+    opt.setSteps(50);
     ls::DoubleMatrix s0result(*(rr.simulate(&opt)));
     rr.reset(int(SelectionRecord::SelectionType::ALL));
-    opt.start = -2;
+    opt.setStartTime(-2);
     ls::DoubleMatrix sneg2result(*(rr.simulate(&opt)));
     rr.reset(int(SelectionRecord::SelectionType::ALL));
-    opt.start = 2;
+    opt.setStartTime(2);
     ls::DoubleMatrix s2result(*(rr.simulate(&opt)));
 
 
-    for (int i = 0; i <= opt.steps; i++)
+    for (int i = 0; i <= opt.getSteps(); i++)
     {
         EXPECT_NEAR(s0result.Element(i, 0), sneg2result.Element(i, 0) + 2, 0.01);
         EXPECT_NEAR(s0result.Element(i, 0), s2result.Element(i, 0) - 2, 0.01);
@@ -946,18 +1044,18 @@ TEST_F(ModelAnalysisTests, NonZeroStarts_RK4) {
     rr.setIntegrator("rk4");
     //rr.getIntegrator()->setValue("variable_step_size", false);
     SimulateOptions opt;
-    opt.start = 0;
-    opt.duration = 10;
-    opt.steps = 50;
+    opt.setStartTime(0);
+    opt.setDuration(10);
+    opt.setSteps(50);
     ls::DoubleMatrix s0result(*(rr.simulate(&opt)));
     rr.reset(int(SelectionRecord::SelectionType::ALL));
-    opt.start = -2;
+    opt.setStartTime(-2);
     ls::DoubleMatrix sneg2result(*(rr.simulate(&opt)));
     rr.reset(int(SelectionRecord::SelectionType::ALL));
-    opt.start = 2;
+    opt.setStartTime(2);
     ls::DoubleMatrix s2result(*(rr.simulate(&opt)));
 
-    for (int i = 0; i <= opt.steps; i++)
+    for (int i = 0; i <= opt.getSteps(); i++)
     {
         EXPECT_NEAR(s0result.Element(i, 0), sneg2result.Element(i, 0) + 2, 0.01);
         EXPECT_NEAR(s0result.Element(i, 0), s2result.Element(i, 0) - 2, 0.01);
@@ -977,18 +1075,18 @@ TEST_F(ModelAnalysisTests, NonZeroStarts_RK45) {
     rr.setIntegrator("rk45");
     rr.getIntegrator()->setValue("variable_step_size", false);
     SimulateOptions opt;
-    opt.start = 0;
-    opt.duration = 10;
-    opt.steps = 50;
+    opt.setStartTime(0);
+    opt.setDuration(10);
+    opt.setSteps(50);
     ls::DoubleMatrix s0result(*(rr.simulate(&opt)));
     rr.reset(int(SelectionRecord::SelectionType::ALL));
-    opt.start = -2;
+    opt.setStartTime(-2);
     ls::DoubleMatrix sneg2result(*(rr.simulate(&opt)));
     rr.reset(int(SelectionRecord::SelectionType::ALL));
-    opt.start = 2;
+    opt.setStartTime(2);
     ls::DoubleMatrix s2result(*(rr.simulate(&opt)));
 
-    for (int i = 0; i <= opt.steps; i++)
+    for (int i = 0; i <= opt.getSteps(); i++)
     {
         EXPECT_NEAR(s0result.Element(i, 0), sneg2result.Element(i, 0) + 2, 0.01);
         EXPECT_NEAR(s0result.Element(i, 0), s2result.Element(i, 0) - 2, 0.01);
@@ -1007,20 +1105,20 @@ TEST_F(ModelAnalysisTests, NonZeroStarts_Gillespie) {
     rr.getIntegrator()->setValue("variable_step_size", false);
     rr.getIntegrator()->setValue("seed", 1001);
     SimulateOptions opt;
-    opt.start = 0;
-    opt.duration = 10;
-    opt.steps = 50;
+    opt.setStartTime(0);
+    opt.setDuration(10);
+    opt.setSteps(50);
     ls::DoubleMatrix s0result(*(rr.simulate(&opt)));
     rr.reset(int(SelectionRecord::SelectionType::ALL));
     rr.getIntegrator()->setValue("seed", 1001);
-    opt.start = -2;
+    opt.setStartTime(-2);
     ls::DoubleMatrix sneg2result(*(rr.simulate(&opt)));
     rr.reset(int(SelectionRecord::SelectionType::ALL));
     rr.getIntegrator()->setValue("seed", 1001);
-    opt.start = 2;
+    opt.setStartTime(2);
     ls::DoubleMatrix s2result(*(rr.simulate(&opt)));
 
-    for (int i = 0; i <= opt.steps; i++)
+    for (int i = 0; i <= opt.getSteps(); i++)
     {
         EXPECT_NEAR(s0result.Element(i, 0), sneg2result.Element(i, 0) + 2, 0.01);
         EXPECT_NEAR(s0result.Element(i, 0), s2result.Element(i, 0) - 2, 0.01);
@@ -1834,13 +1932,13 @@ TEST_F(ModelAnalysisTests, SimulateGillespieZeroDuration) {
     RoadRunner *rr = new RoadRunner((modelAnalysisModelsDir / "BIOMD0000000035_url.xml").string());
     rr->setIntegrator("gillespie");
     SimulateOptions opts = rr->getSimulateOptions();
-    opts.duration = 0;
-    opts.steps = 100;
+    opts.setDuration(0);
+    opts.setSteps(100);
 
     const ls::DoubleMatrix *results = rr->simulate(&opts);
     EXPECT_EQ(results->RSize(), 100);
 
-    opts.steps = 1000;
+    opts.setSteps(1000);
     results = rr->simulate(&opts);
     EXPECT_EQ(results->RSize(), 1000);
 
@@ -1851,13 +1949,13 @@ TEST_F(ModelAnalysisTests, SimulateGillespieDuration) {
     RoadRunner *rr = new RoadRunner((modelAnalysisModelsDir / "BIOMD0000000035_url.xml").string());
     rr->setIntegrator("gillespie");
     SimulateOptions opts = rr->getSimulateOptions();
-    opts.duration = 0.5;
+    opts.setDuration(0.5);
 
     const ls::DoubleMatrix *results = rr->simulate(&opts);
     EXPECT_NEAR(results->Element(results->numRows() - 1, 0), 0.5, 0.0001);
 
-    opts.start = 0;
-    opts.duration = 0.7;
+    opts.setStartTime(0);
+    opts.setDuration(0.7);
     results = rr->simulate(&opts);
     EXPECT_NEAR(results->Element(results->numRows() - 1, 0), 0.7, 0.0001);
 
@@ -1867,9 +1965,9 @@ TEST_F(ModelAnalysisTests, SimulateGillespieDuration) {
 TEST_F(ModelAnalysisTests, SimulateAccordingToDocs) {
     RoadRunner rr((modelAnalysisModelsDir / "BIOMD0000000035_url.xml").string());
     SimulateOptions opt;
-    opt.start = 0;
-    opt.duration = 10;
-    opt.steps = 1000;
+    opt.setStartTime(0);
+    opt.setDuration(10);
+    opt.setSteps(1000);
     const ls::DoubleMatrix* result = rr.simulate(&opt);
 
 }
@@ -1882,7 +1980,7 @@ TEST_F(ModelAnalysisTests, SimulateWithTimes) {
     times.push_back(5);
     times.push_back(10);
     SimulateOptions opt;
-    opt.times = times;
+    opt.setTimes(times);
     const ls::DoubleMatrix* result = rr.simulate(&opt);
     EXPECT_EQ(result->numRows(), 4);
     EXPECT_EQ(result->Element(0, 0), 0);
@@ -1905,6 +2003,7 @@ TEST_F(ModelAnalysisTests, SimulateWithTimesFunction) {
     EXPECT_EQ(result->Element(2, 0), 5);
     EXPECT_EQ(result->Element(3, 0), 10);
 }
+
 
 TEST_F(ModelAnalysisTests, ResetAfterControlCalc) {
     RoadRunner rr((modelAnalysisModelsDir / "conserved_cycle.xml").string());

--- a/test/python/test_python_api.py
+++ b/test/python/test_python_api.py
@@ -21,6 +21,7 @@ try:
         LinesearchNewtonIteration,
         NLEQ1Solver,
         NLEQ2Solver,
+        SimulateOptions,
     )
 
 
@@ -35,6 +36,7 @@ except ImportError:
         LinesearchNewtonIteration,
         NLEQ1Solver,
         NLEQ2Solver,
+        SimulateOptions,
     )
 
 # note, we can also just import test models directly
@@ -1227,10 +1229,66 @@ class RoadRunnerTests(unittest.TestCase):
     def test_simulateWithNumpyIntTimes(self):
         self.rr.resetToOrigin()
         numpy_intvec = numpy.array([0, 1, 5, 10])
-        
+
         self.rr.simulate(times = numpy_intvec)
         result = self.rr.getSimulationData()
         self.assertEqual(list(result[:,0]), [0, 1, 5, 10])
+
+    # https://github.com/sys-bio/roadrunner/issues/1339
+    # SimulateOptions is a long-lived object that gets mutated field-by-field
+    # across repeated simulations, both from the C API and here, where 'opt'
+    # is reused across two _simulate(opt) calls exactly like the C API reuses
+    # its persistent options object. Setting 'opt.start'/'opt.end'/'opt.steps'
+    # or 'opt.times' should each clear whichever of the other is now stale,
+    # so times-mode and steps-mode are always freely interleavable regardless
+    # of what a previous call left set on 'opt'.
+
+    def test_simulateOptions_timesAfterSteps(self):
+        opt = SimulateOptions()
+        opt.start = 0
+        opt.end = 9
+        opt.steps = 3
+        self.rr._simulate(opt)
+        self.rr.reset()
+
+        times = [0, 1, 2, 9]
+        opt.times = times
+        result = self.rr._simulate(opt)
+        self.assertEqual(list(result[:, 0]), times)
+
+    def test_simulateOptions_stepsAfterTimes(self):
+        opt = SimulateOptions()
+        opt.times = [0, 1, 5, 10, 20]
+        self.rr._simulate(opt)
+        self.rr.reset()
+
+        opt.start = 0
+        opt.end = 6
+        opt.steps = 3
+        result = self.rr._simulate(opt)
+        self.assertEqual(list(result[:, 0]), [0, 2, 4, 6])
+
+    def test_simulateOptions_largerTimesAfterTimes(self):
+        opt = SimulateOptions()
+        opt.times = [0, 5, 10]
+        self.rr._simulate(opt)
+        self.rr.reset()
+
+        times2 = [0, 1, 2, 3, 10]
+        opt.times = times2
+        result = self.rr._simulate(opt)
+        self.assertEqual(list(result[:, 0]), times2)
+
+    def test_simulateOptions_smallerTimesAfterTimes(self):
+        opt = SimulateOptions()
+        opt.times = [0, 1, 2, 3, 10]
+        self.rr._simulate(opt)
+        self.rr.reset()
+
+        times2 = [0, 5, 10]
+        opt.times = times2
+        result = self.rr._simulate(opt)
+        self.assertEqual(list(result[:, 0]), times2)
 
 
 if __name__ == "__main__":

--- a/test/sbml_features/boolean_delay.cpp
+++ b/test/sbml_features/boolean_delay.cpp
@@ -26,10 +26,10 @@ TEST_F(SBMLFeatures, BOOLEAN_DELAY_1)
     {
         RoadRunner rri((SBMLFeaturesDir / "boolean_trigger.l3v2.xml").string());
         rri.validateCurrentSBML();
-        rri.getSimulateOptions().duration = 2;
+        rri.getSimulateOptions().setDuration(2);
         rri.simulate();
         EXPECT_EQ(rri.getValue(rri.createSelection("x")), 0.0);
-        rri.getSimulateOptions().start = 0.1;
+        rri.getSimulateOptions().setStartTime(0.1);
         rri.simulate();
         EXPECT_EQ(rri.getValue(rri.createSelection("x")), 3);
     }
@@ -45,10 +45,10 @@ TEST_F(SBMLFeatures, BOOLEAN_DELAY_2)
     {
         RoadRunner rri((SBMLFeaturesDir / "boolean_trigger_2.l3v2.xml").string());
         rri.validateCurrentSBML();
-        rri.getSimulateOptions().duration = 1;
+        rri.getSimulateOptions().setDuration(1);
         rri.simulate();
         EXPECT_EQ(rri.getValue(rri.createSelection("x")), 0.0);
-        rri.getSimulateOptions().start = 0.1;
+        rri.getSimulateOptions().setStartTime(0.1);
         rri.simulate();
         EXPECT_EQ(rri.getValue(rri.createSelection("x")), 3);
     }

--- a/test/sbml_features/rateOf.cpp
+++ b/test/sbml_features/rateOf.cpp
@@ -29,7 +29,7 @@ TEST_F(SBMLFeatures, RATEOF_RNX1)
     try
     {
         RoadRunner rri((SBMLFeaturesDir / "rateOf_1reaction.xml").string());
-        rri.getSimulateOptions().duration = 2;
+        rri.getSimulateOptions().setDuration(2);
         rri.simulate();
         EXPECT_EQ(rri.getValue(rri.createSelection("s2")), 1.2);
     }
@@ -45,7 +45,7 @@ TEST_F(SBMLFeatures, RATEOF_AR1)
     try
     {
         RoadRunner rri((SBMLFeaturesDir / "rateOf_assignmentRule1.xml").string());
-        rri.getSimulateOptions().duration = 2;
+        rri.getSimulateOptions().setDuration(2);
         rri.simulate();
         EXPECT_EQ(rri.getValue(rri.createSelection("s2")), 0.0);
     }
@@ -63,7 +63,7 @@ TEST_F(SBMLFeatures, RATEOF_AR2)
         RoadRunner rri((SBMLFeaturesDir / "rateOf_assignmentRule2.xml").string());
         EXPECT_EQ(rri.getValue(rri.createSelection("s2")), 1.0);
         EXPECT_EQ(rri.getValue(rri.createSelection("s1'")), 1.0);
-        rri.getSimulateOptions().duration = 1;
+        rri.getSimulateOptions().setDuration(1);
         rri.simulate();
         EXPECT_EQ(rri.getValue(rri.createSelection("s2")), 1.0);
         EXPECT_NEAR(rri.getValue(rri.createSelection("s1")), 6.0, 0.0001);

--- a/test/serialization/state_saving.cpp
+++ b/test/serialization/state_saving.cpp
@@ -669,23 +669,25 @@ TEST_F(StateSavingTests, SaveThenLoadAndSimulateCase1120) {
 
 TEST_F(StateSavingTests, SAVE_STATE_19) {
     ASSERT_TRUE(RunStateSavingTest([](RoadRunner *rri, std::string fname) {
-        rri->getSimulateOptions().duration /= 2;
-        rri->getSimulateOptions().steps /= 2;
+        SimulateOptions& opt = rri->getSimulateOptions();
+        opt.setDuration(opt.getDuration() / 2);
+        opt.setSteps(opt.getSteps() / 2);
         rri->simulate();
         rri->saveState(fname);
         rri->loadState(fname);
-        rri->getSimulateOptions().start = rri->getSimulateOptions().duration;
+        opt.setStartTime(opt.getDuration());
     }, "l3v1"));
 }
 
 TEST_F(StateSavingTests, SAVE_STATE_20) {
     ASSERT_TRUE(RunStateSavingTest([](RoadRunner *rri, std::string fname) {
-        rri->getSimulateOptions().duration /= 2;
-        rri->getSimulateOptions().steps /= 2;
+        SimulateOptions& opt = rri->getSimulateOptions();
+        opt.setDuration(opt.getDuration() / 2);
+        opt.setSteps(opt.getSteps() / 2);
         rri->simulate();
         rri->saveState(fname);
         rri->loadState(fname);
-        rri->getSimulateOptions().start = rri->getSimulateOptions().duration;
+        opt.setStartTime(opt.getDuration());
     }));
 }
 

--- a/test/sundials-tests/CVODEIntegratorTests/CvodeIntegrationTest.h
+++ b/test/sundials-tests/CVODEIntegratorTests/CvodeIntegrationTest.h
@@ -55,11 +55,11 @@ public:
             } else if (setting.first == "copy_result") {
                 opt.copy_result = setting.second;
             } else if (setting.first == "steps") {
-                opt.steps = setting.second;
+                opt.setSteps(setting.second);
             } else if (setting.first == "start") {
-                opt.start = setting.second;
+                opt.setStartTime(setting.second);
             } else if (setting.first == "duration") {
-                opt.duration = setting.second;
+                opt.setDuration(setting.second);
             }
 
             // then try applying integration level settings.

--- a/wrappers/C/rrc_api.cpp
+++ b/wrappers/C/rrc_api.cpp
@@ -562,7 +562,7 @@ bool rrcCallConv setTimeStart(RRHandle handle, const double timeStart)
 {
     start_try
         RoadRunner* rri = castToRoadRunner(handle);
-        rri->getSimulateOptions().start = timeStart;
+        rri->getSimulateOptions().setStartTime(timeStart);
         return true;
     catch_bool_macro
 }
@@ -572,7 +572,7 @@ bool rrcCallConv setTimeEnd(RRHandle handle, const double timeEnd)
     start_try
         RoadRunner* rri = castToRoadRunner(handle);
         SimulateOptions &opt = rri->getSimulateOptions();
-        opt.duration = timeEnd - opt.start;
+        opt.setDuration(timeEnd - opt.getStartTime());
         return true;
     catch_bool_macro
 }
@@ -582,7 +582,7 @@ bool rrcCallConv setNumPoints(RRHandle handle, const int nrPoints)
     start_try
         RoadRunner* rri = castToRoadRunner(handle);
         SimulateOptions &opt = rri->getSimulateOptions();
-        opt.steps = nrPoints - 1;
+        opt.setSteps(nrPoints - 1);
         return true;
     catch_bool_macro
 }
@@ -592,11 +592,8 @@ bool rrcCallConv setTimes(RRHandle handle, const double* times, int size)
     start_try
         RoadRunner* rri = castToRoadRunner(handle);
         SimulateOptions& opt = rri->getSimulateOptions();
-        opt.times.clear();
-        for (int t = 0; t < size; t++)
-        {
-            opt.times.push_back(times[t]);
-        }
+        std::vector<double> newTimes(times, times + size);
+        opt.setTimes(newTimes);
         return true;
     catch_bool_macro
 }
@@ -605,7 +602,7 @@ bool rrcCallConv getTimeStart(RRHandle handle, double* timeStart)
 {
     start_try
         RoadRunner* rri = castToRoadRunner(handle);
-        *timeStart = rri->getSimulateOptions().start;
+        *timeStart = rri->getSimulateOptions().getStartTime();
         return true;
     catch_bool_macro
 }
@@ -614,7 +611,7 @@ bool rrcCallConv getTimeEnd(RRHandle handle, double* timeEnd)
 {
     start_try
         RoadRunner* rri = castToRoadRunner(handle);
-        *timeEnd = rri->getSimulateOptions().duration + rri->getSimulateOptions().start;
+        *timeEnd = rri->getSimulateOptions().getDuration() + rri->getSimulateOptions().getStartTime();
         return true;
     catch_bool_macro
 }
@@ -623,7 +620,7 @@ bool rrcCallConv getNumPoints(RRHandle handle, int* numPoints)
 {
     start_try
         RoadRunner* rri = castToRoadRunner(handle);
-        *numPoints = rri->getSimulateOptions().steps + 1;
+        *numPoints = rri->getSimulateOptions().getSteps() + 1;
         return true;
     catch_bool_macro
 }
@@ -3468,7 +3465,7 @@ C_DECL_SPEC RRCDataPtr rrcCallConv gillespieMeanOnGrid(RRHandle handle, int numb
         // Size the accumulator from the requested grid (o.steps, set by
         // setNumPoints/gillespieMeanOnGridEx) and the model's current
         // selection list.
-        int nRows = static_cast<int>(o.steps) + 1;
+        int nRows = static_cast<int>(o.getSteps()) + 1;
         const std::vector<SelectionRecord> &selections = rref.getSelections();
         int nCols = static_cast<int>(selections.size());
 
@@ -3540,7 +3537,7 @@ C_DECL_SPEC RRCDataPtr rrcCallConv gillespieMeanSDOnGrid(RRHandle handle, int nu
 
         // Size the grid and compute both avg and sum-of-squared-deviations in
         // the same pass.
-        int nRows = static_cast<int>(o.steps) + 1;
+        int nRows = static_cast<int>(o.getSteps()) + 1;
         const std::vector<SelectionRecord> &selections = rref.getSelections();
         int nCols = static_cast<int>(selections.size());
 

--- a/wrappers/C/rrc_api.h
+++ b/wrappers/C/rrc_api.h
@@ -1763,7 +1763,7 @@ C_DECL_SPEC bool rrcCallConv setNumPoints(RRHandle handle, int numberOfPoints);
  \return Returns true if successful
  \ingroup simulation
 */
-C_DECL_SPEC bool rrcCallConv setTimes(RRHandle handle, double* times, int size);
+C_DECL_SPEC bool rrcCallConv setTimes(RRHandle handle, const double* times, int size);
 
 
 /*!

--- a/wrappers/Java/roadrunner/jroadrunner.i
+++ b/wrappers/Java/roadrunner/jroadrunner.i
@@ -689,9 +689,9 @@ SWIGEXPORT jobjectArray JNICALL Java_roadrunner_roadrunnerJNI_jrr_1simulate_1(JN
   n = (int)jn;
 
   rr::SimulateOptions& opt = r->getSimulateOptions();
-  opt.start = tstart;
-  opt.duration = tend - tstart;
-  opt.steps = n;
+  opt.setStartTime(tstart);
+  opt.setDuration(tend - tstart);
+  opt.setSteps(n);
   //if(variable step?) {
   //  opt.integratorFlags |= Integrator::VARIABLE_STEP;
   //}
@@ -814,6 +814,16 @@ SWIGEXPORT jobjectArray JNICALL Java_roadrunner_roadrunnerJNI_jrr_1simulate_1(JN
     bool structuredResult;
     bool variableStep;
     bool copyResult;
+    // 'start'/'duration'/'steps' are private in C++ (backed by
+    // setStartTime/setDuration/setSteps, each of which clears a stale
+    // 'times' left by a previous call). These phantom members route
+    // assignment through those setters so the same guarantee applies from
+    // Java. 'times' (std::vector<double>) is deliberately not exposed as a
+    // property here -- use getTimes()/setTimes() directly, since there is
+    // no working std::vector<double> <-> Java array typemap in this file.
+    double start;
+    double duration;
+    int steps;
 
     std::string __repr__() {
         return ($self)->toRepr();
@@ -827,11 +837,35 @@ SWIGEXPORT jobjectArray JNICALL Java_roadrunner_roadrunnerJNI_jrr_1simulate_1(JN
 
 %{
     double rr_SimulateOptions_end_get(SimulateOptions* opt) {
-        return opt->start + opt->duration;
+        return opt->getStartTime() + opt->getDuration();
     }
 
     void rr_SimulateOptions_end_set(SimulateOptions* opt, double end) {
-        opt->duration = end - opt->start;
+        opt->setDuration(end - opt->getStartTime());
+    }
+
+    double rr_SimulateOptions_start_get(SimulateOptions* opt) {
+        return opt->getStartTime();
+    }
+
+    void rr_SimulateOptions_start_set(SimulateOptions* opt, double value) {
+        opt->setStartTime(value);
+    }
+
+    double rr_SimulateOptions_duration_get(SimulateOptions* opt) {
+        return opt->getDuration();
+    }
+
+    void rr_SimulateOptions_duration_set(SimulateOptions* opt, double value) {
+        opt->setDuration(value);
+    }
+
+    int rr_SimulateOptions_steps_get(SimulateOptions* opt) {
+        return opt->getSteps();
+    }
+
+    void rr_SimulateOptions_steps_set(SimulateOptions* opt, int value) {
+        opt->setSteps(value);
     }
 
     bool rr_SimulateOptions_resetModel_get(SimulateOptions* opt) {

--- a/wrappers/Python/roadrunner/roadrunner.i
+++ b/wrappers/Python/roadrunner/roadrunner.i
@@ -1213,7 +1213,7 @@ namespace std { class ostream{}; }
             PyErr_Format(PyExc_TypeError, "The argument must be of list or subtype of list.");
             return;
         }
-        opt->times.clear();
+        std::vector<double> newTimes;
         for (unsigned int j = 0; j < PyList_Size(list); ++j) {
             PyObject* pval = PyList_GetItem(list, j);
             double val;
@@ -1228,8 +1228,9 @@ namespace std { class ostream{}; }
                 PyErr_Format(PyExc_TypeError, "The entries in the list must be numbers.");
                 return;
             }
-            opt->times.push_back(val);
+            newTimes.push_back(val);
         }
+        opt->setTimes(newTimes);
      }
 
     /**
@@ -2136,6 +2137,14 @@ namespace std { class ostream{}; }
     double end;
     bool structuredResult;
     bool copyResult;
+    // 'start'/'duration'/'steps' are private in C++ (backed by
+    // setStartTime/setDuration/setSteps, each of which clears a stale
+    // 'times' left by a previous call). These phantom members route
+    // 'opt.start = 5' etc. through those setters so the same guarantee
+    // applies from Python.
+    double start;
+    double duration;
+    int steps;
 
     std::string __repr__() {
         return ($self)->toRepr();
@@ -2159,6 +2168,46 @@ namespace std { class ostream{}; }
         return SWIG_NewPointerObj(SWIG_as_voidptr(other), SWIGTYPE_p_rr__SimulateOptions, SWIG_POINTER_OWN );
     }
 
+    /**
+     * 'times' needs custom (not phantom-member) handling: there's no
+     * automatic Python list <-> std::vector<double> typemap in this file,
+     * so 'times' is implemented as an explicit Python property below,
+     * mirroring RoadRunner::_setSimulateOptionsTimes.
+     */
+    PyObject *_getTimes() {
+        const std::vector<double>& t = ($self)->getTimes();
+        size_t size = t.size();
+        PyObject *pyList = PyList_New(size);
+        for (size_t j = 0; j < size; ++j) {
+            PyList_SET_ITEM(pyList, j, PyFloat_FromDouble(t[j]));
+        }
+        return pyList;
+    }
+
+    void _setTimes(PyObject* list) {
+        if (!PyList_Check(list)) {
+            PyErr_Format(PyExc_TypeError, "The argument must be of list or subtype of list.");
+            return;
+        }
+        std::vector<double> newTimes;
+        for (unsigned int j = 0; j < PyList_Size(list); ++j) {
+            PyObject* pval = PyList_GetItem(list, j);
+            double val;
+            if (PyFloat_Check(pval)) {
+                val = PyFloat_AsDouble(pval);
+            }
+            else if (PyArray_IsIntegerScalar(pval)) {
+                val = PyInt_AsLong(pval);
+            }
+            else {
+                PyErr_Format(PyExc_TypeError, "The entries in the list must be numbers.");
+                return;
+            }
+            newTimes.push_back(val);
+        }
+        ($self)->setTimes(newTimes);
+    }
+
     %pythoncode %{
         def getListener(self):
             return self._getListener()
@@ -2168,17 +2217,25 @@ namespace std { class ostream{}; }
                 self._clearListener()
             else:
                 self._setListener(listener)
+
+        def _getTimesProperty(self):
+            return self._getTimes()
+
+        def _setTimesProperty(self, value):
+            self._setTimes(list(value))
+
+        times = property(_getTimesProperty, _setTimesProperty)
     %}
 
 }
 
 %{
     double rr_SimulateOptions_end_get(SimulateOptions* opt) {
-        return opt->start + opt->duration;
+        return opt->getStartTime() + opt->getDuration();
     }
 
     void rr_SimulateOptions_end_set(SimulateOptions* opt, double end) {
-        opt->duration = end - opt->start;
+        opt->setDuration(end - opt->getStartTime());
     }
 
     bool rr_SimulateOptions_structuredResult_get(SimulateOptions* opt) {
@@ -2195,6 +2252,30 @@ namespace std { class ostream{}; }
 
     void rr_SimulateOptions_copyResult_set(SimulateOptions* opt, bool value) {
         opt->copy_result = value;
+    }
+
+    double rr_SimulateOptions_start_get(SimulateOptions* opt) {
+        return opt->getStartTime();
+    }
+
+    void rr_SimulateOptions_start_set(SimulateOptions* opt, double value) {
+        opt->setStartTime(value);
+    }
+
+    double rr_SimulateOptions_duration_get(SimulateOptions* opt) {
+        return opt->getDuration();
+    }
+
+    void rr_SimulateOptions_duration_set(SimulateOptions* opt, double value) {
+        opt->setDuration(value);
+    }
+
+    int rr_SimulateOptions_steps_get(SimulateOptions* opt) {
+        return opt->getSteps();
+    }
+
+    void rr_SimulateOptions_steps_set(SimulateOptions* opt, int value) {
+        opt->setSteps(value);
     }
 %}
 


### PR DESCRIPTION
Extensive fix:  changed the interface for SimulateOptions so that you now set the member variables with setters and getters, so that it's now impossible to have internally-inconsistent values:  if you set 'times', the start/end/duration values are cleared, and visa versa.

This in turn required many changes, and should not only fix the bug, but not allow similar bugs in the future.