### PR TITLE
Fix issues with some models failing to find steady state.

### DIFF
--- a/source/conservation/ConservedMoietyConverter.cpp
+++ b/source/conservation/ConservedMoietyConverter.cpp
@@ -435,12 +435,27 @@ static void createReorderedSpecies(Model* newModel, Model* oldModel,
     // remove all the existing independent species
     ListOfSpecies *species = newModel->getListOfSpecies();
 
+    // indSpecies/depSpecies are about to be (re)inserted fresh below --
+    // exclude them here so a species that's both structurally independent
+    // and constant/boundary (e.g. never a reactant or product, but also
+    // flagged constant) doesn't end up inserted twice.
+    std::set<std::string> reorderedSet(indSpecies.begin(), indSpecies.end());
+    reorderedSet.insert(depSpecies.begin(), depSpecies.end());
+
     unsigned index = 0;
 
     while(index < species->size())
     {
         Species *s = species->get(index);
-        if (!s->getBoundaryCondition())
+        // A constant, non-boundary species (e.g. one used only as a fixed
+        // parameter in kinetic laws) is bookkept as a boundary species
+        // elsewhere (see LLVMModelDataSymbols::initFloatingSpecies /
+        // initBoundarySpecies), so it must be kept here too, or symbols that
+        // reference it (e.g. an assignment rule for an independent species)
+        // would no longer resolve after conversion.
+        bool keep = (s->getBoundaryCondition() || s->getConstant())
+                && reorderedSet.find(s->getId()) == reorderedSet.end();
+        if (!keep)
         {
             species->remove(index);
             delete s;
@@ -793,8 +808,17 @@ static void conservedMoietyCheck(const SBMLDocument *doc)
 
         const Species *species = model->getSpecies(rule->getVariable());
 
+        // Only an AssignmentRule is safe to relax here: its RHS is inlined at
+        // every point of use, so the species it governs never enters the ODE
+        // state vector and (per speciesParticipatesInReactionStoichiometry's
+        // comment above) can never be chosen as a conservation law's
+        // eliminated species. A RateRule species has real, independently
+        // integrated dynamics regardless of whether it participates in any
+        // reaction's stoichiometry, so it must keep throwing unconditionally.
+        bool relaxable = rule->isAssignment()
+                && !speciesParticipatesInReactionStoichiometry(model, species ? species->getId() : "");
         if(species && !species->getBoundaryCondition() && model->getNumReactions() > 0
-                && speciesParticipatesInReactionStoichiometry(model, species->getId()))
+                && !relaxable)
         {
             std::string msg = "Cannot perform moiety conversion when floating "
                     "species are defined by rules. The floating species, "

--- a/source/conservation/ConservedMoietyConverter.cpp
+++ b/source/conservation/ConservedMoietyConverter.cpp
@@ -491,7 +491,8 @@ static void createReorderedSpecies(Model* newModel, Model* oldModel,
 
         assert(s && "could not get dependent species from original model");
 
-        newSpecies->insertAndOwn(index++, new ConservedMoietySpecies(*s, true));
+        bool hasOwnRule = oldModel->getRule(depSpecies[i]) != NULL;
+        newSpecies->insertAndOwn(index++, new ConservedMoietySpecies(*s, !hasOwnRule));
     }
 }
 
@@ -510,6 +511,13 @@ static std::vector<std::string> createConservedMoietyParameters(
 
     for (unsigned int i = 0; i < depSpecies.size(); ++i)
     {
+        if (newModel->getRule(depSpecies[i]) != NULL)
+        {
+            // species already has its own rule; it is not a real
+            // conserved moiety, so it needs no CSUM parameter.
+            continue;
+        }
+
         Poco::UUID uuid = uuidGen.create();
         std::string id = "_CSUM" + rr::toStringSize(i);
         std::replace( id.begin(), id.end(), '-', '_');
@@ -591,6 +599,13 @@ static void createDependentSpeciesRules(Model* newModel,
         if (dspecies == 0)
         {
             throw std::invalid_argument("model does not contain dependent species " + id);
+        }
+
+        if (newModel->getRule(id) != NULL)
+        {
+            // species already has its own rule; do not overwrite it with
+            // a bogus conserved-moiety rule.
+            continue;
         }
 
         bool isAmt = dspecies->getHasOnlySubstanceUnits();

--- a/source/conservation/ConservedMoietyConverter.cpp
+++ b/source/conservation/ConservedMoietyConverter.cpp
@@ -747,6 +747,38 @@ static inline void conservedMoietyException(const std::string& what)
     throw std::invalid_argument(what + help);
 }
 
+// Non-boundary species can be in rules only if they also do not appear in any reactions.
+static bool speciesParticipatesInReactionStoichiometry(const Model* model,
+        const std::string& speciesId)
+{
+    const ListOfReactions* reactions = model->getListOfReactions();
+
+    for (unsigned int i = 0; i < reactions->size(); ++i)
+    {
+        const Reaction* reaction = reactions->get(i);
+
+        const ListOfSpeciesReferences* reactants = reaction->getListOfReactants();
+        for (unsigned int j = 0; j < reactants->size(); ++j)
+        {
+            if (reactants->get(j)->getSpecies() == speciesId)
+            {
+                return true;
+            }
+        }
+
+        const ListOfSpeciesReferences* products = reaction->getListOfProducts();
+        for (unsigned int j = 0; j < products->size(); ++j)
+        {
+            if (products->get(j)->getSpecies() == speciesId)
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 static void conservedMoietyCheck(const SBMLDocument *doc)
 {
 
@@ -761,7 +793,8 @@ static void conservedMoietyCheck(const SBMLDocument *doc)
 
         const Species *species = model->getSpecies(rule->getVariable());
 
-        if(species && !species->getBoundaryCondition() && model->getNumReactions() > 0)
+        if(species && !species->getBoundaryCondition() && model->getNumReactions() > 0
+                && speciesParticipatesInReactionStoichiometry(model, species->getId()))
         {
             std::string msg = "Cannot perform moiety conversion when floating "
                     "species are defined by rules. The floating species, "

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -2048,7 +2048,17 @@ std::vector<std::string> LLVMExecutableModel::getRateRuleSymbols() const {
 int LLVMExecutableModel::getFloatingSpeciesAmounts(size_t len, const int* indx,
         double* values)
 {
-    return getValues(getFloatingSpeciesAmountPtr, len, indx, values);
+    int result = getValues(getFloatingSpeciesAmountPtr, len, indx, values);
+    if (len == 1) {
+        int j = indx ? indx[0] : 0;
+        std::cerr << "DIAG getFloatingSpeciesAmounts: index=" << j
+            << " modelData=" << (void*)modelData
+            << " floatingSpeciesAmountsAlias=" << (void*)modelData->floatingSpeciesAmountsAlias
+            << " numIndFloatingSpecies=" << modelData->numIndFloatingSpecies
+            << " funcPtr=" << (void*)getFloatingSpeciesAmountPtr
+            << " value=" << values[0] << std::endl;
+    }
+    return result;
 }
 
 int LLVMExecutableModel::setFloatingSpeciesAmounts(size_t len, int const* indx,

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -2049,17 +2049,6 @@ int LLVMExecutableModel::getFloatingSpeciesAmounts(size_t len, const int* indx,
         double* values)
 {
     int result = getValues(getFloatingSpeciesAmountPtr, len, indx, values);
-#if 0
-    if (len == 1) {
-        int j = indx ? indx[0] : 0;
-        std::cerr << "DIAG getFloatingSpeciesAmounts: index=" << j
-            << " modelData=" << (void*)modelData
-            << " floatingSpeciesAmountsAlias=" << (void*)modelData->floatingSpeciesAmountsAlias
-            << " numIndFloatingSpecies=" << modelData->numIndFloatingSpecies
-            << " funcPtr=" << (void*)getFloatingSpeciesAmountPtr
-            << " value=" << values[0] << std::endl;
-    }
-#endif
     return result;
 }
 

--- a/source/llvm/LLVMExecutableModel.cpp
+++ b/source/llvm/LLVMExecutableModel.cpp
@@ -2049,6 +2049,7 @@ int LLVMExecutableModel::getFloatingSpeciesAmounts(size_t len, const int* indx,
         double* values)
 {
     int result = getValues(getFloatingSpeciesAmountPtr, len, indx, values);
+#if 0
     if (len == 1) {
         int j = indx ? indx[0] : 0;
         std::cerr << "DIAG getFloatingSpeciesAmounts: index=" << j
@@ -2058,6 +2059,7 @@ int LLVMExecutableModel::getFloatingSpeciesAmounts(size_t len, const int* indx,
             << " funcPtr=" << (void*)getFloatingSpeciesAmountPtr
             << " value=" << values[0] << std::endl;
     }
+#endif
     return result;
 }
 

--- a/source/llvm/LLVMModelDataSymbols.cpp
+++ b/source/llvm/LLVMModelDataSymbols.cpp
@@ -21,6 +21,7 @@
 #pragma warning(default: 4624)
 #endif
 
+#include <iostream>
 #include "rr-libstruct/lsLibStructural.h"
 #include "rrLogger.h"
 #include "rrSparse.h"
@@ -171,6 +172,12 @@ LLVMModelDataSymbols::LLVMModelDataSymbols(const libsbml::Model *model, unsigned
 
             if (rule->getTypeCode() == SBML_ASSIGNMENT_RULE)
             {
+                if (rule->getVariable() == "W1" || rule->getVariable() == "S2") {
+                    char* diagFormula = SBML_formulaToL3String(rule->getMath());
+                    std::cerr << "DIAG LLVMModelDataSymbols ctor: assignmentRule variable="
+                        << rule->getVariable() << " formula=" << diagFormula << std::endl;
+                    free(diagFormula);
+                }
                 assignmentRules.insert(rule->getVariable());
             }
             else if (rule->getTypeCode() == SBML_RATE_RULE)
@@ -1181,6 +1188,12 @@ void LLVMModelDataSymbols::initFloatingSpecies(const libsbml::Model* model, bool
         }
 
         bool conservedMoiety = ConservationExtension::getConservedMoiety(*s);
+
+        if (sid == "W1" || sid == "S2" || sid == "Q" || sid == "A" || sid == "P2" || sid == "B") {
+            std::cerr << "DIAG initFloatingSpecies(" << sid << "): isIndependentElement="
+                << isIndependentElement(sid) << " conservedMoiety=" << conservedMoiety
+                << " hasAssignmentRule=" << hasAssignmentRule(sid) << std::endl;
+        }
 
         bool indInit = (!hasInitialAssignmentRule(sid) &&
                 (!hasAssignmentRule(sid) || conservedMoiety));

--- a/source/llvm/LLVMModelDataSymbols.cpp
+++ b/source/llvm/LLVMModelDataSymbols.cpp
@@ -945,7 +945,7 @@ void LLVMModelDataSymbols::initBoundarySpecies(const libsbml::Model* model)
         const Species* s = species->get(i);
         std::vector<std::string> quantities = ConservationExtension::getConservedQuantities(*s);
 
-        if (!s->getBoundaryCondition())
+        if (!s->getBoundaryCondition() && !s->getConstant())
         {
             continue;
         }
@@ -1146,8 +1146,14 @@ void LLVMModelDataSymbols::initFloatingSpecies(const libsbml::Model* model, bool
         const Species *s = species->get(i);
         std::vector<std::string> quantities = ConservationExtension::getConservedQuantities(*s);
 
-        if (s->getBoundaryCondition())
+        if (s->getBoundaryCondition() || s->getConstant())
         {
+            // Constant, non-boundary species (e.g. a species used only as a
+            // fixed parameter in rate laws) are processed as boundary
+            // species instead -- they have no ODE and are never touched by
+            // moiety or state-vector reduction, so treating them as
+            // floating species here would leave a structurally-zero row in
+            // the steady-state Jacobian.
             continue;
         }
 

--- a/source/llvm/LLVMModelDataSymbols.cpp
+++ b/source/llvm/LLVMModelDataSymbols.cpp
@@ -172,12 +172,14 @@ LLVMModelDataSymbols::LLVMModelDataSymbols(const libsbml::Model *model, unsigned
 
             if (rule->getTypeCode() == SBML_ASSIGNMENT_RULE)
             {
+#if 0
                 if (rule->getVariable() == "W1" || rule->getVariable() == "S2") {
                     char* diagFormula = SBML_formulaToL3String(rule->getMath());
                     std::cerr << "DIAG LLVMModelDataSymbols ctor: assignmentRule variable="
                         << rule->getVariable() << " formula=" << diagFormula << std::endl;
                     free(diagFormula);
                 }
+#endif
                 assignmentRules.insert(rule->getVariable());
             }
             else if (rule->getTypeCode() == SBML_RATE_RULE)
@@ -1189,11 +1191,13 @@ void LLVMModelDataSymbols::initFloatingSpecies(const libsbml::Model* model, bool
 
         bool conservedMoiety = ConservationExtension::getConservedMoiety(*s);
 
+#if 0
         if (sid == "W1" || sid == "S2" || sid == "Q" || sid == "A" || sid == "P2" || sid == "B") {
             std::cerr << "DIAG initFloatingSpecies(" << sid << "): isIndependentElement="
                 << isIndependentElement(sid) << " conservedMoiety=" << conservedMoiety
                 << " hasAssignmentRule=" << hasAssignmentRule(sid) << std::endl;
         }
+#endif
 
         bool indInit = (!hasInitialAssignmentRule(sid) &&
                 (!hasAssignmentRule(sid) || conservedMoiety));

--- a/source/llvm/LLVMModelDataSymbols.cpp
+++ b/source/llvm/LLVMModelDataSymbols.cpp
@@ -172,14 +172,6 @@ LLVMModelDataSymbols::LLVMModelDataSymbols(const libsbml::Model *model, unsigned
 
             if (rule->getTypeCode() == SBML_ASSIGNMENT_RULE)
             {
-#if 0
-                if (rule->getVariable() == "W1" || rule->getVariable() == "S2") {
-                    char* diagFormula = SBML_formulaToL3String(rule->getMath());
-                    std::cerr << "DIAG LLVMModelDataSymbols ctor: assignmentRule variable="
-                        << rule->getVariable() << " formula=" << diagFormula << std::endl;
-                    free(diagFormula);
-                }
-#endif
                 assignmentRules.insert(rule->getVariable());
             }
             else if (rule->getTypeCode() == SBML_RATE_RULE)
@@ -1191,13 +1183,6 @@ void LLVMModelDataSymbols::initFloatingSpecies(const libsbml::Model* model, bool
 
         bool conservedMoiety = ConservationExtension::getConservedMoiety(*s);
 
-#if 0
-        if (sid == "W1" || sid == "S2" || sid == "Q" || sid == "A" || sid == "P2" || sid == "B") {
-            std::cerr << "DIAG initFloatingSpecies(" << sid << "): isIndependentElement="
-                << isIndependentElement(sid) << " conservedMoiety=" << conservedMoiety
-                << " hasAssignmentRule=" << hasAssignmentRule(sid) << std::endl;
-        }
-#endif
 
         bool indInit = (!hasInitialAssignmentRule(sid) &&
                 (!hasAssignmentRule(sid) || conservedMoiety));

--- a/source/llvm/LLVMModelGenerator.cpp
+++ b/source/llvm/LLVMModelGenerator.cpp
@@ -21,7 +21,6 @@
 #include <rrLogger.h>
 #include <rrUtils.h>
 #include <Poco/Mutex.h>
-#include <iostream>
 
 #ifdef _MSC_VER
 #pragma warning(disable: 4146)
@@ -323,25 +322,10 @@ namespace rrllvm {
             auto transferFloatingSpecies = [&](int i, const std::string& id) {
                 double value = 0;
                 oldModel->getFloatingSpeciesAmounts(1, &i, &value);
-#if 0
-                if (id == "W1" || id == "S2" || id == "Q" || id == "A" || id == "P2" || id == "B") {
-                    std::cerr << "DIAG transferFloatingSpecies(" << id << "): oldValue=" << value << std::endl;
-                }
-#endif
                 try {
                     newModel->setValue(id, value);
-#if 0
-                    if (id == "W1" || id == "S2" || id == "Q" || id == "A" || id == "P2" || id == "B") {
-                        std::cerr << "DIAG transferFloatingSpecies(" << id << "): setValue SUCCEEDED" << std::endl;
-                    }
-#endif
                 }
                 catch (const exception& e) {
-#if 0
-                    if (id == "W1" || id == "S2" || id == "Q" || id == "A" || id == "P2" || id == "B") {
-                        std::cerr << "DIAG transferFloatingSpecies(" << id << "): setValue THREW: " << e.what() << std::endl;
-                    }
-#endif
                     rrLog(Logger::LOG_WARNING) << "regenerateModel: failed to transfer current "
                         "value for floating species '" << id << "' (value " << value
                         << "): " << e.what();
@@ -357,11 +341,6 @@ namespace rrllvm {
                 if (index >= 0) {
                     // new model has this species
                     bool isCM = newModel->symbols->isConservedMoietySpecies(id);
-#if 0
-                    if (id == "W1" || id == "S2" || id == "Q" || id == "A" || id == "P2" || id == "B") {
-                        std::cerr << "DIAG transfer loop(" << id << "): isConservedMoietySpecies=" << isCM << std::endl;
-                    }
-#endif
                     if (isCM) {
                         deferredConservedMoietySpecies.push_back(i);
                         continue;

--- a/source/llvm/LLVMModelGenerator.cpp
+++ b/source/llvm/LLVMModelGenerator.cpp
@@ -323,19 +323,25 @@ namespace rrllvm {
             auto transferFloatingSpecies = [&](int i, const std::string& id) {
                 double value = 0;
                 oldModel->getFloatingSpeciesAmounts(1, &i, &value);
+#if 0
                 if (id == "W1" || id == "S2" || id == "Q" || id == "A" || id == "P2" || id == "B") {
                     std::cerr << "DIAG transferFloatingSpecies(" << id << "): oldValue=" << value << std::endl;
                 }
+#endif
                 try {
                     newModel->setValue(id, value);
+#if 0
                     if (id == "W1" || id == "S2" || id == "Q" || id == "A" || id == "P2" || id == "B") {
                         std::cerr << "DIAG transferFloatingSpecies(" << id << "): setValue SUCCEEDED" << std::endl;
                     }
+#endif
                 }
                 catch (const exception& e) {
+#if 0
                     if (id == "W1" || id == "S2" || id == "Q" || id == "A" || id == "P2" || id == "B") {
                         std::cerr << "DIAG transferFloatingSpecies(" << id << "): setValue THREW: " << e.what() << std::endl;
                     }
+#endif
                     rrLog(Logger::LOG_WARNING) << "regenerateModel: failed to transfer current "
                         "value for floating species '" << id << "' (value " << value
                         << "): " << e.what();
@@ -351,9 +357,11 @@ namespace rrllvm {
                 if (index >= 0) {
                     // new model has this species
                     bool isCM = newModel->symbols->isConservedMoietySpecies(id);
+#if 0
                     if (id == "W1" || id == "S2" || id == "Q" || id == "A" || id == "P2" || id == "B") {
                         std::cerr << "DIAG transfer loop(" << id << "): isConservedMoietySpecies=" << isCM << std::endl;
                     }
+#endif
                     if (isCM) {
                         deferredConservedMoietySpecies.push_back(i);
                         continue;

--- a/source/llvm/LLVMModelGenerator.cpp
+++ b/source/llvm/LLVMModelGenerator.cpp
@@ -21,6 +21,7 @@
 #include <rrLogger.h>
 #include <rrUtils.h>
 #include <Poco/Mutex.h>
+#include <iostream>
 
 #ifdef _MSC_VER
 #pragma warning(disable: 4146)
@@ -322,10 +323,19 @@ namespace rrllvm {
             auto transferFloatingSpecies = [&](int i, const std::string& id) {
                 double value = 0;
                 oldModel->getFloatingSpeciesAmounts(1, &i, &value);
+                if (id == "W1" || id == "S2" || id == "Q" || id == "A" || id == "P2" || id == "B") {
+                    std::cerr << "DIAG transferFloatingSpecies(" << id << "): oldValue=" << value << std::endl;
+                }
                 try {
                     newModel->setValue(id, value);
+                    if (id == "W1" || id == "S2" || id == "Q" || id == "A" || id == "P2" || id == "B") {
+                        std::cerr << "DIAG transferFloatingSpecies(" << id << "): setValue SUCCEEDED" << std::endl;
+                    }
                 }
                 catch (const exception& e) {
+                    if (id == "W1" || id == "S2" || id == "Q" || id == "A" || id == "P2" || id == "B") {
+                        std::cerr << "DIAG transferFloatingSpecies(" << id << "): setValue THREW: " << e.what() << std::endl;
+                    }
                     rrLog(Logger::LOG_WARNING) << "regenerateModel: failed to transfer current "
                         "value for floating species '" << id << "' (value " << value
                         << "): " << e.what();
@@ -340,7 +350,11 @@ namespace rrllvm {
 
                 if (index >= 0) {
                     // new model has this species
-                    if (newModel->symbols->isConservedMoietySpecies(id)) {
+                    bool isCM = newModel->symbols->isConservedMoietySpecies(id);
+                    if (id == "W1" || id == "S2" || id == "Q" || id == "A" || id == "P2" || id == "B") {
+                        std::cerr << "DIAG transfer loop(" << id << "): isConservedMoietySpecies=" << isCM << std::endl;
+                    }
+                    if (isCM) {
                         deferredConservedMoietySpecies.push_back(i);
                         continue;
                     }

--- a/source/llvm/LLVMModelSymbols.cpp
+++ b/source/llvm/LLVMModelSymbols.cpp
@@ -397,8 +397,11 @@ void LLVMModelSymbols::processSpecies(SymbolForest &currentSymbols,
 
     assert(math);
 
-    if (species->getBoundaryCondition())
+    if (species->getBoundaryCondition() || species->getConstant())
     {
+        // Keep in sync with LLVMModelDataSymbols::initFloatingSpecies /
+        // initBoundarySpecies, which route constant non-boundary species
+        // into the boundary-species bucket as well.
         currentSymbols.boundarySpecies[species->getId()] = math;
     }
     else

--- a/source/llvm/ModelDataSymbolResolver.cpp
+++ b/source/llvm/ModelDataSymbolResolver.cpp
@@ -12,7 +12,6 @@
 #include "KineticLawParameterResolver.h"
 #include "rrLogger.h"
 #include <sbml/Model.h>
-#include <iostream>
 
 
 using namespace libsbml;
@@ -81,12 +80,6 @@ namespace rrllvm
         {
             SymbolForest::ConstIterator i = modelSymbols.getAssigmentRules().find(
                 symbol);
-#if 0
-            if (symbol == "W1" || symbol == "S2" || symbol == "Q") {
-                std::cerr << "DIAG loadSymbolValue(" << symbol << "): assignmentRules.find "
-                    << (i != modelSymbols.getAssigmentRules().end() ? "FOUND" : "not found") << std::endl;
-            }
-#endif
             if (i != modelSymbols.getAssigmentRules().end())
             {
                 recursiveSymbolPush(symbol);
@@ -100,14 +93,6 @@ namespace rrllvm
         /* Species */
         /*************************************************************************/
         const Species* species = model->getSpecies(symbol);
-#if 0
-        if (symbol == "W1" || symbol == "S2" || symbol == "Q") {
-            std::cerr << "DIAG loadSymbolValue(" << symbol << "): fell through to Species branch, "
-                << "species=" << (species ? "found" : "NULL")
-                << " isIndependentFloatingSpecies=" << (species && modelDataSymbols.isIndependentFloatingSpecies(symbol))
-                << std::endl;
-        }
-#endif
         if (species)
         {
             Value* amt = 0;

--- a/source/llvm/ModelDataSymbolResolver.cpp
+++ b/source/llvm/ModelDataSymbolResolver.cpp
@@ -12,6 +12,7 @@
 #include "KineticLawParameterResolver.h"
 #include "rrLogger.h"
 #include <sbml/Model.h>
+#include <iostream>
 
 
 using namespace libsbml;
@@ -80,6 +81,10 @@ namespace rrllvm
         {
             SymbolForest::ConstIterator i = modelSymbols.getAssigmentRules().find(
                 symbol);
+            if (symbol == "W1" || symbol == "S2" || symbol == "Q") {
+                std::cerr << "DIAG loadSymbolValue(" << symbol << "): assignmentRules.find "
+                    << (i != modelSymbols.getAssigmentRules().end() ? "FOUND" : "not found") << std::endl;
+            }
             if (i != modelSymbols.getAssigmentRules().end())
             {
                 recursiveSymbolPush(symbol);
@@ -93,6 +98,12 @@ namespace rrllvm
         /* Species */
         /*************************************************************************/
         const Species* species = model->getSpecies(symbol);
+        if (symbol == "W1" || symbol == "S2" || symbol == "Q") {
+            std::cerr << "DIAG loadSymbolValue(" << symbol << "): fell through to Species branch, "
+                << "species=" << (species ? "found" : "NULL")
+                << " isIndependentFloatingSpecies=" << (species && modelDataSymbols.isIndependentFloatingSpecies(symbol))
+                << std::endl;
+        }
         if (species)
         {
             Value* amt = 0;

--- a/source/llvm/ModelDataSymbolResolver.cpp
+++ b/source/llvm/ModelDataSymbolResolver.cpp
@@ -81,10 +81,12 @@ namespace rrllvm
         {
             SymbolForest::ConstIterator i = modelSymbols.getAssigmentRules().find(
                 symbol);
+#if 0
             if (symbol == "W1" || symbol == "S2" || symbol == "Q") {
                 std::cerr << "DIAG loadSymbolValue(" << symbol << "): assignmentRules.find "
                     << (i != modelSymbols.getAssigmentRules().end() ? "FOUND" : "not found") << std::endl;
             }
+#endif
             if (i != modelSymbols.getAssigmentRules().end())
             {
                 recursiveSymbolPush(symbol);
@@ -98,12 +100,14 @@ namespace rrllvm
         /* Species */
         /*************************************************************************/
         const Species* species = model->getSpecies(symbol);
+#if 0
         if (symbol == "W1" || symbol == "S2" || symbol == "Q") {
             std::cerr << "DIAG loadSymbolValue(" << symbol << "): fell through to Species branch, "
                 << "species=" << (species ? "found" : "NULL")
                 << " isIndependentFloatingSpecies=" << (species && modelDataSymbols.isIndependentFloatingSpecies(symbol))
                 << std::endl;
         }
+#endif
         if (species)
         {
             Value* amt = 0;

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1786,8 +1786,8 @@ namespace rr {
                 self.loadOpt.setConservedMoietyConversion(previousValue);
                 throw;
             }
-            impl->document.reset(olddoc);
-
+            //impl->document.reset(olddoc);
+            delete olddoc;
             // restore original reload value
             self.loadOpt.modelGeneratorOpt = savedOpt;
         }

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1281,7 +1281,14 @@ namespace rr {
                 break;
 
             case SelectionRecord::FLOATING_AMOUNT:
+                if (record.p1 == "W1" || record.p1 == "S2" || record.p1 == "Q") {
+                    std::cerr << "DIAG getValue(" << record.p1 << "): FLOATING_AMOUNT index="
+                        << record.index << std::endl;
+                }
                 impl->model->getFloatingSpeciesAmounts(1, &record.index, &dResult);
+                if (record.p1 == "W1" || record.p1 == "S2" || record.p1 == "Q") {
+                    std::cerr << "DIAG getValue(" << record.p1 << "): result=" << dResult << std::endl;
+                }
                 break;
 
             case SelectionRecord::BOUNDARY_AMOUNT:

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1281,18 +1281,7 @@ namespace rr {
                 break;
 
             case SelectionRecord::FLOATING_AMOUNT:
-#if 0
-                if (record.p1 == "W1" || record.p1 == "S2" || record.p1 == "Q") {
-                    std::cerr << "DIAG getValue(" << record.p1 << "): FLOATING_AMOUNT index="
-                        << record.index << std::endl;
-                }
-#endif
                 impl->model->getFloatingSpeciesAmounts(1, &record.index, &dResult);
-#if 0
-                if (record.p1 == "W1" || record.p1 == "S2" || record.p1 == "Q") {
-                    std::cerr << "DIAG getValue(" << record.p1 << "): result=" << dResult << std::endl;
-                }
-#endif
                 break;
 
             case SelectionRecord::BOUNDARY_AMOUNT:

--- a/source/rrRoadRunner.cpp
+++ b/source/rrRoadRunner.cpp
@@ -1281,14 +1281,18 @@ namespace rr {
                 break;
 
             case SelectionRecord::FLOATING_AMOUNT:
+#if 0
                 if (record.p1 == "W1" || record.p1 == "S2" || record.p1 == "Q") {
                     std::cerr << "DIAG getValue(" << record.p1 << "): FLOATING_AMOUNT index="
                         << record.index << std::endl;
                 }
+#endif
                 impl->model->getFloatingSpeciesAmounts(1, &record.index, &dResult);
+#if 0
                 if (record.p1 == "W1" || record.p1 == "S2" || record.p1 == "Q") {
                     std::cerr << "DIAG getValue(" << record.p1 << "): result=" << dResult << std::endl;
                 }
+#endif
                 break;
 
             case SelectionRecord::BOUNDARY_AMOUNT:

--- a/test/cxx_api_tests/StructuralAnalysisTests.cpp
+++ b/test/cxx_api_tests/StructuralAnalysisTests.cpp
@@ -149,195 +149,15 @@ public:
 
 };
 
-TEST_F(StructuralAnalysisTests, S2ValueUpdatesAfterConservedMoietyConversion) {
-  std::string sbml =
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-    "<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n"
-    "  <model id=\"AssignmentRuleChainMoiety\">\n"
-    "    <listOfCompartments>\n"
-    "      <compartment id=\"default_compartment\" spatialDimensions=\"3\" size=\"1\" constant=\"true\"/>\n"
-    "    </listOfCompartments>\n"
-    "    <listOfSpecies>\n"
-    "      <species id=\"Q\" compartment=\"default_compartment\" initialConcentration=\"2\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"P2\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"A\" compartment=\"default_compartment\" initialConcentration=\"3\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"B\" compartment=\"default_compartment\" initialConcentration=\"1\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"W1\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"S2\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "    </listOfSpecies>\n"
-    "    <listOfParameters>\n"
-    "      <parameter id=\"k1\" value=\"0.5\" constant=\"true\"/>\n"
-    "      <parameter id=\"kw1\" value=\"2\" constant=\"true\"/>\n"
-    "      <parameter id=\"ks2\" value=\"3\" constant=\"true\"/>\n"
-    "      <parameter id=\"k2\" value=\"0.8\" constant=\"true\"/>\n"
-    "      <parameter id=\"k3\" value=\"0.4\" constant=\"true\"/>\n"
-    "    </listOfParameters>\n"
-    "    <listOfRules>\n"
-    "      <assignmentRule variable=\"W1\">\n"
-    "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
-    "          <apply><times/><ci> kw1 </ci><ci> Q </ci></apply>\n"
-    "        </math>\n"
-    "      </assignmentRule>\n"
-    "      <assignmentRule variable=\"S2\">\n"
-    "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
-    "          <apply><times/><ci> ks2 </ci><ci> W1 </ci></apply>\n"
-    "        </math>\n"
-    "      </assignmentRule>\n"
-    "    </listOfRules>\n"
-    "    <listOfReactions>\n"
-    "      <reaction id=\"J1\" reversible=\"false\" fast=\"false\">\n"
-    "        <listOfReactants>\n"
-    "          <speciesReference species=\"Q\" stoichiometry=\"1\" constant=\"true\"/>\n"
-    "        </listOfReactants>\n"
-    "        <listOfProducts>\n"
-    "          <speciesReference species=\"P2\" stoichiometry=\"1\" constant=\"true\"/>\n"
-    "        </listOfProducts>\n"
-    "        <kineticLaw>\n"
-    "          <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
-    "            <apply><times/><ci> k1 </ci><ci> S2 </ci></apply>\n"
-    "          </math>\n"
-    "        </kineticLaw>\n"
-    "      </reaction>\n"
-    "      <reaction id=\"J2\" reversible=\"true\" fast=\"false\">\n"
-    "        <listOfReactants>\n"
-    "          <speciesReference species=\"A\" stoichiometry=\"1\" constant=\"true\"/>\n"
-    "        </listOfReactants>\n"
-    "        <listOfProducts>\n"
-    "          <speciesReference species=\"B\" stoichiometry=\"1\" constant=\"true\"/>\n"
-    "        </listOfProducts>\n"
-    "        <kineticLaw>\n"
-    "          <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
-    "            <apply><minus/>\n"
-    "              <apply><times/><ci> k2 </ci><ci> A </ci></apply>\n"
-    "              <apply><times/><ci> k3 </ci><ci> B </ci></apply>\n"
-    "            </apply>\n"
-    "          </math>\n"
-    "        </kineticLaw>\n"
-    "      </reaction>\n"
-    "    </listOfReactions>\n"
-    "  </model>\n"
-    "</sbml>";
-
-  RoadRunner rr(sbml);
-  rr.setConservedMoietyAnalysis(true);
-
-  ExecutableModel* model = rr.getModel();
-  std::cout << "numIndFloatingSpecies=" << model->getNumIndFloatingSpecies()
-    << " numConservedMoieties=" << model->getNumConservedMoieties() << std::endl;
-  std::vector<std::string> floatIds = rr.getFloatingSpeciesIds();
-  for (size_t k = 0; k < floatIds.size(); ++k) {
-    std::cout << "floatingSpecies[" << k << "] = " << floatIds[k] << std::endl;
-  }
-  std::cout << rr.getCurrentSBML() << std::endl;
-  int n = model->getStateVector(0);
-  std::vector<std::string> ids;
-  for (int i = 0; i < n; ++i) {
-    ids.push_back(model->getStateVectorId(i));
-  }
-  int qIndex = std::distance(ids.begin(), std::find(ids.begin(), ids.end(), "Q"));
-  ASSERT_LT(qIndex, n);
-
-  std::vector<double> y(n);
-  model->getStateVector(y.data());
-
-  double s2Before = rr.getValue("S2");
-  double w1Before = rr.getValue("W1");
-  double qBefore = rr.getValue("Q");
-
-  y[qIndex] += 0.1;
-  model->setStateVector(y.data());
-
-  double s2After = rr.getValue("S2");
-  double w1After = rr.getValue("W1");
-  double qAfter = rr.getValue("Q");
-
-  int j1Index = model->getReactionIndex("J1");
-  double rateAfter = 0;
-  model->getReactionRates(1, &j1Index, &rateAfter);
-
-  std::cout << "Q: " << qBefore << " -> " << qAfter << std::endl;
-  std::cout << "W1: " << w1Before << " -> " << w1After << std::endl;
-  std::cout << "S2: " << s2Before << " -> " << s2After << std::endl;
-  std::cout << "J1 rate after perturbing Q: " << rateAfter << std::endl;
-}
-
-
-// Minimal repro: Q's only reaction (J1) reaches Q solely through two
-// levels of inlined assignment rules (S2 = ks2*W1, W1 = kw1*Q), never
-// directly. A/B form a separate, unrelated conservation law elsewhere in
-// the same model, so setConservedMoietyAnalysis(true) actually converts
-// something. Checks whether J1's rate still responds to Q after
-// conversion, isolating whether the Teusink P-column bug is a general
-// RoadRunner defect in assignment-rule-chain resolution post-conversion,
-// or specific to Teusink's own structure.
-TEST_F(StructuralAnalysisTests, AssignmentRuleChainSurvivesConservedMoietyConversion) {
-  std::string sbml =
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-    "<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n"
-    "  <model id=\"AssignmentRuleChainMoiety\">\n"
-    "    <listOfCompartments>\n"
-    "      <compartment id=\"default_compartment\" spatialDimensions=\"3\" size=\"1\" constant=\"true\"/>\n"
-    "    </listOfCompartments>\n"
-    "    <listOfSpecies>\n"
-    "      <species id=\"Q\" compartment=\"default_compartment\" initialConcentration=\"2\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"P2\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"A\" compartment=\"default_compartment\" initialConcentration=\"3\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"B\" compartment=\"default_compartment\" initialConcentration=\"1\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"W1\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"S2\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "    </listOfSpecies>\n"
-    "    <listOfParameters>\n"
-    "      <parameter id=\"k1\" value=\"0.5\" constant=\"true\"/>\n"
-    "      <parameter id=\"kw1\" value=\"2\" constant=\"true\"/>\n"
-    "      <parameter id=\"ks2\" value=\"3\" constant=\"true\"/>\n"
-    "      <parameter id=\"k2\" value=\"0.8\" constant=\"true\"/>\n"
-    "      <parameter id=\"k3\" value=\"0.4\" constant=\"true\"/>\n"
-    "    </listOfParameters>\n"
-    "    <listOfRules>\n"
-    "      <assignmentRule variable=\"W1\">\n"
-    "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
-    "          <apply><times/><ci> kw1 </ci><ci> Q </ci></apply>\n"
-    "        </math>\n"
-    "      </assignmentRule>\n"
-    "      <assignmentRule variable=\"S2\">\n"
-    "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
-    "          <apply><times/><ci> ks2 </ci><ci> W1 </ci></apply>\n"
-    "        </math>\n"
-    "      </assignmentRule>\n"
-    "    </listOfRules>\n"
-    "    <listOfReactions>\n"
-    "      <reaction id=\"J1\" reversible=\"false\" fast=\"false\">\n"
-    "        <listOfReactants>\n"
-    "          <speciesReference species=\"Q\" stoichiometry=\"1\" constant=\"true\"/>\n"
-    "        </listOfReactants>\n"
-    "        <listOfProducts>\n"
-    "          <speciesReference species=\"P2\" stoichiometry=\"1\" constant=\"true\"/>\n"
-    "        </listOfProducts>\n"
-    "        <kineticLaw>\n"
-    "          <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
-    "            <apply><times/><ci> k1 </ci><ci> S2 </ci></apply>\n"
-    "          </math>\n"
-    "        </kineticLaw>\n"
-    "      </reaction>\n"
-    "      <reaction id=\"J2\" reversible=\"true\" fast=\"false\">\n"
-    "        <listOfReactants>\n"
-    "          <speciesReference species=\"A\" stoichiometry=\"1\" constant=\"true\"/>\n"
-    "        </listOfReactants>\n"
-    "        <listOfProducts>\n"
-    "          <speciesReference species=\"B\" stoichiometry=\"1\" constant=\"true\"/>\n"
-    "        </listOfProducts>\n"
-    "        <kineticLaw>\n"
-    "          <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
-    "            <apply><minus/>\n"
-    "              <apply><times/><ci> k2 </ci><ci> A </ci></apply>\n"
-    "              <apply><times/><ci> k3 </ci><ci> B </ci></apply>\n"
-    "            </apply>\n"
-    "          </math>\n"
-    "        </kineticLaw>\n"
-    "      </reaction>\n"
-    "    </listOfReactions>\n"
-    "  </model>\n"
-    "</sbml>";
+// Regression test for a general RoadRunner bug (not specific to Teusink's
+// NAD/NADH or ATP/ADP/AMP structure): after a real conserved-moiety
+// conversion, a species governed by its own pre-existing assignment-rule
+// chain stopped responding to changes in its dependency, even though it
+// has nothing to do with the moiety being eliminated. J1's rate reaches Q
+// only through that chain (S2 = ks2*W1, W1 = kw1*Q), so its sensitivity to
+// Q must be identical before and after conversion.
+TEST_F(StructuralAnalysisTests, AssignmentRuleChainRateSensitivitySurvivesConversion) {
+  path sbmlPath = modelAnalysisModelsDir / "assignment_rule_chain_moiety.xml";
 
   auto measureJ1RateSensitivityToQ = [](RoadRunner& rr) {
     ExecutableModel* model = rr.getModel();
@@ -365,91 +185,54 @@ TEST_F(StructuralAnalysisTests, AssignmentRuleChainSurvivesConservedMoietyConver
     return rateAfter - rateBefore;
     };
 
-  RoadRunner rrBefore(sbml);
-  double deltaBefore = measureJ1RateSensitivityToQ(rrBefore);
-  std::cout << "J1 rate change per +0.1 Q, before moiety conversion: " << deltaBefore << std::endl;
-  EXPECT_NEAR(deltaBefore, 0.1 * 0.5 * 3 * 2, 1e-6);
+  double expectedDelta = 0.1 * 0.5 * 3 * 2; // dQ * k1 * ks2 * kw1
 
-  RoadRunner rrAfter(sbml);
+  RoadRunner rrBefore(sbmlPath.string());
+  EXPECT_NEAR(measureJ1RateSensitivityToQ(rrBefore), expectedDelta, 1e-6);
+
+  RoadRunner rrAfter(sbmlPath.string());
   rrAfter.setConservedMoietyAnalysis(true);
-  double deltaAfter = measureJ1RateSensitivityToQ(rrAfter);
-  std::cout << "J1 rate change per +0.1 Q, after moiety conversion: " << deltaAfter << std::endl;
+  EXPECT_NEAR(measureJ1RateSensitivityToQ(rrAfter), expectedDelta, 1e-6);
 }
 
-TEST_F(StructuralAnalysisTests, PrintPostConversionSBMLForAssignmentRuleChain) {
-  std::string sbml =
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-    "<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n"
-    "  <model id=\"AssignmentRuleChainMoiety\">\n"
-    "    <listOfCompartments>\n"
-    "      <compartment id=\"default_compartment\" spatialDimensions=\"3\" size=\"1\" constant=\"true\"/>\n"
-    "    </listOfCompartments>\n"
-    "    <listOfSpecies>\n"
-    "      <species id=\"Q\" compartment=\"default_compartment\" initialConcentration=\"2\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"P2\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"A\" compartment=\"default_compartment\" initialConcentration=\"3\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"B\" compartment=\"default_compartment\" initialConcentration=\"1\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"W1\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "      <species id=\"S2\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
-    "    </listOfSpecies>\n"
-    "    <listOfParameters>\n"
-    "      <parameter id=\"k1\" value=\"0.5\" constant=\"true\"/>\n"
-    "      <parameter id=\"kw1\" value=\"2\" constant=\"true\"/>\n"
-    "      <parameter id=\"ks2\" value=\"3\" constant=\"true\"/>\n"
-    "      <parameter id=\"k2\" value=\"0.8\" constant=\"true\"/>\n"
-    "      <parameter id=\"k3\" value=\"0.4\" constant=\"true\"/>\n"
-    "    </listOfParameters>\n"
-    "    <listOfRules>\n"
-    "      <assignmentRule variable=\"W1\">\n"
-    "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
-    "          <apply><times/><ci> kw1 </ci><ci> Q </ci></apply>\n"
-    "        </math>\n"
-    "      </assignmentRule>\n"
-    "      <assignmentRule variable=\"S2\">\n"
-    "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
-    "          <apply><times/><ci> ks2 </ci><ci> W1 </ci></apply>\n"
-    "        </math>\n"
-    "      </assignmentRule>\n"
-    "    </listOfRules>\n"
-    "    <listOfReactions>\n"
-    "      <reaction id=\"J1\" reversible=\"false\" fast=\"false\">\n"
-    "        <listOfReactants>\n"
-    "          <speciesReference species=\"Q\" stoichiometry=\"1\" constant=\"true\"/>\n"
-    "        </listOfReactants>\n"
-    "        <listOfProducts>\n"
-    "          <speciesReference species=\"P2\" stoichiometry=\"1\" constant=\"true\"/>\n"
-    "        </listOfProducts>\n"
-    "        <kineticLaw>\n"
-    "          <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
-    "            <apply><times/><ci> k1 </ci><ci> S2 </ci></apply>\n"
-    "          </math>\n"
-    "        </kineticLaw>\n"
-    "      </reaction>\n"
-    "      <reaction id=\"J2\" reversible=\"true\" fast=\"false\">\n"
-    "        <listOfReactants>\n"
-    "          <speciesReference species=\"A\" stoichiometry=\"1\" constant=\"true\"/>\n"
-    "        </listOfReactants>\n"
-    "        <listOfProducts>\n"
-    "          <speciesReference species=\"B\" stoichiometry=\"1\" constant=\"true\"/>\n"
-    "        </listOfProducts>\n"
-    "        <kineticLaw>\n"
-    "          <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
-    "            <apply><minus/>\n"
-    "              <apply><times/><ci> k2 </ci><ci> A </ci></apply>\n"
-    "              <apply><times/><ci> k3 </ci><ci> B </ci></apply>\n"
-    "            </apply>\n"
-    "          </math>\n"
-    "        </kineticLaw>\n"
-    "      </reaction>\n"
-    "    </listOfReactions>\n"
-    "  </model>\n"
-    "</sbml>";
-
-  RoadRunner rr(sbml);
+// A species governed by its own assignment rule but with zero stoichiometric
+// coupling to any reaction (W1, S2) is not a real conserved moiety and must
+// not be counted as one: only the genuine Q+P2 (via J1) and A+B (via J2)
+// cycles should be reported. W1 and S2 must also keep tracking their
+// dependency chain dynamically after conversion, not freeze at their
+// pre-conversion value.
+TEST_F(StructuralAnalysisTests, RuleGovernedSpeciesTrackDependencyAfterConversion) {
+  RoadRunner rr((modelAnalysisModelsDir / "assignment_rule_chain_moiety.xml").string());
   rr.setConservedMoietyAnalysis(true);
-  std::cout << rr.getCurrentSBML() << std::endl;
-}
 
+  ExecutableModel* model = rr.getModel();
+  EXPECT_EQ(model->getNumConservedMoieties(), 2);
+
+  int n = model->getStateVector(0);
+  std::vector<std::string> ids;
+  for (int i = 0; i < n; ++i) {
+    ids.push_back(model->getStateVectorId(i));
+  }
+  int qIndex = std::distance(ids.begin(), std::find(ids.begin(), ids.end(), "Q"));
+  ASSERT_LT(qIndex, n);
+
+  std::vector<double> y(n);
+  model->getStateVector(y.data());
+  y[qIndex] += 0.1;
+  model->setStateVector(y.data());
+
+  double qAfter = rr.getValue("Q");
+  double w1After = rr.getValue("W1");
+  double s2After = rr.getValue("S2");
+
+  EXPECT_NEAR(w1After, 2.0 * qAfter, 1e-9);
+  EXPECT_NEAR(s2After, 3.0 * w1After, 1e-9);
+
+  int j1Index = model->getReactionIndex("J1");
+  double rate = 0;
+  model->getReactionRates(1, &j1Index, &rate);
+  EXPECT_NEAR(rate, 0.5 * s2After, 1e-9);
+}
 
 // BIOMD0000000064 (Teusink et al. 2000, yeast glycolysis) has two species,
 // SUM_P and F26BP, declared with constant="true" and boundaryCondition="false"
@@ -485,13 +268,11 @@ TEST_F(StructuralAnalysisTests, TeusinkNADCycleIsFound) {
   EXPECT_TRUE(foundNADCycle);
 }
 
-// Before the constant-species-as-boundary fix, steadyState() failed with
-// "Jacobian matrix singular in NLEQ" on this model: SUM_P and F26BP were
-// counted as independent floating species even though nothing ever changes
-// them, giving the Newton solve two structurally-zero Jacobian rows on top
-// of the NAD/NADH moiety dependency. Expected values are this model's own
-// steady state (matches Table 4 of Teusink et al. 2000, and the "this
-// model" column in the SBML's own notes).
+// Before the constant-species-as-boundary fix and the conserved-moiety
+// rule-duplication fix, steadyState() failed with "Jacobian matrix singular
+// in NLEQ" on this model. Expected values are this model's own steady
+// state (matches Table 4 of Teusink et al. 2000, and the "this model"
+// column in the SBML's own notes).
 TEST_F(StructuralAnalysisTests, TeusinkSteadyStateConverges) {
   RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
 
@@ -509,8 +290,11 @@ TEST_F(StructuralAnalysisTests, TeusinkSteadyStateConverges) {
 // the raw stoichiometry, but steadyState()'s auto_moiety_analysis retry
 // swallows any exception from setConservedMoietyAnalysis() and silently falls
 // back to no conversion. Calling it directly here surfaces that exception (if
-// any) instead, and confirms the conversion actually produces a conserved
-// moiety on the compiled model, not just in the structural analysis.
+// any) instead, and confirms the conversion actually produces the expected
+// number of conserved moieties on the compiled model, not just in the
+// structural analysis (3 real cycles: NAD/NADH, the adenylate pool, and one
+// more -- not the 6 a rule-duplication bug once produced by also counting
+// non-reacting, rule-governed species as moieties).
 TEST_F(StructuralAnalysisTests, TeusinkConservedMoietyConversionSucceeds) {
   RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
 
@@ -519,120 +303,10 @@ TEST_F(StructuralAnalysisTests, TeusinkConservedMoietyConversionSucceeds) {
   EXPECT_EQ(rr.getModel()->getNumConservedMoieties(), 3);
 }
 
-// Conversion succeeds and reports a conserved moiety, but steadyState()
-// still hits a singular Jacobian. Print the actual reduced Jacobian NLEQ
-// solves against (row/col names are the floating species included in the
-// post-conversion state vector) to see the singularity directly.
-TEST_F(StructuralAnalysisTests, TeusinkPrintReducedJacobian) {
-  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
-  rr.setConservedMoietyAnalysis(true);
-
-  ls::DoubleMatrix jac = rr.getReducedJacobian();
-  std::cout << jac << std::endl;
-}
-
-// getReducedJacobian() reads its rates through RoadRunner::getRatesOfChange(),
-// which applies a LibStructural link-matrix correction whenever conserved
-// moiety analysis is on (see getRatesOfChange() in rrRoadRunner.cpp). NLEQ's
-// own residual function never goes through that: it calls
-// ExecutableModel::setStateVector()/getStateVectorRate() directly. Build the
-// Jacobian the same way NLEQ does, bypassing getRatesOfChange() entirely, to
-// see what NLEQ itself actually sees.
-TEST_F(StructuralAnalysisTests, TeusinkPrintRawStateVectorJacobian) {
-  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
-  rr.setConservedMoietyAnalysis(true);
-
-  ExecutableModel* model = rr.getModel();
-  int n = model->getStateVector(0);
-  double h = 1e-6;
-
-  std::vector<std::string> ids;
-  for (int i = 0; i < n; ++i) {
-    ids.push_back(model->getStateVectorId(i));
-  }
-
-  std::vector<double> y(n);
-  model->getStateVector(y.data());
-
-  ls::DoubleMatrix jac(n, n);
-  jac.setRowNames(ids);
-  jac.setColNames(ids);
-
-  std::vector<double> dyPlus(n), dyMinus(n);
-  for (int col = 0; col < n; ++col) {
-    double saved = y[col];
-
-    y[col] = saved + h;
-    model->setStateVector(y.data());
-    model->getStateVectorRate(0, y.data(), dyPlus.data());
-
-    y[col] = saved - h;
-    model->setStateVector(y.data());
-    model->getStateVectorRate(0, y.data(), dyMinus.data());
-
-    y[col] = saved;
-    model->setStateVector(y.data());
-
-    for (int row = 0; row < n; ++row) {
-      jac(row, col) = (dyPlus[row] - dyMinus[row]) / (2.0 * h);
-    }
-  }
-
-  std::cout << jac << std::endl;
-}
-
-// Same raw state-vector Jacobian, but on the plain unconverted model (no
-// setConservedMoietyAnalysis call) to check whether the P column is zero
-// even without conserved moiety conversion in the picture -- i.e. whether
-// this is a pre-existing bug unrelated to the NAD/NADH moiety work.
-TEST_F(StructuralAnalysisTests, TeusinkPrintRawStateVectorJacobianNoConservedMoieties) {
-  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
-
-  ExecutableModel* model = rr.getModel();
-  int n = model->getStateVector(0);
-  double h = 1e-6;
-
-  std::vector<std::string> ids;
-  for (int i = 0; i < n; ++i) {
-    ids.push_back(model->getStateVectorId(i));
-  }
-
-  std::vector<double> y(n);
-  model->getStateVector(y.data());
-
-  ls::DoubleMatrix jac(n, n);
-  jac.setRowNames(ids);
-  jac.setColNames(ids);
-
-  std::vector<double> dyPlus(n), dyMinus(n);
-  for (int col = 0; col < n; ++col) {
-    double saved = y[col];
-
-    y[col] = saved + h;
-    model->setStateVector(y.data());
-    model->getStateVectorRate(0, y.data(), dyPlus.data());
-
-    y[col] = saved - h;
-    model->setStateVector(y.data());
-    model->getStateVectorRate(0, y.data(), dyMinus.data());
-
-    y[col] = saved;
-    model->setStateVector(y.data());
-
-    for (int row = 0; row < n; ++row) {
-      jac(row, col) = (dyPlus[row] - dyMinus[row]) / (2.0 * h);
-    }
-  }
-
-  std::cout << jac << std::endl;
-}
-
-// Splits the question: does perturbing P even propagate through the
-// AK-equilibrium assignment rules to ATP/ADP after conversion? If not, the
-// break is in the assignment-rule chain itself. If it does update correctly
-// here (via getValue(), a different read path than getStateVectorRate's
-// inlined kinetic law code), the break must be one level deeper: inside
-// evalReactionRatesPtr's own inlined copy of that same computation.
+// ATP and ADP are related to P (and SUM_P) through the AK-equilibrium
+// assignment rules, never directly through a reaction. Perturbing P must
+// still update them dynamically after conversion, not leave them frozen at
+// their pre-conversion value the way the rule-duplication bug did.
 TEST_F(StructuralAnalysisTests, TeusinkPerturbingPAfterConversionUpdatesATP) {
   RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
   rr.setConservedMoietyAnalysis(true);
@@ -658,16 +332,16 @@ TEST_F(StructuralAnalysisTests, TeusinkPerturbingPAfterConversionUpdatesATP) {
   double atpAfter = rr.getValue("[ATP]");
   double adpAfter = rr.getValue("[ADP]");
 
-  std::cout << "ATP: " << atpBefore << " -> " << atpAfter << std::endl;
-  std::cout << "ADP: " << adpBefore << " -> " << adpAfter << std::endl;
+  EXPECT_NE(atpAfter, atpBefore);
+  EXPECT_NE(adpAfter, adpBefore);
 }
 
 // createReorderedSpecies deletes any <species> that's neither
 // boundary/constant nor part of indSpecies/depSpecies -- ATP/ADP/AMP satisfy
-// none of those (not constant, never a reactant/product), so their
-// <species> elements are likely gone post-conversion even though their
-// assignment rules (untouched, in <listOfRules>) still reference P and
-// SUM_P. Check what they actually get classified as.
+// none of those (not constant, never a reactant/product). Their <species>
+// elements, and their classification as ordinary floating species, must
+// survive conversion so their assignment rules (referencing P and SUM_P)
+// keep resolving.
 TEST_F(StructuralAnalysisTests, TeusinkATPClassificationAfterConversion) {
   RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
   rr.setConservedMoietyAnalysis(true);
@@ -676,21 +350,20 @@ TEST_F(StructuralAnalysisTests, TeusinkATPClassificationAfterConversion) {
   auto boundaryIds = rr.getBoundarySpeciesIds();
   auto globalParamIds = rr.getGlobalParameterIds();
 
-  for (const std::string& id : {"ATP", "ADP", "AMP", "SUM_P", "F26BP", "P"}) {
-    bool isFloating = std::find(floatingIds.begin(), floatingIds.end(), id) != floatingIds.end();
-    bool isBoundary = std::find(boundaryIds.begin(), boundaryIds.end(), id) != boundaryIds.end();
-    bool isGlobalParam = std::find(globalParamIds.begin(), globalParamIds.end(), id) != globalParamIds.end();
-    std::cout << id << ": floating=" << isFloating << " boundary=" << isBoundary
-               << " globalParam=" << isGlobalParam << std::endl;
+  for (const std::string& id : {"ATP", "ADP", "AMP"}) {
+    EXPECT_NE(std::find(floatingIds.begin(), floatingIds.end(), id), floatingIds.end()) << id;
+    EXPECT_EQ(std::find(boundaryIds.begin(), boundaryIds.end(), id), boundaryIds.end()) << id;
+    EXPECT_EQ(std::find(globalParamIds.begin(), globalParamIds.end(), id), globalParamIds.end()) << id;
+  }
+  for (const std::string& id : {"SUM_P", "F26BP"}) {
+    EXPECT_NE(std::find(boundaryIds.begin(), boundaryIds.end(), id), boundaryIds.end()) << id;
   }
 }
 
-// Splits the zero P column further: does perturbing P even change the
-// reaction rates themselves (a kinetic-law/inlining problem), or do the
-// rates respond correctly and it's the stoichiometry-matrix multiply that
-// silently drops P's contribution when turning rates into species rates
-// of change (a whole zero column points more toward the former, but
-// check directly rather than assume).
+// P only reaches kinetic laws indirectly, through the inlined ADP/ATP
+// assignment rules, so perturbing it must still change at least one
+// reaction rate after conversion -- the rule-duplication bug froze those
+// rules to a constant, making every reaction rate blind to P.
 TEST_F(StructuralAnalysisTests, TeusinkPerturbingPAfterConversionChangesReactionRates) {
   RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
   rr.setConservedMoietyAnalysis(true);
@@ -717,34 +390,14 @@ TEST_F(StructuralAnalysisTests, TeusinkPerturbingPAfterConversionChangesReaction
   std::vector<double> ratesAfter(numReactions);
   model->getReactionRates(numReactions, 0, ratesAfter.data());
 
+  bool anyRateChanged = false;
   for (int i = 0; i < numReactions; ++i) {
-    std::cout << model->getReactionId(i) << ": " << ratesBefore[i] << " -> " << ratesAfter[i] << std::endl;
-  }
-}
-
-// The reaction-rate freeze is specific to P -- other floating species
-// (G6P, TRIO, etc, referenced directly in kinetic laws) respond correctly
-// to perturbation. P only reaches kinetic laws indirectly, through the
-// inlined ADP/ATP assignment rules. Dump the actual post-conversion SBML
-// for those rules to check whether conversion mangled their math, before
-// looking any further at codegen.
-TEST_F(StructuralAnalysisTests, TeusinkPrintConvertedAssignmentRules) {
-  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
-  rr.setConservedMoietyAnalysis(true);
-
-  std::string sbml = rr.getCurrentSBML();
-
-  for (const std::string& variable : {"ADP", "ATP", "AMP"}) {
-    std::string needle = "variable=\"" + variable + "\"";
-    size_t pos = sbml.find(needle);
-    if (pos == std::string::npos) {
-      std::cout << "no rule found for " << variable << std::endl;
-      continue;
+    if (std::abs(ratesAfter[i] - ratesBefore[i]) > 1e-9) {
+      anyRateChanged = true;
+      break;
     }
-    size_t start = sbml.rfind("<assignmentRule", pos);
-    size_t end = sbml.find("</assignmentRule>", pos);
-    std::cout << sbml.substr(start, end + std::string("</assignmentRule>").size() - start) << std::endl;
   }
+  EXPECT_TRUE(anyRateChanged);
 }
 
 /************************************************************

--- a/test/cxx_api_tests/StructuralAnalysisTests.cpp
+++ b/test/cxx_api_tests/StructuralAnalysisTests.cpp
@@ -1,10 +1,12 @@
 #include <rrRoadRunner.h>
 #include "gtest/gtest.h"
+#include <algorithm>
 
 #include "RoadRunnerTest.h"
 #include "TestModelFactory.h"
 #include "GillespieIntegrator.h"
 #include "rrConfig.h"
+#include "rrExecutableModel.h"
 #include "Matrix.h"
 
 using namespace rr;
@@ -146,6 +148,604 @@ public:
 
 
 };
+
+TEST_F(StructuralAnalysisTests, S2ValueUpdatesAfterConservedMoietyConversion) {
+  std::string sbml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+    "<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n"
+    "  <model id=\"AssignmentRuleChainMoiety\">\n"
+    "    <listOfCompartments>\n"
+    "      <compartment id=\"default_compartment\" spatialDimensions=\"3\" size=\"1\" constant=\"true\"/>\n"
+    "    </listOfCompartments>\n"
+    "    <listOfSpecies>\n"
+    "      <species id=\"Q\" compartment=\"default_compartment\" initialConcentration=\"2\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"P2\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"A\" compartment=\"default_compartment\" initialConcentration=\"3\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"B\" compartment=\"default_compartment\" initialConcentration=\"1\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"W1\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"S2\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "    </listOfSpecies>\n"
+    "    <listOfParameters>\n"
+    "      <parameter id=\"k1\" value=\"0.5\" constant=\"true\"/>\n"
+    "      <parameter id=\"kw1\" value=\"2\" constant=\"true\"/>\n"
+    "      <parameter id=\"ks2\" value=\"3\" constant=\"true\"/>\n"
+    "      <parameter id=\"k2\" value=\"0.8\" constant=\"true\"/>\n"
+    "      <parameter id=\"k3\" value=\"0.4\" constant=\"true\"/>\n"
+    "    </listOfParameters>\n"
+    "    <listOfRules>\n"
+    "      <assignmentRule variable=\"W1\">\n"
+    "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+    "          <apply><times/><ci> kw1 </ci><ci> Q </ci></apply>\n"
+    "        </math>\n"
+    "      </assignmentRule>\n"
+    "      <assignmentRule variable=\"S2\">\n"
+    "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+    "          <apply><times/><ci> ks2 </ci><ci> W1 </ci></apply>\n"
+    "        </math>\n"
+    "      </assignmentRule>\n"
+    "    </listOfRules>\n"
+    "    <listOfReactions>\n"
+    "      <reaction id=\"J1\" reversible=\"false\" fast=\"false\">\n"
+    "        <listOfReactants>\n"
+    "          <speciesReference species=\"Q\" stoichiometry=\"1\" constant=\"true\"/>\n"
+    "        </listOfReactants>\n"
+    "        <listOfProducts>\n"
+    "          <speciesReference species=\"P2\" stoichiometry=\"1\" constant=\"true\"/>\n"
+    "        </listOfProducts>\n"
+    "        <kineticLaw>\n"
+    "          <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+    "            <apply><times/><ci> k1 </ci><ci> S2 </ci></apply>\n"
+    "          </math>\n"
+    "        </kineticLaw>\n"
+    "      </reaction>\n"
+    "      <reaction id=\"J2\" reversible=\"true\" fast=\"false\">\n"
+    "        <listOfReactants>\n"
+    "          <speciesReference species=\"A\" stoichiometry=\"1\" constant=\"true\"/>\n"
+    "        </listOfReactants>\n"
+    "        <listOfProducts>\n"
+    "          <speciesReference species=\"B\" stoichiometry=\"1\" constant=\"true\"/>\n"
+    "        </listOfProducts>\n"
+    "        <kineticLaw>\n"
+    "          <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+    "            <apply><minus/>\n"
+    "              <apply><times/><ci> k2 </ci><ci> A </ci></apply>\n"
+    "              <apply><times/><ci> k3 </ci><ci> B </ci></apply>\n"
+    "            </apply>\n"
+    "          </math>\n"
+    "        </kineticLaw>\n"
+    "      </reaction>\n"
+    "    </listOfReactions>\n"
+    "  </model>\n"
+    "</sbml>";
+
+  RoadRunner rr(sbml);
+  rr.setConservedMoietyAnalysis(true);
+
+  ExecutableModel* model = rr.getModel();
+  std::cout << "numIndFloatingSpecies=" << model->getNumIndFloatingSpecies()
+    << " numConservedMoieties=" << model->getNumConservedMoieties() << std::endl;
+  std::vector<std::string> floatIds = rr.getFloatingSpeciesIds();
+  for (size_t k = 0; k < floatIds.size(); ++k) {
+    std::cout << "floatingSpecies[" << k << "] = " << floatIds[k] << std::endl;
+  }
+  std::cout << rr.getCurrentSBML() << std::endl;
+  int n = model->getStateVector(0);
+  std::vector<std::string> ids;
+  for (int i = 0; i < n; ++i) {
+    ids.push_back(model->getStateVectorId(i));
+  }
+  int qIndex = std::distance(ids.begin(), std::find(ids.begin(), ids.end(), "Q"));
+  ASSERT_LT(qIndex, n);
+
+  std::vector<double> y(n);
+  model->getStateVector(y.data());
+
+  double s2Before = rr.getValue("S2");
+  double w1Before = rr.getValue("W1");
+  double qBefore = rr.getValue("Q");
+
+  y[qIndex] += 0.1;
+  model->setStateVector(y.data());
+
+  double s2After = rr.getValue("S2");
+  double w1After = rr.getValue("W1");
+  double qAfter = rr.getValue("Q");
+
+  int j1Index = model->getReactionIndex("J1");
+  double rateAfter = 0;
+  model->getReactionRates(1, &j1Index, &rateAfter);
+
+  std::cout << "Q: " << qBefore << " -> " << qAfter << std::endl;
+  std::cout << "W1: " << w1Before << " -> " << w1After << std::endl;
+  std::cout << "S2: " << s2Before << " -> " << s2After << std::endl;
+  std::cout << "J1 rate after perturbing Q: " << rateAfter << std::endl;
+}
+
+
+// Minimal repro: Q's only reaction (J1) reaches Q solely through two
+// levels of inlined assignment rules (S2 = ks2*W1, W1 = kw1*Q), never
+// directly. A/B form a separate, unrelated conservation law elsewhere in
+// the same model, so setConservedMoietyAnalysis(true) actually converts
+// something. Checks whether J1's rate still responds to Q after
+// conversion, isolating whether the Teusink P-column bug is a general
+// RoadRunner defect in assignment-rule-chain resolution post-conversion,
+// or specific to Teusink's own structure.
+TEST_F(StructuralAnalysisTests, AssignmentRuleChainSurvivesConservedMoietyConversion) {
+  std::string sbml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+    "<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n"
+    "  <model id=\"AssignmentRuleChainMoiety\">\n"
+    "    <listOfCompartments>\n"
+    "      <compartment id=\"default_compartment\" spatialDimensions=\"3\" size=\"1\" constant=\"true\"/>\n"
+    "    </listOfCompartments>\n"
+    "    <listOfSpecies>\n"
+    "      <species id=\"Q\" compartment=\"default_compartment\" initialConcentration=\"2\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"P2\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"A\" compartment=\"default_compartment\" initialConcentration=\"3\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"B\" compartment=\"default_compartment\" initialConcentration=\"1\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"W1\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"S2\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "    </listOfSpecies>\n"
+    "    <listOfParameters>\n"
+    "      <parameter id=\"k1\" value=\"0.5\" constant=\"true\"/>\n"
+    "      <parameter id=\"kw1\" value=\"2\" constant=\"true\"/>\n"
+    "      <parameter id=\"ks2\" value=\"3\" constant=\"true\"/>\n"
+    "      <parameter id=\"k2\" value=\"0.8\" constant=\"true\"/>\n"
+    "      <parameter id=\"k3\" value=\"0.4\" constant=\"true\"/>\n"
+    "    </listOfParameters>\n"
+    "    <listOfRules>\n"
+    "      <assignmentRule variable=\"W1\">\n"
+    "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+    "          <apply><times/><ci> kw1 </ci><ci> Q </ci></apply>\n"
+    "        </math>\n"
+    "      </assignmentRule>\n"
+    "      <assignmentRule variable=\"S2\">\n"
+    "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+    "          <apply><times/><ci> ks2 </ci><ci> W1 </ci></apply>\n"
+    "        </math>\n"
+    "      </assignmentRule>\n"
+    "    </listOfRules>\n"
+    "    <listOfReactions>\n"
+    "      <reaction id=\"J1\" reversible=\"false\" fast=\"false\">\n"
+    "        <listOfReactants>\n"
+    "          <speciesReference species=\"Q\" stoichiometry=\"1\" constant=\"true\"/>\n"
+    "        </listOfReactants>\n"
+    "        <listOfProducts>\n"
+    "          <speciesReference species=\"P2\" stoichiometry=\"1\" constant=\"true\"/>\n"
+    "        </listOfProducts>\n"
+    "        <kineticLaw>\n"
+    "          <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+    "            <apply><times/><ci> k1 </ci><ci> S2 </ci></apply>\n"
+    "          </math>\n"
+    "        </kineticLaw>\n"
+    "      </reaction>\n"
+    "      <reaction id=\"J2\" reversible=\"true\" fast=\"false\">\n"
+    "        <listOfReactants>\n"
+    "          <speciesReference species=\"A\" stoichiometry=\"1\" constant=\"true\"/>\n"
+    "        </listOfReactants>\n"
+    "        <listOfProducts>\n"
+    "          <speciesReference species=\"B\" stoichiometry=\"1\" constant=\"true\"/>\n"
+    "        </listOfProducts>\n"
+    "        <kineticLaw>\n"
+    "          <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+    "            <apply><minus/>\n"
+    "              <apply><times/><ci> k2 </ci><ci> A </ci></apply>\n"
+    "              <apply><times/><ci> k3 </ci><ci> B </ci></apply>\n"
+    "            </apply>\n"
+    "          </math>\n"
+    "        </kineticLaw>\n"
+    "      </reaction>\n"
+    "    </listOfReactions>\n"
+    "  </model>\n"
+    "</sbml>";
+
+  auto measureJ1RateSensitivityToQ = [](RoadRunner& rr) {
+    ExecutableModel* model = rr.getModel();
+    int n = model->getStateVector(0);
+    std::vector<std::string> ids;
+    for (int i = 0; i < n; ++i) {
+      ids.push_back(model->getStateVectorId(i));
+    }
+    int qIndex = std::distance(ids.begin(), std::find(ids.begin(), ids.end(), "Q"));
+    EXPECT_LT(qIndex, n);
+
+    std::vector<double> y(n);
+    model->getStateVector(y.data());
+
+    int j1Index = model->getReactionIndex("J1");
+    double rateBefore = 0;
+    model->getReactionRates(1, &j1Index, &rateBefore);
+
+    y[qIndex] += 0.1;
+    model->setStateVector(y.data());
+
+    double rateAfter = 0;
+    model->getReactionRates(1, &j1Index, &rateAfter);
+
+    return rateAfter - rateBefore;
+    };
+
+  RoadRunner rrBefore(sbml);
+  double deltaBefore = measureJ1RateSensitivityToQ(rrBefore);
+  std::cout << "J1 rate change per +0.1 Q, before moiety conversion: " << deltaBefore << std::endl;
+  EXPECT_NEAR(deltaBefore, 0.1 * 0.5 * 3 * 2, 1e-6);
+
+  RoadRunner rrAfter(sbml);
+  rrAfter.setConservedMoietyAnalysis(true);
+  double deltaAfter = measureJ1RateSensitivityToQ(rrAfter);
+  std::cout << "J1 rate change per +0.1 Q, after moiety conversion: " << deltaAfter << std::endl;
+}
+
+TEST_F(StructuralAnalysisTests, PrintPostConversionSBMLForAssignmentRuleChain) {
+  std::string sbml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+    "<sbml xmlns=\"http://www.sbml.org/sbml/level3/version1/core\" level=\"3\" version=\"1\">\n"
+    "  <model id=\"AssignmentRuleChainMoiety\">\n"
+    "    <listOfCompartments>\n"
+    "      <compartment id=\"default_compartment\" spatialDimensions=\"3\" size=\"1\" constant=\"true\"/>\n"
+    "    </listOfCompartments>\n"
+    "    <listOfSpecies>\n"
+    "      <species id=\"Q\" compartment=\"default_compartment\" initialConcentration=\"2\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"P2\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"A\" compartment=\"default_compartment\" initialConcentration=\"3\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"B\" compartment=\"default_compartment\" initialConcentration=\"1\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"W1\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "      <species id=\"S2\" compartment=\"default_compartment\" initialConcentration=\"0\" hasOnlySubstanceUnits=\"false\" boundaryCondition=\"false\" constant=\"false\"/>\n"
+    "    </listOfSpecies>\n"
+    "    <listOfParameters>\n"
+    "      <parameter id=\"k1\" value=\"0.5\" constant=\"true\"/>\n"
+    "      <parameter id=\"kw1\" value=\"2\" constant=\"true\"/>\n"
+    "      <parameter id=\"ks2\" value=\"3\" constant=\"true\"/>\n"
+    "      <parameter id=\"k2\" value=\"0.8\" constant=\"true\"/>\n"
+    "      <parameter id=\"k3\" value=\"0.4\" constant=\"true\"/>\n"
+    "    </listOfParameters>\n"
+    "    <listOfRules>\n"
+    "      <assignmentRule variable=\"W1\">\n"
+    "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+    "          <apply><times/><ci> kw1 </ci><ci> Q </ci></apply>\n"
+    "        </math>\n"
+    "      </assignmentRule>\n"
+    "      <assignmentRule variable=\"S2\">\n"
+    "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+    "          <apply><times/><ci> ks2 </ci><ci> W1 </ci></apply>\n"
+    "        </math>\n"
+    "      </assignmentRule>\n"
+    "    </listOfRules>\n"
+    "    <listOfReactions>\n"
+    "      <reaction id=\"J1\" reversible=\"false\" fast=\"false\">\n"
+    "        <listOfReactants>\n"
+    "          <speciesReference species=\"Q\" stoichiometry=\"1\" constant=\"true\"/>\n"
+    "        </listOfReactants>\n"
+    "        <listOfProducts>\n"
+    "          <speciesReference species=\"P2\" stoichiometry=\"1\" constant=\"true\"/>\n"
+    "        </listOfProducts>\n"
+    "        <kineticLaw>\n"
+    "          <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+    "            <apply><times/><ci> k1 </ci><ci> S2 </ci></apply>\n"
+    "          </math>\n"
+    "        </kineticLaw>\n"
+    "      </reaction>\n"
+    "      <reaction id=\"J2\" reversible=\"true\" fast=\"false\">\n"
+    "        <listOfReactants>\n"
+    "          <speciesReference species=\"A\" stoichiometry=\"1\" constant=\"true\"/>\n"
+    "        </listOfReactants>\n"
+    "        <listOfProducts>\n"
+    "          <speciesReference species=\"B\" stoichiometry=\"1\" constant=\"true\"/>\n"
+    "        </listOfProducts>\n"
+    "        <kineticLaw>\n"
+    "          <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n"
+    "            <apply><minus/>\n"
+    "              <apply><times/><ci> k2 </ci><ci> A </ci></apply>\n"
+    "              <apply><times/><ci> k3 </ci><ci> B </ci></apply>\n"
+    "            </apply>\n"
+    "          </math>\n"
+    "        </kineticLaw>\n"
+    "      </reaction>\n"
+    "    </listOfReactions>\n"
+    "  </model>\n"
+    "</sbml>";
+
+  RoadRunner rr(sbml);
+  rr.setConservedMoietyAnalysis(true);
+  std::cout << rr.getCurrentSBML() << std::endl;
+}
+
+
+// BIOMD0000000064 (Teusink et al. 2000, yeast glycolysis) has two species,
+// SUM_P and F26BP, declared with constant="true" and boundaryCondition="false"
+// -- they're used only as fixed parameters inside kinetic laws (the AK
+// equilibrium and the PFK rate law), never as reactants/products. They
+// should be classified as boundary species (and excluded from the
+// floating-species/Newton state vector), not as ordinary floating species
+// with a structurally-zero rate row.
+TEST_F(StructuralAnalysisTests, TeusinkConstantSpeciesAreBoundary) {
+  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
+
+  auto boundaryIds = rr.getBoundarySpeciesIds();
+  EXPECT_NE(std::find(boundaryIds.begin(), boundaryIds.end(), "SUM_P"), boundaryIds.end());
+  EXPECT_NE(std::find(boundaryIds.begin(), boundaryIds.end(), "F26BP"), boundaryIds.end());
+
+  auto floatingIds = rr.getFloatingSpeciesIds();
+  EXPECT_EQ(std::find(floatingIds.begin(), floatingIds.end(), "SUM_P"), floatingIds.end());
+  EXPECT_EQ(std::find(floatingIds.begin(), floatingIds.end(), "F26BP"), floatingIds.end());
+}
+
+// The NAD/NADH pair forms a genuine stoichiometric conservation cycle in
+// this model (via the GAPDH/ADH/G3PDH reactions), independent of the
+// constant-species fix above. This checks that RoadRunner's structural
+// analysis (the same analysis ConservedMoietyConverter::convert() reads
+// its independent/dependent species split from) actually finds it: NAD or
+// NADH should come back as a dependent species for a conservation law.
+TEST_F(StructuralAnalysisTests, TeusinkNADCycleIsFound) {
+  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
+
+  auto dependentIds = rr.getDependentFloatingSpeciesIds();
+  bool foundNADCycle = std::find(dependentIds.begin(), dependentIds.end(), "NAD") != dependentIds.end()
+    || std::find(dependentIds.begin(), dependentIds.end(), "NADH") != dependentIds.end();
+  EXPECT_TRUE(foundNADCycle);
+}
+
+// Before the constant-species-as-boundary fix, steadyState() failed with
+// "Jacobian matrix singular in NLEQ" on this model: SUM_P and F26BP were
+// counted as independent floating species even though nothing ever changes
+// them, giving the Newton solve two structurally-zero Jacobian rows on top
+// of the NAD/NADH moiety dependency. Expected values are this model's own
+// steady state (matches Table 4 of Teusink et al. 2000, and the "this
+// model" column in the SBML's own notes).
+TEST_F(StructuralAnalysisTests, TeusinkSteadyStateConverges) {
+  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
+
+  ASSERT_NO_THROW(rr.steadyState());
+
+  EXPECT_NEAR(rr.getValue("[G6P]"), 1.0332, 1e-3);
+  EXPECT_NEAR(rr.getValue("[F6P]"), 0.1128, 1e-3);
+  EXPECT_NEAR(rr.getValue("[PYR]"), 8.5232, 1e-3);
+  EXPECT_NEAR(rr.getValue("[ATP]"), 2.5084, 1e-3);
+  EXPECT_NEAR(rr.getValue("[ADP]"), 1.2921, 1e-3);
+  EXPECT_NEAR(rr.getValue("[NADH]"), 0.0444, 1e-3);
+}
+
+// TeusinkNADCycleIsFound confirms LibStructural finds the NAD/NADH cycle from
+// the raw stoichiometry, but steadyState()'s auto_moiety_analysis retry
+// swallows any exception from setConservedMoietyAnalysis() and silently falls
+// back to no conversion. Calling it directly here surfaces that exception (if
+// any) instead, and confirms the conversion actually produces a conserved
+// moiety on the compiled model, not just in the structural analysis.
+TEST_F(StructuralAnalysisTests, TeusinkConservedMoietyConversionSucceeds) {
+  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
+
+  ASSERT_NO_THROW(rr.setConservedMoietyAnalysis(true));
+  EXPECT_TRUE(rr.getConservedMoietyAnalysis());
+  EXPECT_EQ(rr.getModel()->getNumConservedMoieties(), 3);
+}
+
+// Conversion succeeds and reports a conserved moiety, but steadyState()
+// still hits a singular Jacobian. Print the actual reduced Jacobian NLEQ
+// solves against (row/col names are the floating species included in the
+// post-conversion state vector) to see the singularity directly.
+TEST_F(StructuralAnalysisTests, TeusinkPrintReducedJacobian) {
+  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
+  rr.setConservedMoietyAnalysis(true);
+
+  ls::DoubleMatrix jac = rr.getReducedJacobian();
+  std::cout << jac << std::endl;
+}
+
+// getReducedJacobian() reads its rates through RoadRunner::getRatesOfChange(),
+// which applies a LibStructural link-matrix correction whenever conserved
+// moiety analysis is on (see getRatesOfChange() in rrRoadRunner.cpp). NLEQ's
+// own residual function never goes through that: it calls
+// ExecutableModel::setStateVector()/getStateVectorRate() directly. Build the
+// Jacobian the same way NLEQ does, bypassing getRatesOfChange() entirely, to
+// see what NLEQ itself actually sees.
+TEST_F(StructuralAnalysisTests, TeusinkPrintRawStateVectorJacobian) {
+  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
+  rr.setConservedMoietyAnalysis(true);
+
+  ExecutableModel* model = rr.getModel();
+  int n = model->getStateVector(0);
+  double h = 1e-6;
+
+  std::vector<std::string> ids;
+  for (int i = 0; i < n; ++i) {
+    ids.push_back(model->getStateVectorId(i));
+  }
+
+  std::vector<double> y(n);
+  model->getStateVector(y.data());
+
+  ls::DoubleMatrix jac(n, n);
+  jac.setRowNames(ids);
+  jac.setColNames(ids);
+
+  std::vector<double> dyPlus(n), dyMinus(n);
+  for (int col = 0; col < n; ++col) {
+    double saved = y[col];
+
+    y[col] = saved + h;
+    model->setStateVector(y.data());
+    model->getStateVectorRate(0, y.data(), dyPlus.data());
+
+    y[col] = saved - h;
+    model->setStateVector(y.data());
+    model->getStateVectorRate(0, y.data(), dyMinus.data());
+
+    y[col] = saved;
+    model->setStateVector(y.data());
+
+    for (int row = 0; row < n; ++row) {
+      jac(row, col) = (dyPlus[row] - dyMinus[row]) / (2.0 * h);
+    }
+  }
+
+  std::cout << jac << std::endl;
+}
+
+// Same raw state-vector Jacobian, but on the plain unconverted model (no
+// setConservedMoietyAnalysis call) to check whether the P column is zero
+// even without conserved moiety conversion in the picture -- i.e. whether
+// this is a pre-existing bug unrelated to the NAD/NADH moiety work.
+TEST_F(StructuralAnalysisTests, TeusinkPrintRawStateVectorJacobianNoConservedMoieties) {
+  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
+
+  ExecutableModel* model = rr.getModel();
+  int n = model->getStateVector(0);
+  double h = 1e-6;
+
+  std::vector<std::string> ids;
+  for (int i = 0; i < n; ++i) {
+    ids.push_back(model->getStateVectorId(i));
+  }
+
+  std::vector<double> y(n);
+  model->getStateVector(y.data());
+
+  ls::DoubleMatrix jac(n, n);
+  jac.setRowNames(ids);
+  jac.setColNames(ids);
+
+  std::vector<double> dyPlus(n), dyMinus(n);
+  for (int col = 0; col < n; ++col) {
+    double saved = y[col];
+
+    y[col] = saved + h;
+    model->setStateVector(y.data());
+    model->getStateVectorRate(0, y.data(), dyPlus.data());
+
+    y[col] = saved - h;
+    model->setStateVector(y.data());
+    model->getStateVectorRate(0, y.data(), dyMinus.data());
+
+    y[col] = saved;
+    model->setStateVector(y.data());
+
+    for (int row = 0; row < n; ++row) {
+      jac(row, col) = (dyPlus[row] - dyMinus[row]) / (2.0 * h);
+    }
+  }
+
+  std::cout << jac << std::endl;
+}
+
+// Splits the question: does perturbing P even propagate through the
+// AK-equilibrium assignment rules to ATP/ADP after conversion? If not, the
+// break is in the assignment-rule chain itself. If it does update correctly
+// here (via getValue(), a different read path than getStateVectorRate's
+// inlined kinetic law code), the break must be one level deeper: inside
+// evalReactionRatesPtr's own inlined copy of that same computation.
+TEST_F(StructuralAnalysisTests, TeusinkPerturbingPAfterConversionUpdatesATP) {
+  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
+  rr.setConservedMoietyAnalysis(true);
+
+  ExecutableModel* model = rr.getModel();
+  int n = model->getStateVector(0);
+  std::vector<std::string> ids;
+  for (int i = 0; i < n; ++i) {
+    ids.push_back(model->getStateVectorId(i));
+  }
+  int pIndex = std::distance(ids.begin(), std::find(ids.begin(), ids.end(), "P"));
+  ASSERT_LT(pIndex, n);
+
+  std::vector<double> y(n);
+  model->getStateVector(y.data());
+
+  double atpBefore = rr.getValue("[ATP]");
+  double adpBefore = rr.getValue("[ADP]");
+
+  y[pIndex] += 1.0;
+  model->setStateVector(y.data());
+
+  double atpAfter = rr.getValue("[ATP]");
+  double adpAfter = rr.getValue("[ADP]");
+
+  std::cout << "ATP: " << atpBefore << " -> " << atpAfter << std::endl;
+  std::cout << "ADP: " << adpBefore << " -> " << adpAfter << std::endl;
+}
+
+// createReorderedSpecies deletes any <species> that's neither
+// boundary/constant nor part of indSpecies/depSpecies -- ATP/ADP/AMP satisfy
+// none of those (not constant, never a reactant/product), so their
+// <species> elements are likely gone post-conversion even though their
+// assignment rules (untouched, in <listOfRules>) still reference P and
+// SUM_P. Check what they actually get classified as.
+TEST_F(StructuralAnalysisTests, TeusinkATPClassificationAfterConversion) {
+  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
+  rr.setConservedMoietyAnalysis(true);
+
+  auto floatingIds = rr.getFloatingSpeciesIds();
+  auto boundaryIds = rr.getBoundarySpeciesIds();
+  auto globalParamIds = rr.getGlobalParameterIds();
+
+  for (const std::string& id : {"ATP", "ADP", "AMP", "SUM_P", "F26BP", "P"}) {
+    bool isFloating = std::find(floatingIds.begin(), floatingIds.end(), id) != floatingIds.end();
+    bool isBoundary = std::find(boundaryIds.begin(), boundaryIds.end(), id) != boundaryIds.end();
+    bool isGlobalParam = std::find(globalParamIds.begin(), globalParamIds.end(), id) != globalParamIds.end();
+    std::cout << id << ": floating=" << isFloating << " boundary=" << isBoundary
+               << " globalParam=" << isGlobalParam << std::endl;
+  }
+}
+
+// Splits the zero P column further: does perturbing P even change the
+// reaction rates themselves (a kinetic-law/inlining problem), or do the
+// rates respond correctly and it's the stoichiometry-matrix multiply that
+// silently drops P's contribution when turning rates into species rates
+// of change (a whole zero column points more toward the former, but
+// check directly rather than assume).
+TEST_F(StructuralAnalysisTests, TeusinkPerturbingPAfterConversionChangesReactionRates) {
+  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
+  rr.setConservedMoietyAnalysis(true);
+
+  ExecutableModel* model = rr.getModel();
+  int n = model->getStateVector(0);
+  std::vector<std::string> ids;
+  for (int i = 0; i < n; ++i) {
+    ids.push_back(model->getStateVectorId(i));
+  }
+  int pIndex = std::distance(ids.begin(), std::find(ids.begin(), ids.end(), "P"));
+  ASSERT_LT(pIndex, n);
+
+  std::vector<double> y(n);
+  model->getStateVector(y.data());
+
+  int numReactions = model->getNumReactions();
+  std::vector<double> ratesBefore(numReactions);
+  model->getReactionRates(numReactions, 0, ratesBefore.data());
+
+  y[pIndex] += 1.0;
+  model->setStateVector(y.data());
+
+  std::vector<double> ratesAfter(numReactions);
+  model->getReactionRates(numReactions, 0, ratesAfter.data());
+
+  for (int i = 0; i < numReactions; ++i) {
+    std::cout << model->getReactionId(i) << ": " << ratesBefore[i] << " -> " << ratesAfter[i] << std::endl;
+  }
+}
+
+// The reaction-rate freeze is specific to P -- other floating species
+// (G6P, TRIO, etc, referenced directly in kinetic laws) respond correctly
+// to perturbation. P only reaches kinetic laws indirectly, through the
+// inlined ADP/ATP assignment rules. Dump the actual post-conversion SBML
+// for those rules to check whether conversion mangled their math, before
+// looking any further at codegen.
+TEST_F(StructuralAnalysisTests, TeusinkPrintConvertedAssignmentRules) {
+  RoadRunner rr((modelAnalysisModelsDir / "teusink_glycolysis.xml").string());
+  rr.setConservedMoietyAnalysis(true);
+
+  std::string sbml = rr.getCurrentSBML();
+
+  for (const std::string& variable : {"ADP", "ATP", "AMP"}) {
+    std::string needle = "variable=\"" + variable + "\"";
+    size_t pos = sbml.find(needle);
+    if (pos == std::string::npos) {
+      std::cout << "no rule found for " << variable << std::endl;
+      continue;
+    }
+    size_t start = sbml.rfind("<assignmentRule", pos);
+    size_t end = sbml.find("</assignmentRule>", pos);
+    std::cout << sbml.substr(start, end + std::string("</assignmentRule>").size() - start) << std::endl;
+  }
+}
 
 /************************************************************
  * Check structural properties in the BimolecularEnd TestModel
@@ -479,9 +1079,3 @@ J0,J1,J2,J3,J4
 0,1,-1,0,-1
      */
 }
-
-
-
-
-
-

--- a/test/models/ModelAnalysis/assignment_rule_chain_moiety.xml
+++ b/test/models/ModelAnalysis/assignment_rule_chain_moiety.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+  <model id="AssignmentRuleChainMoiety">
+    <!--
+      Minimal repro of a general RoadRunner bug: Q's only reaction (J1)
+      reaches Q solely through two levels of inlined assignment rules
+      (S2 = ks2*W1, W1 = kw1*Q), never directly. A/B form a separate,
+      unrelated conservation cycle via the reversible J2 reaction, and Q/P2
+      form another via J1, so setConservedMoietyAnalysis(true) actually
+      converts something. W1 and S2 have no part in either cycle, and must
+      keep tracking their dependency chain dynamically after conversion.
+    -->
+    <listOfCompartments>
+      <compartment id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="Q" compartment="default_compartment" initialConcentration="2" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="P2" compartment="default_compartment" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="A" compartment="default_compartment" initialConcentration="3" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="B" compartment="default_compartment" initialConcentration="1" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="W1" compartment="default_compartment" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="S2" compartment="default_compartment" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="k1" value="0.5" constant="true"/>
+      <parameter id="kw1" value="2" constant="true"/>
+      <parameter id="ks2" value="3" constant="true"/>
+      <parameter id="k2" value="0.8" constant="true"/>
+      <parameter id="k3" value="0.4" constant="true"/>
+    </listOfParameters>
+    <listOfRules>
+      <assignmentRule variable="W1">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply><times/><ci> kw1 </ci><ci> Q </ci></apply>
+        </math>
+      </assignmentRule>
+      <assignmentRule variable="S2">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply><times/><ci> ks2 </ci><ci> W1 </ci></apply>
+        </math>
+      </assignmentRule>
+    </listOfRules>
+    <listOfReactions>
+      <reaction id="J1" reversible="false" fast="false">
+        <listOfReactants>
+          <speciesReference species="Q" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="P2" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply><times/><ci> k1 </ci><ci> S2 </ci></apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="J2" reversible="true" fast="false">
+        <listOfReactants>
+          <speciesReference species="A" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="B" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply><minus/>
+              <apply><times/><ci> k2 </ci><ci> A </ci></apply>
+              <apply><times/><ci> k3 </ci><ci> B </ci></apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/models/ModelAnalysis/teusink_glycolysis.xml
+++ b/test/models/ModelAnalysis/teusink_glycolysis.xml
@@ -1,0 +1,2733 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" metaid="metaid_0000001" level="2" version="4">
+  <model metaid="metaid_0000002" id="Teusink2000_Glycolysis" name="Teusink2000_Glycolysis">
+    <notes>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+        <p>
+          <b>Can yeast glycolysis be understood in terms of in vitro kinetics of the constituent enzymes? Testing biochemistry.</b>
+          <br/>
+          <i>Teusink,B et al.: Eur J Biochem 2000 Sep;267(17):5313-29.</i>
+          <br/>
+          The model reproduces the steady-state fluxes and metabolite concentrations of the branched model as given in Table 4 of the paper. It is derived from the model on JWS online, but has the ATP consumption in the succinate branch with the same stoichiometrie as in the publication. The model was successfully tested on copasi v.4.4(build 26).      <br/>
+          For Vmax values, please note that there is a conversion factor of approx. 270 to convert from U/mg-protein as shown in Table 1 of the paper to mmol/(min*L_cytosol). The equilibrium constant for the ADH reaction in the paper is given for the reverse reaction (Keq = 1.45*10      <sup>4</sup>
+          ). The value used in this model is for the forward reaction: 1/Keq = 6.9*10      <sup>-5</sup>
+          .      <br/>
+          Vmax parameters values used (in [mM/min] except VmGLT):      <table border="0" cellpadding="2" cellspacing="0">
+            <tr>
+              <td>
+                <b>VmGLT</b>
+              </td>
+              <td>97.264</td>
+              <td>mmol/min</td>
+            </tr>
+            <tr>
+              <td>
+                <b>VmGLK</b>
+              </td>
+              <td>226.45</td>
+              <td/>
+            </tr>
+            <tr>
+              <td>
+                <b>VmPGI</b>
+              </td>
+              <td>339.667</td>
+              <td/>
+            </tr>
+            <tr>
+              <td>
+                <b>VmPFK</b>
+              </td>
+              <td>182.903</td>
+              <td/>
+            </tr>
+            <tr>
+              <td>
+                <b>VmALD</b>
+              </td>
+              <td>322.258</td>
+              <td/>
+            </tr>
+            <tr>
+              <td>
+                <b>VmGAPDH_f</b>
+              </td>
+              <td>1184.52</td>
+              <td/>
+            </tr>
+            <tr>
+              <td>
+                <b>VmGAPDH_r</b>
+              </td>
+              <td>6549.68</td>
+              <td/>
+            </tr>
+            <tr>
+              <td>
+                <b>VmPGK</b>
+              </td>
+              <td>1306.45</td>
+              <td/>
+            </tr>
+            <tr>
+              <td>
+                <b>VmPGM</b>
+              </td>
+              <td>2525.81</td>
+              <td/>
+            </tr>
+            <tr>
+              <td>
+                <b>VmENO</b>
+              </td>
+              <td>365.806</td>
+              <td/>
+            </tr>
+            <tr>
+              <td>
+                <b>VmPYK</b>
+              </td>
+              <td>1088.71</td>
+              <td/>
+            </tr>
+            <tr>
+              <td>
+                <b>VmPDC</b>
+              </td>
+              <td>174.194</td>
+              <td/>
+            </tr>
+            <tr>
+              <td>
+                <b>VmG3PDH</b>
+              </td>
+              <td>70.15</td>
+              <td/>
+            </tr>
+          </table>
+          The result of the G6P steady state concentration (marked in red) differs slightly from the one given in table 4. of the publication      <br/>
+          Results for steady state:      <table border="0" cellpadding="2" cellspacing="0">
+            <thead>
+              <tr>
+                <th align="left" bgcolor="#eeeeee" valign="middle"/>
+                <th align="left" bgcolor="#eeeeee" valign="middle">orig. article</th>
+                <th align="center" bgcolor="#eeeeee" valign="middle">this model</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <b>Fluxes[mM/min]</b>
+                                 </td>
+                  <td/>
+                  <td/>
+                </tr>
+                <tr>
+                  <td>Glucose </td>
+                  <td>88 </td>
+                  <td>88 </td>
+                </tr>
+                <tr>
+                  <td>Ethanol </td>
+                  <td>129 </td>
+                  <td>129 </td>
+                </tr>
+                <tr>
+                  <td>Glycogen </td>
+                  <td>6 </td>
+                  <td>6 </td>
+                </tr>
+                <tr>
+                  <td>Trehalose </td>
+                  <td>4.8 </td>
+                  <td>4.8 </td>
+                  <td>(G6P flux through trehalose branch)</td>
+                </tr>
+                <tr>
+                  <td>Glycerol </td>
+                  <td>18.2 </td>
+                  <td>18.2 </td>
+                </tr>
+                <tr>
+                  <td>Succinate </td>
+                  <td>3.6 </td>
+                  <td>3.6 </td>
+                </tr>
+                <tr>
+                  <td>
+                    <b>Conc.[mM]</b>
+                                 </td>
+                    <td/>
+                    <td/>
+                  </tr>
+                  <tr>
+                    <td>G6P </td>
+                    <td>1.07 </td>
+                    <td style="color: red">1.03 </td>
+                  </tr>
+                  <tr>
+                    <td>F6P </td>
+                    <td>0.11 </td>
+                    <td>0.11 </td>
+                  </tr>
+                  <tr>
+                    <td>F1,6P </td>
+                    <td>0.6 </td>
+                    <td>0.6 </td>
+                  </tr>
+                  <tr>
+                    <td>DHAP </td>
+                    <td>0.74 </td>
+                    <td>0.74 </td>
+                  </tr>
+                  <tr>
+                    <td>3PGA </td>
+                    <td>0.36 </td>
+                    <td>0.36 </td>
+                  </tr>
+                  <tr>
+                    <td>2PGA </td>
+                    <td>0.04 </td>
+                    <td>0.04 </td>
+                  </tr>
+                  <tr>
+                    <td>PEP </td>
+                    <td>0.07 </td>
+                    <td>0.07 </td>
+                  </tr>
+                  <tr>
+                    <td>PYR </td>
+                    <td>8.52 </td>
+                    <td>8.52 </td>
+                  </tr>
+                  <tr>
+                    <td>AcAld </td>
+                    <td>0.17 </td>
+                    <td>0.17 </td>
+                  </tr>
+                  <tr>
+                    <td>ATP </td>
+                    <td>2.51 </td>
+                    <td>2.51 </td>
+                  </tr>
+                  <tr>
+                    <td>ADP </td>
+                    <td>1.29 </td>
+                    <td>1.29 </td>
+                  </tr>
+                  <tr>
+                    <td>AMP </td>
+                    <td>0.3 </td>
+                    <td>0.3 </td>
+                  </tr>
+                  <tr>
+                    <td>NAD </td>
+                    <td>1.55 </td>
+                    <td>1.55 </td>
+                  </tr>
+                  <tr>
+                    <td>NADH </td>
+                    <td>0.04 </td>
+                    <td>0.04 </td>
+                  </tr>
+                </tbody>
+              </table>
+          Authors of the publication also mentioned a few misprints in the original article:      <br/>
+          in the kinetic law for      <em>ADH</em>
+          :      <ol>
+                <li>the species          <em>a</em>
+              should denote          <em>NAD</em>
+              and          <em>b</em>
+                <em>Ethanol</em></li>
+                <li>the last term in the equation should read          <em>bpq</em>
+              /(          <em>K            <sub>ib</sub>
+                K            <sub>iq</sub>
+                K            <sub>p</sub></em>
+              )          </li>
+              </ol>
+          in the kinetic law for      <em>PFK</em>
+          :      <ol>
+                <li>R = 1 + λ          <sub>1</sub>
+              + λ          <sub>2</sub>
+              + g          <sub>r</sub>
+              λ          <sub>1</sub>
+              λ          <sub>2</sub></li>
+                <li>equation L  should read: L = L0*(..)          <sup>2</sup>
+              *(..)          <sup>2</sup>
+              *(..)          <sup>2</sup>
+              not L = L0*(..)          <sup>2</sup>
+              *(..)          <sup>2</sup>
+              *(..)          </li>
+              </ol>
+          To make the model easier to curate, the species      <em>ATP</em>
+          ,      <em>ADP</em>
+          and      <em>AMP</em>
+          were added. These are calculated via assignment rules from the active phosphate species,      <em>P</em>
+          , and the sum of all      <em>AXP</em>
+          ,      <em>SUM_P</em>
+          .      </p>
+              <br/>
+              <p>To the extent possible under law, all copyright and related or neighbouring rights to this encoded model have been dedicated to the public domain worldwide. Please refer to      <a href="http://creativecommons.org/publicdomain/zero/1.0/" title="Creative Commons CC0">CC0 Public Domain Dedication</a>
+          for more information.      </p>
+              <p>In summary, you are entitled to use this encoded model in absolutely any manner you deem suitable, verbatim, or with modification, alone or embedded it in a larger context, redistribute it, commercially or not, in a restricted way or not.</p>
+              <br/>
+              <p>To cite BioModels Database, please use:      <a href="http://www.ncbi.nlm.nih.gov/pubmed/20587024" target="_blank">Li C, Donizelli M, Rodriguez N, Dharuri H, Endler L, Chelliah V, Li L, He E, Henry A, Stefan MI, Snoep JL, Hucka M, Le Novère N, Laibe C (2010) BioModels Database: An enhanced, curated and annotated resource for published quantitative kinetic models. BMC Syst Biol., 4:92.</a></p>
+            </body>
+          </notes>
+    <annotation>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+        <rdf:Description rdf:about="#metaid_0000002">
+          <dc:creator>
+            <rdf:Bag>
+              <rdf:li rdf:parseType="Resource">
+                <vCard:N rdf:parseType="Resource">
+                  <vCard:Family>Snoep</vCard:Family>
+                  <vCard:Given>Jacky L</vCard:Given>
+                </vCard:N>
+                <vCard:EMAIL>jls@sun.ac.za</vCard:EMAIL>
+                <vCard:ORG rdf:parseType="Resource">
+                  <vCard:Orgname>Stellenbosh University</vCard:Orgname>
+                </vCard:ORG>
+              </rdf:li>
+              <rdf:li rdf:parseType="Resource">
+                <vCard:N rdf:parseType="Resource">
+                  <vCard:Family>Endler</vCard:Family>
+                  <vCard:Given>Lukas</vCard:Given>
+                </vCard:N>
+                <vCard:EMAIL>lukas@ebi.ac.uk</vCard:EMAIL>
+                <vCard:ORG rdf:parseType="Resource">
+                  <vCard:Orgname>EMBL-EBI</vCard:Orgname>
+                </vCard:ORG>
+              </rdf:li>
+              <rdf:li rdf:parseType="Resource">
+                <vCard:N rdf:parseType="Resource">
+                  <vCard:Family>Dharuri</vCard:Family>
+                  <vCard:Given>Harish</vCard:Given>
+                </vCard:N>
+                <vCard:EMAIL>hdharuri@cds.caltech.edu</vCard:EMAIL>
+                <vCard:ORG rdf:parseType="Resource">
+                  <vCard:Orgname>California Institute of Technology</vCard:Orgname>
+                </vCard:ORG>
+              </rdf:li>
+            </rdf:Bag>
+          </dc:creator>
+          <dcterms:created rdf:parseType="Resource">
+            <dcterms:W3CDTF>2008-09-16T14:00:06Z</dcterms:W3CDTF>
+          </dcterms:created>
+          <dcterms:modified rdf:parseType="Resource">
+            <dcterms:W3CDTF>2012-07-19T18:26:07Z</dcterms:W3CDTF>
+          </dcterms:modified>
+          <bqmodel:is>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/biomodels.db/MODEL6623915522"/>
+            </rdf:Bag>
+          </bqmodel:is>
+          <bqmodel:is>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/biomodels.db/BIOMD0000000064"/>
+            </rdf:Bag>
+          </bqmodel:is>
+          <bqmodel:isDescribedBy>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/pubmed/10951190"/>
+            </rdf:Bag>
+          </bqmodel:isDescribedBy>
+          <bqbiol:hasTaxon>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/taxonomy/4932"/>
+            </rdf:Bag>
+          </bqbiol:hasTaxon>
+          <bqbiol:is>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/kegg.pathway/sce00010"/>
+              <rdf:li rdf:resource="http://identifiers.org/go/GO:0006096"/>
+            </rdf:Bag>
+          </bqbiol:is>
+          <bqbiol:isHomologTo>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_723"/>
+            </rdf:Bag>
+          </bqbiol:isHomologTo>
+        </rdf:Description>
+      </rdf:RDF>
+    </annotation>
+    <listOfFunctionDefinitions>
+      <functionDefinition metaid="metaid_0000073" id="L_PFK" name="L_PFK">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> L </ci>
+            </bvar>
+            <bvar>
+              <ci> CiATP </ci>
+            </bvar>
+            <bvar>
+              <ci> KiATP </ci>
+            </bvar>
+            <bvar>
+              <ci> CAMP </ci>
+            </bvar>
+            <bvar>
+              <ci> KAMP </ci>
+            </bvar>
+            <bvar>
+              <ci> CF26BP </ci>
+            </bvar>
+            <bvar>
+              <ci> KF26BP </ci>
+            </bvar>
+            <bvar>
+              <ci> CF16BP </ci>
+            </bvar>
+            <bvar>
+              <ci> KF16BP </ci>
+            </bvar>
+            <bvar>
+              <ci> AT </ci>
+            </bvar>
+            <bvar>
+              <ci> AM </ci>
+            </bvar>
+            <bvar>
+              <ci> F16 </ci>
+            </bvar>
+            <bvar>
+              <ci> F26 </ci>
+            </bvar>
+            <apply>
+              <times/>
+              <ci> L </ci>
+              <apply>
+                <power/>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <plus/>
+                    <cn type="integer"> 1 </cn>
+                    <apply>
+                      <times/>
+                      <ci> CiATP </ci>
+                      <apply>
+                        <divide/>
+                        <ci> AT </ci>
+                        <ci> KiATP </ci>
+                      </apply>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <plus/>
+                    <cn type="integer"> 1 </cn>
+                    <apply>
+                      <divide/>
+                      <ci> AT </ci>
+                      <ci> KiATP </ci>
+                    </apply>
+                  </apply>
+                </apply>
+                <cn type="integer"> 2 </cn>
+              </apply>
+              <apply>
+                <power/>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <plus/>
+                    <cn type="integer"> 1 </cn>
+                    <apply>
+                      <times/>
+                      <ci> CAMP </ci>
+                      <apply>
+                        <divide/>
+                        <ci> AM </ci>
+                        <ci> KAMP </ci>
+                      </apply>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <plus/>
+                    <cn type="integer"> 1 </cn>
+                    <apply>
+                      <divide/>
+                      <ci> AM </ci>
+                      <ci> KAMP </ci>
+                    </apply>
+                  </apply>
+                </apply>
+                <cn type="integer"> 2 </cn>
+              </apply>
+              <apply>
+                <power/>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <plus/>
+                    <cn type="integer"> 1 </cn>
+                    <apply>
+                      <divide/>
+                      <apply>
+                        <times/>
+                        <ci> CF26BP </ci>
+                        <ci> F26 </ci>
+                      </apply>
+                      <ci> KF26BP </ci>
+                    </apply>
+                    <apply>
+                      <divide/>
+                      <apply>
+                        <times/>
+                        <ci> CF16BP </ci>
+                        <ci> F16 </ci>
+                      </apply>
+                      <ci> KF16BP </ci>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <plus/>
+                    <cn type="integer"> 1 </cn>
+                    <apply>
+                      <divide/>
+                      <ci> F26 </ci>
+                      <ci> KF26BP </ci>
+                    </apply>
+                    <apply>
+                      <divide/>
+                      <ci> F16 </ci>
+                      <ci> KF16BP </ci>
+                    </apply>
+                  </apply>
+                </apply>
+                <cn type="integer"> 2 </cn>
+              </apply>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="metaid_0000074" id="R_PFK" name="R_PFK">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> KmF6P </ci>
+            </bvar>
+            <bvar>
+              <ci> KmATP </ci>
+            </bvar>
+            <bvar>
+              <ci> g </ci>
+            </bvar>
+            <bvar>
+              <ci> AT </ci>
+            </bvar>
+            <bvar>
+              <ci> F6 </ci>
+            </bvar>
+            <apply>
+              <plus/>
+              <cn type="integer"> 1 </cn>
+              <apply>
+                <divide/>
+                <ci> F6 </ci>
+                <ci> KmF6P </ci>
+              </apply>
+              <apply>
+                <divide/>
+                <ci> AT </ci>
+                <ci> KmATP </ci>
+              </apply>
+              <apply>
+                <times/>
+                <ci> g </ci>
+                <apply>
+                  <divide/>
+                  <ci> F6 </ci>
+                  <ci> KmF6P </ci>
+                </apply>
+                <apply>
+                  <divide/>
+                  <ci> AT </ci>
+                  <ci> KmATP </ci>
+                </apply>
+              </apply>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+      <functionDefinition metaid="metaid_0000180" id="T_PFK" name="T_PFK">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> CATP </ci>
+            </bvar>
+            <bvar>
+              <ci> KmATP </ci>
+            </bvar>
+            <bvar>
+              <ci> AT </ci>
+            </bvar>
+            <apply>
+              <plus/>
+              <cn type="integer"> 1 </cn>
+              <apply>
+                <times/>
+                <ci> CATP </ci>
+                <apply>
+                  <divide/>
+                  <ci> AT </ci>
+                  <ci> KmATP </ci>
+                </apply>
+              </apply>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+    </listOfFunctionDefinitions>
+    <listOfUnitDefinitions>
+      <unitDefinition metaid="metaid_0000070" id="substance" name="millimole">
+        <listOfUnits>
+          <unit metaid="_772471" kind="mole" scale="-3"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition metaid="metaid_0000071" id="time" name="minute">
+        <listOfUnits>
+          <unit metaid="_772483" kind="second" multiplier="60"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition metaid="metaid_0000072" id="mM" name="mM">
+        <listOfUnits>
+          <unit metaid="_772495" kind="mole" scale="-3"/>
+          <unit metaid="_772507" kind="litre" exponent="-1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition metaid="metaid_0000084" id="mMpermin" name="mMpermin">
+        <listOfUnits>
+          <unit metaid="_772519" kind="mole" scale="-3"/>
+          <unit metaid="_772531" kind="litre" exponent="-1"/>
+          <unit metaid="_772544" kind="second" exponent="-1" multiplier="60"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition metaid="metaid_0000085" id="permin" name="permin">
+        <listOfUnits>
+          <unit metaid="_772557" kind="second" exponent="-1" multiplier="60"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition metaid="metaid_0000086" id="mmolepermin" name="mmolepermin">
+        <listOfUnits>
+          <unit metaid="_772570" kind="mole" scale="-3"/>
+          <unit metaid="_772583" kind="second" exponent="-1" multiplier="60"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment metaid="metaid_0000003" id="extracellular" size="1">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000003">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0005576"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </compartment>
+      <compartment metaid="metaid_0000075" id="cytosol" size="1" outside="extracellular">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000075">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0005829"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </compartment>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species metaid="metaid_0000004" id="GLCi" name="Glucose in Cytosol" compartment="cytosol" initialConcentration="0.087">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000004">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:17234"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00293"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000005" id="G6P" name="Glucose 6 Phosphate" compartment="cytosol" initialConcentration="2.45">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000005">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:17665"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00668"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000006" id="F6P" name="Fructose 6 Phosphate" compartment="cytosol" initialConcentration="0.62">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000006">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:15946"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C05345"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000007" id="F16P" name="Fructose-1,6 bisphosphate" compartment="cytosol" initialConcentration="5.51">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000007">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:16905"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00354"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000008" id="TRIO" name="Triose-phosphate" compartment="cytosol" initialConcentration="0.96">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000008">
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:16108"/>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:29052"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00118"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00111"/>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:29052"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000009" id="BPG" name="1,3-bisphosphoglycerate" compartment="cytosol" initialConcentration="0">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000009">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:16001"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00236"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000010" id="P3G" name="3-phosphoglycerate" compartment="cytosol" initialConcentration="0.9">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:17794"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00197"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000011" id="P2G" name="2-phosphoglycerate" compartment="cytosol" initialConcentration="0.12">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000011">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:17835"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00631"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000012" id="PEP" name="Phosphoenolpyruvate" compartment="cytosol" initialConcentration="0.07">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000012">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00074"/>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:18021"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:18021"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000013" id="PYR" name="Pyruvate" compartment="cytosol" initialConcentration="1.85">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000013">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:15361"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00022"/>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:32816"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000014" id="ACE" name="Acetaldehyde" compartment="cytosol" initialConcentration="0.17">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000014">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:15343"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00084"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000042" id="P" name="High energy phosphates" compartment="cytosol" initialConcentration="6.31">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000042">
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00008"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00002"/>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:16761"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:16761"/>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:15422"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000016" id="NAD" name="NAD" compartment="cytosol" initialConcentration="1.2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000016">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:15846"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00003"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000017" id="NADH" name="NADH" compartment="cytosol" initialConcentration="0.39">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000017">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:16908"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00004"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000018" id="Glyc" name="Glycogen" compartment="cytosol" initialConcentration="0" boundaryCondition="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000018">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:28087"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00182"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000019" id="Trh" name="Trehalose" compartment="cytosol" initialConcentration="0" boundaryCondition="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000019">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:27082"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C01083"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000020" id="CO2" name="CO2" compartment="cytosol" initialConcentration="1" boundaryCondition="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:16526"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00011"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000021" id="SUCC" name="Succinate" compartment="cytosol" initialConcentration="0" boundaryCondition="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000021">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:30031"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000022" id="GLCo" name="Extracellular Glucose" compartment="extracellular" initialConcentration="50" boundaryCondition="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000022">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:17234"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00293"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000023" id="ETOH" name="Ethanol" compartment="cytosol" initialConcentration="50" boundaryCondition="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000023">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:16236"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00469"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000024" id="GLY" name="Glycerol" compartment="cytosol" initialConcentration="0.15" boundaryCondition="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000024">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:17754"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00116"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000076" id="ATP" name="ATP concentration" compartment="cytosol">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000076">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:15422"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00002"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000077" id="ADP" name="ADP concentration" compartment="cytosol">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000077">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:16761"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00008"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000078" id="AMP" name="AMP concentration" compartment="cytosol">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000078">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:16027"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00020"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000079" id="SUM_P" name="sum of AXP conc" compartment="cytosol" initialConcentration="4.1" constant="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000079">
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:15422"/>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:16761"/>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:16027"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+              <bqbiol:hasPart>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00002"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00008"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00020"/>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:15422"/>
+                </rdf:Bag>
+              </bqbiol:hasPart>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="metaid_0000061" id="F26BP" name="F2,6P" compartment="cytosol" initialConcentration="0.02" constant="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000061">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:28602"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.compound/C00665"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter metaid="metaid_0000050" id="gR" value="5.12" units="dimensionless"/>
+      <parameter metaid="metaid_0000051" id="KmPFKF6P" value="0.1" units="mM"/>
+      <parameter metaid="metaid_0000054" id="KmPFKATP" value="0.71" units="mM"/>
+      <parameter metaid="metaid_0000055" id="Lzero" value="0.66" units="dimensionless"/>
+      <parameter metaid="metaid_0000056" id="CiPFKATP" value="100" units="dimensionless"/>
+      <parameter metaid="metaid_0000057" id="KiPFKATP" value="0.65" units="mM"/>
+      <parameter metaid="metaid_0000058" id="CPFKAMP" value="0.0845" units="dimensionless"/>
+      <parameter metaid="metaid_0000059" id="KPFKAMP" value="0.0995" units="mM"/>
+      <parameter metaid="metaid_0000060" id="CPFKF26BP" value="0.0174" units="dimensionless"/>
+      <parameter metaid="metaid_0000062" id="KPFKF26BP" value="0.000682" units="mM"/>
+      <parameter metaid="metaid_0000063" id="CPFKF16BP" value="0.397" units="dimensionless"/>
+      <parameter metaid="metaid_0000064" id="KPFKF16BP" value="0.111" units="mM"/>
+      <parameter metaid="metaid_0000065" id="CPFKATP" value="3" units="dimensionless"/>
+      <parameter metaid="metaid_0000080" id="KeqAK" name="AK eq constant" value="0.45" units="dimensionless"/>
+      <parameter metaid="metaid_0000090" id="KeqTPI" name="TPI eq constant" value="0.045" units="dimensionless"/>
+    </listOfParameters>
+    <listOfRules>
+      <assignmentRule metaid="metaid_0000081" variable="ADP">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <divide/>
+            <apply>
+              <minus/>
+              <ci> SUM_P </ci>
+              <apply>
+                <power/>
+                <apply>
+                  <plus/>
+                  <apply>
+                    <times/>
+                    <apply>
+                      <power/>
+                      <ci> P </ci>
+                      <cn type="integer"> 2 </cn>
+                    </apply>
+                    <apply>
+                      <minus/>
+                      <cn type="integer"> 1 </cn>
+                      <apply>
+                        <times/>
+                        <cn type="integer"> 4 </cn>
+                        <ci> KeqAK </ci>
+                      </apply>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn type="integer"> 2 </cn>
+                    <ci> SUM_P </ci>
+                    <ci> P </ci>
+                    <apply>
+                      <minus/>
+                      <apply>
+                        <times/>
+                        <cn type="integer"> 4 </cn>
+                        <ci> KeqAK </ci>
+                      </apply>
+                      <cn type="integer"> 1 </cn>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <power/>
+                    <ci> SUM_P </ci>
+                    <cn type="integer"> 2 </cn>
+                  </apply>
+                </apply>
+                <cn> 0.5 </cn>
+              </apply>
+            </apply>
+            <apply>
+              <minus/>
+              <cn type="integer"> 1 </cn>
+              <apply>
+                <times/>
+                <cn type="integer"> 4 </cn>
+                <ci> KeqAK </ci>
+              </apply>
+            </apply>
+          </apply>
+        </math>
+      </assignmentRule>
+      <assignmentRule metaid="metaid_0000082" variable="ATP">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <divide/>
+            <apply>
+              <minus/>
+              <ci> P </ci>
+              <ci> ADP </ci>
+            </apply>
+            <cn type="integer"> 2 </cn>
+          </apply>
+        </math>
+      </assignmentRule>
+      <assignmentRule metaid="metaid_0000083" variable="AMP">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <minus/>
+            <apply>
+              <minus/>
+              <ci> SUM_P </ci>
+              <ci> ATP </ci>
+            </apply>
+            <ci> ADP </ci>
+          </apply>
+        </math>
+      </assignmentRule>
+    </listOfRules>
+    <listOfReactions>
+      <reaction metaid="metaid_0000025" id="vGLK" name="Hexokinase">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000025">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.1.2"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.reaction/R00299"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_1318"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_772596" species="GLCi"/>
+          <speciesReference metaid="_772609" species="P"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_772621" species="G6P"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_772634" species="ATP"/>
+          <modifierSpeciesReference metaid="_772647" species="ADP"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_772659">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <ci> cytosol </ci>
+                    <ci> VmGLK </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <ci> KmGLKGLCi </ci>
+                    <ci> KmGLKATP </ci>
+                  </apply>
+                </apply>
+                <apply>
+                  <minus/>
+                  <apply>
+                    <times/>
+                    <ci> GLCi </ci>
+                    <ci> ATP </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> G6P </ci>
+                      <ci> ADP </ci>
+                    </apply>
+                    <ci> KeqGLK </ci>
+                  </apply>
+                </apply>
+              </apply>
+              <apply>
+                <times/>
+                <apply>
+                  <plus/>
+                  <cn type="integer"> 1 </cn>
+                  <apply>
+                    <divide/>
+                    <ci> GLCi </ci>
+                    <ci> KmGLKGLCi </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <ci> G6P </ci>
+                    <ci> KmGLKG6P </ci>
+                  </apply>
+                </apply>
+                <apply>
+                  <plus/>
+                  <cn type="integer"> 1 </cn>
+                  <apply>
+                    <divide/>
+                    <ci> ATP </ci>
+                    <ci> KmGLKATP </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <ci> ADP </ci>
+                    <ci> KmGLKADP </ci>
+                  </apply>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_772671" id="VmGLK" value="226.452" units="mMpermin"/>
+            <parameter metaid="_772683" id="KmGLKGLCi" value="0.08" units="mM"/>
+            <parameter metaid="_772695" id="KmGLKATP" value="0.15" units="mM"/>
+            <parameter metaid="_772707" id="KeqGLK" value="3800" units="dimensionless"/>
+            <parameter metaid="_772719" id="KmGLKG6P" value="30" units="mM"/>
+            <parameter metaid="_772731" id="KmGLKADP" value="0.23" units="mM"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000026" id="vPGI" name="Glucose-6-phosphate isomerase">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000026">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/5.3.1.9"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.reaction/R00771"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_116"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_772743" species="G6P"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_772756" species="F6P"/>
+        </listOfProducts>
+        <kineticLaw metaid="_772769">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <ci> cytosol </ci>
+                    <ci> VmPGI_2 </ci>
+                  </apply>
+                  <ci> KmPGIG6P_2 </ci>
+                </apply>
+                <apply>
+                  <minus/>
+                  <ci> G6P </ci>
+                  <apply>
+                    <divide/>
+                    <ci> F6P </ci>
+                    <ci> KeqPGI_2 </ci>
+                  </apply>
+                </apply>
+              </apply>
+              <apply>
+                <plus/>
+                <cn type="integer"> 1 </cn>
+                <apply>
+                  <divide/>
+                  <ci> G6P </ci>
+                  <ci> KmPGIG6P_2 </ci>
+                </apply>
+                <apply>
+                  <divide/>
+                  <ci> F6P </ci>
+                  <ci> KmPGIF6P_2 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_772782" id="VmPGI_2" value="339.677" units="mMpermin"/>
+            <parameter metaid="_772794" id="KmPGIG6P_2" value="1.4" units="mM"/>
+            <parameter metaid="_772807" id="KeqPGI_2" value="0.314" units="dimensionless"/>
+            <parameter metaid="_772819" id="KmPGIF6P_2" value="0.3" units="mM"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000027" id="vGLYCO" name="Glycogen synthesis" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000027">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0005978"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_1736"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_772831" species="G6P"/>
+          <speciesReference metaid="_772843" species="P"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_772855" species="Glyc"/>
+        </listOfProducts>
+        <kineticLaw metaid="_772867">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cytosol </ci>
+              <ci> KGLYCOGEN_3 </ci>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_772879" id="KGLYCOGEN_3" value="6" units="mMpermin"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000028" id="vTreha" name="Trehalose 6-phosphate synthase" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000028">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0005992"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_772891" species="G6P" stoichiometry="2"/>
+          <speciesReference metaid="_772903" species="P"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_772915" species="Trh"/>
+        </listOfProducts>
+        <kineticLaw metaid="_772928">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cytosol </ci>
+              <ci> KTREHALOSE </ci>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_772940" id="KTREHALOSE" value="2.4" units="mMpermin"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000029" id="vPFK" name="Phosphofructokinase" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000029">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.1.11"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.reaction/R00756"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_736"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_772953" species="F6P"/>
+          <speciesReference metaid="_772966" species="P"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_772979" species="F16P"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_772992" species="AMP"/>
+          <modifierSpeciesReference metaid="_773005" species="ATP"/>
+          <modifierSpeciesReference metaid="_773018" species="F26BP"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_773032">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> cytosol </ci>
+                <ci> VmPFK </ci>
+                <ci> gR </ci>
+                <apply>
+                  <divide/>
+                  <ci> F6P </ci>
+                  <ci> KmPFKF6P </ci>
+                </apply>
+                <apply>
+                  <divide/>
+                  <ci> ATP </ci>
+                  <ci> KmPFKATP </ci>
+                </apply>
+                <apply>
+                  <ci> R_PFK </ci>
+                  <ci> KmPFKF6P </ci>
+                  <ci> KmPFKATP </ci>
+                  <ci> gR </ci>
+                  <ci> ATP </ci>
+                  <ci> F6P </ci>
+                </apply>
+              </apply>
+              <apply>
+                <plus/>
+                <apply>
+                  <power/>
+                  <apply>
+                    <ci> R_PFK </ci>
+                    <ci> KmPFKF6P </ci>
+                    <ci> KmPFKATP </ci>
+                    <ci> gR </ci>
+                    <ci> ATP </ci>
+                    <ci> F6P </ci>
+                  </apply>
+                  <cn type="integer"> 2 </cn>
+                </apply>
+                <apply>
+                  <times/>
+                  <apply>
+                    <ci> L_PFK </ci>
+                    <ci> Lzero </ci>
+                    <ci> CiPFKATP </ci>
+                    <ci> KiPFKATP </ci>
+                    <ci> CPFKAMP </ci>
+                    <ci> KPFKAMP </ci>
+                    <ci> CPFKF26BP </ci>
+                    <ci> KPFKF26BP </ci>
+                    <ci> CPFKF16BP </ci>
+                    <ci> KPFKF16BP </ci>
+                    <ci> ATP </ci>
+                    <ci> AMP </ci>
+                    <ci> F16P </ci>
+                    <ci> F26BP </ci>
+                  </apply>
+                  <apply>
+                    <power/>
+                    <apply>
+                      <ci> T_PFK </ci>
+                      <ci> CPFKATP </ci>
+                      <ci> KmPFKATP </ci>
+                      <ci> ATP </ci>
+                    </apply>
+                    <cn type="integer"> 2 </cn>
+                  </apply>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_773045" id="VmPFK" value="182.903" units="mMpermin"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000030" id="vALD" name="Aldolase">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000030">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/4.1.2.13"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.reaction/R01070"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_1602"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_773058" species="F16P"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_773071" species="TRIO" stoichiometry="2"/>
+        </listOfProducts>
+        <kineticLaw metaid="_773084">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <ci> cytosol </ci>
+                    <ci> VmALD </ci>
+                  </apply>
+                  <ci> KmALDF16P </ci>
+                </apply>
+                <apply>
+                  <minus/>
+                  <ci> F16P </ci>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <apply>
+                        <divide/>
+                        <ci> KeqTPI </ci>
+                        <apply>
+                          <plus/>
+                          <cn type="integer"> 1 </cn>
+                          <ci> KeqTPI </ci>
+                        </apply>
+                      </apply>
+                      <ci> TRIO </ci>
+                      <apply>
+                        <divide/>
+                        <cn type="integer"> 1 </cn>
+                        <apply>
+                          <plus/>
+                          <cn type="integer"> 1 </cn>
+                          <ci> KeqTPI </ci>
+                        </apply>
+                      </apply>
+                      <ci> TRIO </ci>
+                    </apply>
+                    <ci> KeqALD </ci>
+                  </apply>
+                </apply>
+              </apply>
+              <apply>
+                <plus/>
+                <cn type="integer"> 1 </cn>
+                <apply>
+                  <divide/>
+                  <ci> F16P </ci>
+                  <ci> KmALDF16P </ci>
+                </apply>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <apply>
+                      <divide/>
+                      <ci> KeqTPI </ci>
+                      <apply>
+                        <plus/>
+                        <cn type="integer"> 1 </cn>
+                        <ci> KeqTPI </ci>
+                      </apply>
+                    </apply>
+                    <ci> TRIO </ci>
+                  </apply>
+                  <ci> KmALDGAP </ci>
+                </apply>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <apply>
+                      <divide/>
+                      <cn type="integer"> 1 </cn>
+                      <apply>
+                        <plus/>
+                        <cn type="integer"> 1 </cn>
+                        <ci> KeqTPI </ci>
+                      </apply>
+                    </apply>
+                    <ci> TRIO </ci>
+                  </apply>
+                  <ci> KmALDDHAP </ci>
+                </apply>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <apply>
+                      <divide/>
+                      <ci> KeqTPI </ci>
+                      <apply>
+                        <plus/>
+                        <cn type="integer"> 1 </cn>
+                        <ci> KeqTPI </ci>
+                      </apply>
+                    </apply>
+                    <ci> TRIO </ci>
+                    <apply>
+                      <divide/>
+                      <cn type="integer"> 1 </cn>
+                      <apply>
+                        <plus/>
+                        <cn type="integer"> 1 </cn>
+                        <ci> KeqTPI </ci>
+                      </apply>
+                    </apply>
+                    <ci> TRIO </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <ci> KmALDGAP </ci>
+                    <ci> KmALDDHAP </ci>
+                  </apply>
+                </apply>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <ci> F16P </ci>
+                    <apply>
+                      <divide/>
+                      <ci> KeqTPI </ci>
+                      <apply>
+                        <plus/>
+                        <cn type="integer"> 1 </cn>
+                        <ci> KeqTPI </ci>
+                      </apply>
+                    </apply>
+                    <ci> TRIO </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <ci> KmALDGAPi </ci>
+                    <ci> KmALDF16P </ci>
+                  </apply>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_773097" id="VmALD" value="322.258" units="mMpermin"/>
+            <parameter metaid="_773110" id="KmALDF16P" value="0.3" units="mM"/>
+            <parameter metaid="_773122" id="KeqALD" value="0.069" units="dimensionless"/>
+            <parameter metaid="_773134" id="KmALDGAP" value="2" units="mM"/>
+            <parameter metaid="_773146" id="KmALDDHAP" value="2.4" units="mM"/>
+            <parameter metaid="_773158" id="KmALDGAPi" value="10" units="mM"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000031" id="vGAPDH" name="Glyceraldehyde 3-phosphate dehydrogenase">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000031">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/1.2.1.12"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.reaction/R01061"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_1847"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_773170" species="TRIO"/>
+          <speciesReference metaid="_773182" species="NAD"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_773194" species="BPG"/>
+          <speciesReference metaid="_773206" species="NADH"/>
+        </listOfProducts>
+        <kineticLaw metaid="_773218">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> cytosol </ci>
+                <apply>
+                  <minus/>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> VmGAPDHf </ci>
+                      <apply>
+                        <divide/>
+                        <ci> KeqTPI </ci>
+                        <apply>
+                          <plus/>
+                          <cn type="integer"> 1 </cn>
+                          <ci> KeqTPI </ci>
+                        </apply>
+                      </apply>
+                      <ci> TRIO </ci>
+                      <ci> NAD </ci>
+                    </apply>
+                    <apply>
+                      <times/>
+                      <ci> KmGAPDHGAP </ci>
+                      <ci> KmGAPDHNAD </ci>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> VmGAPDHr </ci>
+                      <ci> BPG </ci>
+                      <ci> NADH </ci>
+                    </apply>
+                    <apply>
+                      <times/>
+                      <ci> KmGAPDHBPG </ci>
+                      <ci> KmGAPDHNADH </ci>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+              <apply>
+                <times/>
+                <apply>
+                  <plus/>
+                  <cn type="integer"> 1 </cn>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <apply>
+                        <divide/>
+                        <ci> KeqTPI </ci>
+                        <apply>
+                          <plus/>
+                          <cn type="integer"> 1 </cn>
+                          <ci> KeqTPI </ci>
+                        </apply>
+                      </apply>
+                      <ci> TRIO </ci>
+                    </apply>
+                    <ci> KmGAPDHGAP </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <ci> BPG </ci>
+                    <ci> KmGAPDHBPG </ci>
+                  </apply>
+                </apply>
+                <apply>
+                  <plus/>
+                  <cn type="integer"> 1 </cn>
+                  <apply>
+                    <divide/>
+                    <ci> NAD </ci>
+                    <ci> KmGAPDHNAD </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <ci> NADH </ci>
+                    <ci> KmGAPDHNADH </ci>
+                  </apply>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_773230" id="VmGAPDHf" value="1184.52" units="mMpermin"/>
+            <parameter metaid="_773242" id="KmGAPDHGAP" value="0.21" units="mM"/>
+            <parameter metaid="_773254" id="KmGAPDHNAD" value="0.09" units="mM"/>
+            <parameter metaid="_773266" id="VmGAPDHr" value="6549.8" units="mMpermin"/>
+            <parameter metaid="_773278" id="KmGAPDHBPG" value="0.0098" units="mM"/>
+            <parameter metaid="_773290" id="KmGAPDHNADH" value="0.06" units="mM"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000032" id="vPGK" name="Phosphoglycerate kinase">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000032">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.2.3"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.reaction/R01512"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_1771"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_773302" species="BPG"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_773314" species="P3G"/>
+          <speciesReference metaid="_773326" species="P"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_773338" species="ATP"/>
+          <modifierSpeciesReference metaid="_773350" species="ADP"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_773362">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <ci> cytosol </ci>
+                    <ci> VmPGK </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <ci> KmPGKP3G </ci>
+                    <ci> KmPGKATP </ci>
+                  </apply>
+                </apply>
+                <apply>
+                  <minus/>
+                  <apply>
+                    <times/>
+                    <ci> KeqPGK </ci>
+                    <ci> BPG </ci>
+                    <ci> ADP </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <ci> P3G </ci>
+                    <ci> ATP </ci>
+                  </apply>
+                </apply>
+              </apply>
+              <apply>
+                <times/>
+                <apply>
+                  <plus/>
+                  <cn type="integer"> 1 </cn>
+                  <apply>
+                    <divide/>
+                    <ci> BPG </ci>
+                    <ci> KmPGKBPG </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <ci> P3G </ci>
+                    <ci> KmPGKP3G </ci>
+                  </apply>
+                </apply>
+                <apply>
+                  <plus/>
+                  <cn type="integer"> 1 </cn>
+                  <apply>
+                    <divide/>
+                    <ci> ATP </ci>
+                    <ci> KmPGKATP </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <ci> ADP </ci>
+                    <ci> KmPGKADP </ci>
+                  </apply>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_773374" id="VmPGK" value="1306.45" units="mMpermin"/>
+            <parameter metaid="_773386" id="KmPGKP3G" value="0.53" units="mM"/>
+            <parameter metaid="_773398" id="KmPGKATP" value="0.3" units="mM"/>
+            <parameter metaid="_773410" id="KeqPGK" value="3200" units="dimensionless"/>
+            <parameter metaid="_773422" id="KmPGKBPG" value="0.003" units="mM"/>
+            <parameter metaid="_773434" id="KmPGKADP" value="0.2" units="mM"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000033" id="vPGM" name="Phosphoglycerate mutase">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000033">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/5.4.2.1"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.reaction/R01518"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_576"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_773446" species="P3G"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_773458" species="P2G"/>
+        </listOfProducts>
+        <kineticLaw metaid="_773470">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <ci> cytosol </ci>
+                    <ci> VmPGM </ci>
+                  </apply>
+                  <ci> KmPGMP3G </ci>
+                </apply>
+                <apply>
+                  <minus/>
+                  <ci> P3G </ci>
+                  <apply>
+                    <divide/>
+                    <ci> P2G </ci>
+                    <ci> KeqPGM </ci>
+                  </apply>
+                </apply>
+              </apply>
+              <apply>
+                <plus/>
+                <cn type="integer"> 1 </cn>
+                <apply>
+                  <divide/>
+                  <ci> P3G </ci>
+                  <ci> KmPGMP3G </ci>
+                </apply>
+                <apply>
+                  <divide/>
+                  <ci> P2G </ci>
+                  <ci> KmPGMP2G </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_773482" id="VmPGM" value="2525.81" units="mMpermin"/>
+            <parameter metaid="_773494" id="KmPGMP3G" value="1.2" units="mM"/>
+            <parameter metaid="_773506" id="KeqPGM" value="0.19" units="dimensionless"/>
+            <parameter metaid="_773518" id="KmPGMP2G" value="0.08" units="mM"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000034" id="vENO" name="Enolase">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000034">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/4.2.1.11"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.reaction/R00658"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_1400"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_773530" species="P2G"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_773542" species="PEP"/>
+        </listOfProducts>
+        <kineticLaw metaid="_773554">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <ci> cytosol </ci>
+                    <ci> VmENO </ci>
+                  </apply>
+                  <ci> KmENOP2G </ci>
+                </apply>
+                <apply>
+                  <minus/>
+                  <ci> P2G </ci>
+                  <apply>
+                    <divide/>
+                    <ci> PEP </ci>
+                    <ci> KeqENO </ci>
+                  </apply>
+                </apply>
+              </apply>
+              <apply>
+                <plus/>
+                <cn type="integer"> 1 </cn>
+                <apply>
+                  <divide/>
+                  <ci> P2G </ci>
+                  <ci> KmENOP2G </ci>
+                </apply>
+                <apply>
+                  <divide/>
+                  <ci> PEP </ci>
+                  <ci> KmENOPEP </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_773566" id="VmENO" value="365.806" units="mMpermin"/>
+            <parameter metaid="_773578" id="KmENOP2G" value="0.04" units="mM"/>
+            <parameter metaid="_773590" id="KeqENO" value="6.7" units="dimensionless"/>
+            <parameter metaid="_773602" id="KmENOPEP" value="0.5" units="mM"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000035" id="vPYK" name="Pyruvate kinase">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000035">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.1.40"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.reaction/R00200"/>
+                </rdf:Bag>
+              </bqbiol:is>
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_1911"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_773614" species="PEP"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_773626" species="PYR"/>
+          <speciesReference metaid="_773638" species="P"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_773650" species="ATP"/>
+          <modifierSpeciesReference metaid="_773662" species="ADP"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_773674">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <ci> cytosol </ci>
+                    <ci> VmPYK </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <ci> KmPYKPEP </ci>
+                    <ci> KmPYKADP </ci>
+                  </apply>
+                </apply>
+                <apply>
+                  <minus/>
+                  <apply>
+                    <times/>
+                    <ci> PEP </ci>
+                    <ci> ADP </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> PYR </ci>
+                      <ci> ATP </ci>
+                    </apply>
+                    <ci> KeqPYK </ci>
+                  </apply>
+                </apply>
+              </apply>
+              <apply>
+                <times/>
+                <apply>
+                  <plus/>
+                  <cn type="integer"> 1 </cn>
+                  <apply>
+                    <divide/>
+                    <ci> PEP </ci>
+                    <ci> KmPYKPEP </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <ci> PYR </ci>
+                    <ci> KmPYKPYR </ci>
+                  </apply>
+                </apply>
+                <apply>
+                  <plus/>
+                  <cn type="integer"> 1 </cn>
+                  <apply>
+                    <divide/>
+                    <ci> ATP </ci>
+                    <ci> KmPYKATP </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <ci> ADP </ci>
+                    <ci> KmPYKADP </ci>
+                  </apply>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_773686" id="VmPYK" value="1088.71" units="mMpermin"/>
+            <parameter metaid="_773698" id="KmPYKPEP" value="0.14" units="mM"/>
+            <parameter metaid="_773710" id="KmPYKADP" value="0.53" units="mM"/>
+            <parameter metaid="_773722" id="KeqPYK" value="6500" units="dimensionless"/>
+            <parameter metaid="_773734" id="KmPYKPYR" value="21" units="mM"/>
+            <parameter metaid="_773746" id="KmPYKATP" value="1.5" units="mM"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000036" id="vPDC" name="Pyruvate decarboxylase" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000036">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/4.1.1.1"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.reaction/R00224"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_773758" species="PYR"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_773770" species="ACE"/>
+          <speciesReference metaid="_773782" species="CO2"/>
+        </listOfProducts>
+        <kineticLaw metaid="_773794">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> cytosol </ci>
+                <ci> VmPDC </ci>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <power/>
+                    <ci> PYR </ci>
+                    <ci> nPDC </ci>
+                  </apply>
+                  <apply>
+                    <power/>
+                    <ci> KmPDCPYR </ci>
+                    <ci> nPDC </ci>
+                  </apply>
+                </apply>
+              </apply>
+              <apply>
+                <plus/>
+                <cn type="integer"> 1 </cn>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <power/>
+                    <ci> PYR </ci>
+                    <ci> nPDC </ci>
+                  </apply>
+                  <apply>
+                    <power/>
+                    <ci> KmPDCPYR </ci>
+                    <ci> nPDC </ci>
+                  </apply>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_773806" id="VmPDC" value="174.194" units="mMpermin"/>
+            <parameter metaid="_773818" id="nPDC" value="1.9" units="dimensionless"/>
+            <parameter metaid="_773831" id="KmPDCPYR" value="4.33" units="mM"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000037" id="vSUC" name="Succinate synthesis" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000037">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0006105"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_773843" species="ACE" stoichiometry="2"/>
+          <speciesReference metaid="_773855" species="NAD" stoichiometry="3"/>
+          <speciesReference metaid="_773867" species="P" stoichiometry="4"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_773879" species="NADH" stoichiometry="3"/>
+          <speciesReference metaid="_773891" species="SUCC"/>
+        </listOfProducts>
+        <kineticLaw metaid="_773903">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cytosol </ci>
+              <ci> KSUCC </ci>
+              <ci> ACE </ci>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_773915" id="KSUCC" value="21.4"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000038" id="vGLT" name="Glucose transport">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000038">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0046323"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_2092"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_773927" species="GLCo"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_773939" species="GLCi"/>
+        </listOfProducts>
+        <kineticLaw metaid="_773951">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <apply>
+                  <divide/>
+                  <ci> VmGLT </ci>
+                  <ci> KmGLTGLCo </ci>
+                </apply>
+                <apply>
+                  <minus/>
+                  <ci> GLCo </ci>
+                  <apply>
+                    <divide/>
+                    <ci> GLCi </ci>
+                    <ci> KeqGLT </ci>
+                  </apply>
+                </apply>
+              </apply>
+              <apply>
+                <plus/>
+                <cn type="integer"> 1 </cn>
+                <apply>
+                  <divide/>
+                  <ci> GLCo </ci>
+                  <ci> KmGLTGLCo </ci>
+                </apply>
+                <apply>
+                  <divide/>
+                  <ci> GLCi </ci>
+                  <ci> KmGLTGLCi </ci>
+                </apply>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <cn> 0.91 </cn>
+                    <ci> GLCo </ci>
+                    <ci> GLCi </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <ci> KmGLTGLCo </ci>
+                    <ci> KmGLTGLCi </ci>
+                  </apply>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_773963" id="VmGLT" value="97.264" units="mmolepermin"/>
+            <parameter metaid="_773975" id="KmGLTGLCo" value="1.1918" units="mM"/>
+            <parameter metaid="_773987" id="KeqGLT" value="1" units="mM"/>
+            <parameter metaid="_773999" id="KmGLTGLCi" value="1.1918" units="mM"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000039" id="vADH" name="Alcohol dehydrogenase">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000039">
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_799"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/1.1.1.2"/>
+                  <rdf:li rdf:resource="http://identifiers.org/kegg.reaction/R00746"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_774011" species="ACE"/>
+          <speciesReference metaid="_774023" species="NADH"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_774035" species="NAD"/>
+          <speciesReference metaid="_774047" species="ETOH"/>
+        </listOfProducts>
+        <kineticLaw metaid="_774059">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <apply>
+                <minus/>
+                <ci> cytosol </ci>
+              </apply>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <apply>
+                    <divide/>
+                    <ci> VmADH </ci>
+                    <apply>
+                      <times/>
+                      <ci> KiADHNAD </ci>
+                      <ci> KmADHETOH </ci>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <minus/>
+                    <apply>
+                      <times/>
+                      <ci> NAD </ci>
+                      <ci> ETOH </ci>
+                    </apply>
+                    <apply>
+                      <divide/>
+                      <apply>
+                        <times/>
+                        <ci> NADH </ci>
+                        <ci> ACE </ci>
+                      </apply>
+                      <ci> KeqADH </ci>
+                    </apply>
+                  </apply>
+                </apply>
+                <apply>
+                  <plus/>
+                  <cn type="integer"> 1 </cn>
+                  <apply>
+                    <divide/>
+                    <ci> NAD </ci>
+                    <ci> KiADHNAD </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> KmADHNAD </ci>
+                      <ci> ETOH </ci>
+                    </apply>
+                    <apply>
+                      <times/>
+                      <ci> KiADHNAD </ci>
+                      <ci> KmADHETOH </ci>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> KmADHNADH </ci>
+                      <ci> ACE </ci>
+                    </apply>
+                    <apply>
+                      <times/>
+                      <ci> KiADHNADH </ci>
+                      <ci> KmADHACE </ci>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <ci> NADH </ci>
+                    <ci> KiADHNADH </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> NAD </ci>
+                      <ci> ETOH </ci>
+                    </apply>
+                    <apply>
+                      <times/>
+                      <ci> KiADHNAD </ci>
+                      <ci> KmADHETOH </ci>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> KmADHNADH </ci>
+                      <ci> NAD </ci>
+                      <ci> ACE </ci>
+                    </apply>
+                    <apply>
+                      <times/>
+                      <ci> KiADHNAD </ci>
+                      <ci> KiADHNADH </ci>
+                      <ci> KmADHACE </ci>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> KmADHNAD </ci>
+                      <ci> ETOH </ci>
+                      <ci> NADH </ci>
+                    </apply>
+                    <apply>
+                      <times/>
+                      <ci> KiADHNAD </ci>
+                      <ci> KmADHETOH </ci>
+                      <ci> KiADHNADH </ci>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> NADH </ci>
+                      <ci> ACE </ci>
+                    </apply>
+                    <apply>
+                      <times/>
+                      <ci> KiADHNADH </ci>
+                      <ci> KmADHACE </ci>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> NAD </ci>
+                      <ci> ETOH </ci>
+                      <ci> ACE </ci>
+                    </apply>
+                    <apply>
+                      <times/>
+                      <ci> KiADHNAD </ci>
+                      <ci> KmADHETOH </ci>
+                      <ci> KiADHACE </ci>
+                    </apply>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> ETOH </ci>
+                      <ci> NADH </ci>
+                      <ci> ACE </ci>
+                    </apply>
+                    <apply>
+                      <times/>
+                      <ci> KiADHETOH </ci>
+                      <ci> KiADHNADH </ci>
+                      <ci> KmADHACE </ci>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_774071" id="VmADH" value="810" units="mMpermin"/>
+            <parameter metaid="_774083" id="KiADHNAD" value="0.92" units="mM"/>
+            <parameter metaid="_774095" id="KmADHETOH" value="17" units="mM"/>
+            <parameter metaid="_774107" id="KeqADH" value="6.9e-05" units="dimensionless"/>
+            <parameter metaid="_774119" id="KmADHNAD" value="0.17" units="mM"/>
+            <parameter metaid="_774131" id="KmADHNADH" value="0.11" units="mM"/>
+            <parameter metaid="_774143" id="KiADHNADH" value="0.031" units="mM"/>
+            <parameter metaid="_774155" id="KmADHACE" value="1.11" units="mM"/>
+            <parameter metaid="_774167" id="KiADHACE" value="1.1" units="mM"/>
+            <parameter metaid="_774179" id="KiADHETOH" value="90" units="mM"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000040" id="vG3PDH" name="Glycerol 3-phosphate dehydrogenase" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000040">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/1.1.1.8"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_774191" species="TRIO"/>
+          <speciesReference metaid="_774204" species="NADH"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_774216" species="NAD"/>
+          <speciesReference metaid="_774228" species="GLY"/>
+        </listOfProducts>
+        <kineticLaw metaid="_774240">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <ci> cytosol </ci>
+                    <ci> VmG3PDH </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <ci> KmG3PDHDHAP </ci>
+                    <ci> KmG3PDHNADH </ci>
+                  </apply>
+                </apply>
+                <apply>
+                  <minus/>
+                  <apply>
+                    <times/>
+                    <apply>
+                      <divide/>
+                      <cn type="integer"> 1 </cn>
+                      <apply>
+                        <plus/>
+                        <cn type="integer"> 1 </cn>
+                        <ci> KeqTPI </ci>
+                      </apply>
+                    </apply>
+                    <ci> TRIO </ci>
+                    <ci> NADH </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <ci> GLY </ci>
+                      <ci> NAD </ci>
+                    </apply>
+                    <ci> KeqG3PDH </ci>
+                  </apply>
+                </apply>
+              </apply>
+              <apply>
+                <times/>
+                <apply>
+                  <plus/>
+                  <cn type="integer"> 1 </cn>
+                  <apply>
+                    <divide/>
+                    <apply>
+                      <times/>
+                      <apply>
+                        <divide/>
+                        <cn type="integer"> 1 </cn>
+                        <apply>
+                          <plus/>
+                          <cn type="integer"> 1 </cn>
+                          <ci> KeqTPI </ci>
+                        </apply>
+                      </apply>
+                      <ci> TRIO </ci>
+                    </apply>
+                    <ci> KmG3PDHDHAP </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <ci> GLY </ci>
+                    <ci> KmG3PDHGLY </ci>
+                  </apply>
+                </apply>
+                <apply>
+                  <plus/>
+                  <cn type="integer"> 1 </cn>
+                  <apply>
+                    <divide/>
+                    <ci> NADH </ci>
+                    <ci> KmG3PDHNADH </ci>
+                  </apply>
+                  <apply>
+                    <divide/>
+                    <ci> NAD </ci>
+                    <ci> KmG3PDHNAD </ci>
+                  </apply>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_774252" id="VmG3PDH" value="70.15" units="mMpermin"/>
+            <parameter metaid="_774264" id="KmG3PDHDHAP" value="0.4" units="mM"/>
+            <parameter metaid="_774276" id="KmG3PDHNADH" value="0.023" units="mM"/>
+            <parameter metaid="_774288" id="KeqG3PDH" value="4300" units="dimensionless"/>
+            <parameter metaid="_774300" id="KmG3PDHGLY" value="1" units="mM"/>
+            <parameter metaid="_774312" id="KmG3PDHNAD" value="0.93" units="mM"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="metaid_0000041" id="vATP" name="ATPase activity">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000041">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/3.6.1.3"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0016887"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_774324" species="P"/>
+        </listOfReactants>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_774336" species="ATP"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_774348">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cytosol </ci>
+              <ci> KATPASE </ci>
+              <ci> ATP </ci>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_774360" id="KATPASE" value="33.7" units="permin"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>


### PR DESCRIPTION
Fix for #1350, roadrunner failing to find the steady state for BioModel 64.  Turned out to have two parts: some species were 'constant' but not 'boundary', and ended up in the 'floating species' section, making parts of the stoichiometry matrix all zeroes.  Also, since there were assignment rules, roadrunner didn't want to find conserved moieties, so the NAD+NADH conserved cycle created other problems in the Jacobian.  Once we relaxed that restriction, it turned out that assignment rules affecting species levels wasn't being propagated.  Fixing that finally made everything work!